### PR TITLE
Swift4 compat

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -238,7 +238,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + int(truncating: itemCount))
+                value.reserveCapacity(value.count + Int(extendingOrTruncating: itemCount))
                 for _ in 1...itemCount {
                     value.append(try decodeFloat())
                 }
@@ -279,7 +279,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + int(truncating: itemCount))
+                value.reserveCapacity(value.count + Int(extendingOrTruncating: itemCount))
                 for _ in 1...itemCount {
                     let i = try decodeDouble()
                     value.append(i)
@@ -296,7 +296,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = int32(truncating: varint)
+        value = Int32(extendingOrTruncating: varint)
         consumed = true
     }
 
@@ -305,7 +305,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = int32(truncating: varint)
+        value = Int32(extendingOrTruncating: varint)
         consumed = true
     }
 
@@ -313,7 +313,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(int32(truncating: varint))
+            value.append(Int32(extendingOrTruncating: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -321,7 +321,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                value.append(int32(truncating: varint))
+                value.append(Int32(extendingOrTruncating: varint))
             }
             consumed = true
         default:
@@ -372,7 +372,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = uint32(truncating: varint)
+        value = UInt32(extendingOrTruncating: varint)
         consumed = true
     }
 
@@ -381,7 +381,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = uint32(truncating: varint)
+        value = UInt32(extendingOrTruncating: varint)
         consumed = true
     }
 
@@ -389,7 +389,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(uint32(truncating: varint))
+            value.append(UInt32(extendingOrTruncating: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -397,7 +397,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
-                value.append(uint32(truncating: t))
+                value.append(UInt32(extendingOrTruncating: t))
             }
             consumed = true
         default:
@@ -446,7 +446,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = uint32(truncating: varint)
+        let t = UInt32(extendingOrTruncating: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -456,7 +456,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = uint32(truncating: varint)
+        let t = UInt32(extendingOrTruncating: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -465,7 +465,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            let t = uint32(truncating: varint)
+            let t = UInt32(extendingOrTruncating: varint)
             value.append(ZigZag.decoded(t))
             consumed = true
         case WireFormat.lengthDelimited:
@@ -474,7 +474,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                let t = uint32(truncating: varint)
+                let t = UInt32(extendingOrTruncating: varint)
                 value.append(ZigZag.decoded(t))
             }
             consumed = true
@@ -810,7 +810,7 @@ internal struct BinaryDecoder: Decoder {
              return
          }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(int32(truncating: varint))) {
+        if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
             value = v
             consumed = true
         }
@@ -821,7 +821,7 @@ internal struct BinaryDecoder: Decoder {
              return
         }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(int32(truncating: varint))) {
+        if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
             value = v
             consumed = true
         }
@@ -831,7 +831,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            if let v = E(rawValue: Int(int32(truncating: varint))) {
+            if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
                 value.append(v)
                 consumed = true
             }
@@ -842,7 +842,7 @@ internal struct BinaryDecoder: Decoder {
             var subdecoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !subdecoder.complete {
                 let u64 = try subdecoder.decodeVarint()
-                let i32 = int32(truncating: u64)
+                let i32 = Int32(extendingOrTruncating: u64)
                 if let v = E(rawValue: Int(i32)) {
                     value.append(v)
                 } else if !options.discardUnknownFields {
@@ -1401,7 +1401,7 @@ internal struct BinaryDecoder: Decoder {
         }
         let t = try decodeVarint()
         if t < UInt64(UInt32.max) {
-            guard let tag = FieldTag(rawValue: uint32(truncating: t)) else {
+            guard let tag = FieldTag(rawValue: UInt32(extendingOrTruncating: t)) else {
                 throw BinaryDecodingError.malformedProtobuf
             }
             fieldWireFormat = tag.wireFormat

--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -238,7 +238,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + Int(truncatingBitPattern: itemCount))
+                value.reserveCapacity(value.count + int(truncating: itemCount))
                 for _ in 1...itemCount {
                     value.append(try decodeFloat())
                 }
@@ -279,7 +279,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + Int(truncatingBitPattern: itemCount))
+                value.reserveCapacity(value.count + int(truncating: itemCount))
                 for _ in 1...itemCount {
                     let i = try decodeDouble()
                     value.append(i)
@@ -296,7 +296,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = Int32(truncatingBitPattern: varint)
+        value = int32(truncating: varint)
         consumed = true
     }
 
@@ -305,7 +305,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = Int32(truncatingBitPattern: varint)
+        value = int32(truncating: varint)
         consumed = true
     }
 
@@ -313,7 +313,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(Int32(truncatingBitPattern: varint))
+            value.append(int32(truncating: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -321,7 +321,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                value.append(Int32(truncatingBitPattern: varint))
+                value.append(int32(truncating: varint))
             }
             consumed = true
         default:
@@ -372,7 +372,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = UInt32(truncatingBitPattern: varint)
+        value = uint32(truncating: varint)
         consumed = true
     }
 
@@ -381,7 +381,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = UInt32(truncatingBitPattern: varint)
+        value = uint32(truncating: varint)
         consumed = true
     }
 
@@ -389,7 +389,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(UInt32(truncatingBitPattern: varint))
+            value.append(uint32(truncating: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -397,7 +397,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
-                value.append(UInt32(truncatingBitPattern: t))
+                value.append(uint32(truncating: t))
             }
             consumed = true
         default:
@@ -446,7 +446,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = UInt32(truncatingBitPattern: varint)
+        let t = uint32(truncating: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -456,7 +456,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = UInt32(truncatingBitPattern: varint)
+        let t = uint32(truncating: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -465,7 +465,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            let t = UInt32(truncatingBitPattern: varint)
+            let t = uint32(truncating: varint)
             value.append(ZigZag.decoded(t))
             consumed = true
         case WireFormat.lengthDelimited:
@@ -474,7 +474,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                let t = UInt32(truncatingBitPattern: varint)
+                let t = uint32(truncating: varint)
                 value.append(ZigZag.decoded(t))
             }
             consumed = true
@@ -810,7 +810,7 @@ internal struct BinaryDecoder: Decoder {
              return
          }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(Int32(truncatingBitPattern: varint))) {
+        if let v = E(rawValue: Int(int32(truncating: varint))) {
             value = v
             consumed = true
         }
@@ -821,7 +821,7 @@ internal struct BinaryDecoder: Decoder {
              return
         }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(Int32(truncatingBitPattern: varint))) {
+        if let v = E(rawValue: Int(int32(truncating: varint))) {
             value = v
             consumed = true
         }
@@ -831,7 +831,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            if let v = E(rawValue: Int(Int32(truncatingBitPattern: varint))) {
+            if let v = E(rawValue: Int(int32(truncating: varint))) {
                 value.append(v)
                 consumed = true
             }
@@ -842,7 +842,7 @@ internal struct BinaryDecoder: Decoder {
             var subdecoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !subdecoder.complete {
                 let u64 = try subdecoder.decodeVarint()
-                let i32 = Int32(truncatingBitPattern: u64)
+                let i32 = int32(truncating: u64)
                 if let v = E(rawValue: Int(i32)) {
                     value.append(v)
                 } else if !options.discardUnknownFields {
@@ -1401,7 +1401,7 @@ internal struct BinaryDecoder: Decoder {
         }
         let t = try decodeVarint()
         if t < UInt64(UInt32.max) {
-            guard let tag = FieldTag(rawValue: UInt32(truncatingBitPattern: t)) else {
+            guard let tag = FieldTag(rawValue: uint32(truncating: t)) else {
                 throw BinaryDecodingError.malformedProtobuf
             }
             fieldWireFormat = tag.wireFormat

--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -211,7 +211,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += tagSize
-    let dataSize = Varint.encodedSize(of: int32(truncating: value.rawValue))
+    let dataSize = Varint.encodedSize(of: Int32(extendingOrTruncating: value.rawValue))
     serializedSize += dataSize
   }
 
@@ -221,7 +221,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
                            wireFormat: .varint).encodedSize
     serializedSize += value.count * tagSize
     for v in value {
-      let dataSize = Varint.encodedSize(of: int32(truncating: v.rawValue))
+      let dataSize = Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
       serializedSize += dataSize
     }
   }
@@ -237,7 +237,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     serializedSize += tagSize
     var dataSize = 0
     for v in value {
-      dataSize += Varint.encodedSize(of: int32(truncating: v.rawValue))
+      dataSize += Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
     }
     serializedSize += Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }

--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -211,7 +211,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += tagSize
-    let dataSize = Varint.encodedSize(of: Int32(truncatingBitPattern: value.rawValue))
+    let dataSize = Varint.encodedSize(of: int32(truncating: value.rawValue))
     serializedSize += dataSize
   }
 
@@ -221,7 +221,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
                            wireFormat: .varint).encodedSize
     serializedSize += value.count * tagSize
     for v in value {
-      let dataSize = Varint.encodedSize(of: Int32(truncatingBitPattern: v.rawValue))
+      let dataSize = Varint.encodedSize(of: int32(truncating: v.rawValue))
       serializedSize += dataSize
     }
   }
@@ -237,7 +237,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     serializedSize += tagSize
     var dataSize = 0
     for v in value {
-      dataSize += Varint.encodedSize(of: Int32(truncatingBitPattern: v.rawValue))
+      dataSize += Varint.encodedSize(of: int32(truncating: v.rawValue))
     }
     serializedSize += Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -254,7 +254,7 @@ internal struct BinaryEncodingVisitor: Visitor {
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
-      packedSize += Varint.encodedSize(of: int32(truncating: v.rawValue))
+      packedSize += Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
     }
     encoder.putVarInt(value: packedSize)
     for v in value {

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -254,7 +254,7 @@ internal struct BinaryEncodingVisitor: Visitor {
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
-      packedSize += Varint.encodedSize(of: Int32(truncatingBitPattern: v.rawValue))
+      packedSize += Varint.encodedSize(of: int32(truncating: v.rawValue))
     }
     encoder.putVarInt(value: packedSize)
     for v in value {

--- a/Sources/SwiftProtobuf/FieldTag.swift
+++ b/Sources/SwiftProtobuf/FieldTag.swift
@@ -63,7 +63,7 @@ internal struct FieldTag: RawRepresentable {
 
   /// Creates a new tag by composing the given field number and wire format.
   init(fieldNumber: Int, wireFormat: WireFormat) {
-    self.rawValue = uint32(truncating: fieldNumber) << 3 |
+    self.rawValue = UInt32(extendingOrTruncating: fieldNumber) << 3 |
       UInt32(wireFormat.rawValue)
   }
 }

--- a/Sources/SwiftProtobuf/FieldTag.swift
+++ b/Sources/SwiftProtobuf/FieldTag.swift
@@ -63,7 +63,7 @@ internal struct FieldTag: RawRepresentable {
 
   /// Creates a new tag by composing the given field number and wire format.
   init(fieldNumber: Int, wireFormat: WireFormat) {
-    self.rawValue = UInt32(truncatingBitPattern: fieldNumber) << 3 |
+    self.rawValue = uint32(truncating: fieldNumber) << 3 |
       UInt32(wireFormat.rawValue)
   }
 }

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -127,7 +127,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = Int32(truncatingBitPattern: n)
+    value = int32(truncating: n)
   }
 
   mutating func decodeSingularInt32Field(value: inout Int32?) throws {
@@ -139,7 +139,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = Int32(truncatingBitPattern: n)
+    value = int32(truncating: n)
   }
 
   mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
@@ -155,7 +155,7 @@ internal struct JSONDecoder: Decoder {
       if n > Int64(Int32.max) || n < Int64(Int32.min) {
         throw JSONDecodingError.numberRange
       }
-      value.append(Int32(truncatingBitPattern: n))
+      value.append(int32(truncating: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }
@@ -206,7 +206,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = UInt32(truncatingBitPattern: n)
+    value = uint32(truncating: n)
   }
 
   mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
@@ -218,7 +218,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = UInt32(truncatingBitPattern: n)
+    value = uint32(truncating: n)
   }
 
   mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
@@ -234,7 +234,7 @@ internal struct JSONDecoder: Decoder {
       if n > UInt64(UInt32.max) {
         throw JSONDecodingError.numberRange
       }
-      value.append(UInt32(truncatingBitPattern: n))
+      value.append(uint32(truncating: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -127,7 +127,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = int32(truncating: n)
+    value = Int32(extendingOrTruncating: n)
   }
 
   mutating func decodeSingularInt32Field(value: inout Int32?) throws {
@@ -139,7 +139,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = int32(truncating: n)
+    value = Int32(extendingOrTruncating: n)
   }
 
   mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
@@ -155,7 +155,7 @@ internal struct JSONDecoder: Decoder {
       if n > Int64(Int32.max) || n < Int64(Int32.min) {
         throw JSONDecodingError.numberRange
       }
-      value.append(int32(truncating: n))
+      value.append(Int32(extendingOrTruncating: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }
@@ -206,7 +206,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = uint32(truncating: n)
+    value = UInt32(extendingOrTruncating: n)
   }
 
   mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
@@ -218,7 +218,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = uint32(truncating: n)
+    value = UInt32(extendingOrTruncating: n)
   }
 
   mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
@@ -234,7 +234,7 @@ internal struct JSONDecoder: Decoder {
       if n > UInt64(UInt32.max) {
         throw JSONDecodingError.numberRange
       }
-      value.append(uint32(truncating: n))
+      value.append(UInt32(extendingOrTruncating: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -306,19 +306,19 @@ internal struct JSONEncoder {
                 data.append(hexDigits[Int(c.value / 16)])
                 data.append(hexDigits[Int(c.value & 15)])
             case 23...126:
-                data.append(UInt8(truncatingBitPattern: c.value))
+                data.append(uint8(truncating: c.value))
             case 0x80...0x7ff:
-                data.append(0xc0 + UInt8(truncatingBitPattern: c.value >> 6))
-                data.append(0x80 + UInt8(truncatingBitPattern: c.value & 0x3f))
+                data.append(0xc0 + uint8(truncating: c.value >> 6))
+                data.append(0x80 + uint8(truncating: c.value & 0x3f))
             case 0x800...0xffff:
-                data.append(0xe0 + UInt8(truncatingBitPattern: c.value >> 12))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: c.value & 0x3f))
+                data.append(0xe0 + uint8(truncating: c.value >> 12))
+                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + uint8(truncating: c.value & 0x3f))
             default:
-                data.append(0xf0 + UInt8(truncatingBitPattern: c.value >> 18))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 12) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: c.value & 0x3f))
+                data.append(0xf0 + uint8(truncating: c.value >> 18))
+                data.append(0x80 + uint8(truncating: (c.value >> 12) & 0x3f))
+                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + uint8(truncating: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -306,19 +306,19 @@ internal struct JSONEncoder {
                 data.append(hexDigits[Int(c.value / 16)])
                 data.append(hexDigits[Int(c.value & 15)])
             case 23...126:
-                data.append(uint8(truncating: c.value))
+                data.append(UInt8(extendingOrTruncating: c.value))
             case 0x80...0x7ff:
-                data.append(0xc0 + uint8(truncating: c.value >> 6))
-                data.append(0x80 + uint8(truncating: c.value & 0x3f))
+                data.append(0xc0 + UInt8(extendingOrTruncating: c.value >> 6))
+                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
             case 0x800...0xffff:
-                data.append(0xe0 + uint8(truncating: c.value >> 12))
-                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + uint8(truncating: c.value & 0x3f))
+                data.append(0xe0 + UInt8(extendingOrTruncating: c.value >> 12))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
             default:
-                data.append(0xf0 + uint8(truncating: c.value >> 18))
-                data.append(0x80 + uint8(truncating: (c.value >> 12) & 0x3f))
-                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + uint8(truncating: c.value & 0x3f))
+                data.append(0xf0 + UInt8(extendingOrTruncating: c.value >> 18))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 12) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -163,9 +163,9 @@ private func parseBytes(
                 n |= k
                 chars += 1
                 if chars == 4 {
-                    p[0] = uint8(truncating: n >> 16)
-                    p[1] = uint8(truncating: n >> 8)
-                    p[2] = uint8(truncating: n)
+                    p[0] = UInt8(extendingOrTruncating: n >> 16)
+                    p[1] = UInt8(extendingOrTruncating: n >> 8)
+                    p[2] = UInt8(extendingOrTruncating: n)
                     p += 3
                     chars = 0
                     n = 0
@@ -200,13 +200,13 @@ private func parseBytes(
         }
         switch chars {
         case 3:
-            p[0] = uint8(truncating: n >> 10)
-            p[1] = uint8(truncating: n >> 2)
+            p[0] = UInt8(extendingOrTruncating: n >> 10)
+            p[1] = UInt8(extendingOrTruncating: n >> 2)
             if padding == 1 {
                 return
             }
         case 2:
-            p[0] = uint8(truncating: n >> 4)
+            p[0] = UInt8(extendingOrTruncating: n >> 4)
             if padding == 2 {
                 return
             }

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -163,9 +163,9 @@ private func parseBytes(
                 n |= k
                 chars += 1
                 if chars == 4 {
-                    p[0] = UInt8(truncatingBitPattern: n >> 16)
-                    p[1] = UInt8(truncatingBitPattern: n >> 8)
-                    p[2] = UInt8(truncatingBitPattern: n)
+                    p[0] = uint8(truncating: n >> 16)
+                    p[1] = uint8(truncating: n >> 8)
+                    p[2] = uint8(truncating: n)
                     p += 3
                     chars = 0
                     n = 0
@@ -200,13 +200,13 @@ private func parseBytes(
         }
         switch chars {
         case 3:
-            p[0] = UInt8(truncatingBitPattern: n >> 10)
-            p[1] = UInt8(truncatingBitPattern: n >> 2)
+            p[0] = uint8(truncating: n >> 10)
+            p[1] = uint8(truncating: n >> 2)
             if padding == 1 {
                 return
             }
         case 2:
-            p[0] = UInt8(truncatingBitPattern: n >> 4)
+            p[0] = uint8(truncating: n >> 4)
             if padding == 2 {
                 return
             }

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -38,3 +38,98 @@ internal func div<T : SignedInteger>(_ a: T, _ b: T) -> T {
     assert(b > 0)
     return a >= 0 ? a / b : (a + 1) / b - 1
 }
+
+// Swift's standard library changed the name of the initializer
+// that truncates an integer to a narrower type.  To continue
+// to support Swift 3, we've introduced these functions to
+// handle that.
+//
+#if swift(>=4.0)
+//
+// Swift 4 (prerelease) changed this initializer to
+// "extendingOrTruncating"
+//
+internal func uint8(truncating value: UInt32) -> UInt8 {
+    return UInt8(extendingOrTruncating: value)
+}
+
+internal func uint8(truncating value: Int) -> UInt8 {
+    return UInt8(extendingOrTruncating: value)
+}
+
+internal func uint8(truncating value: UInt64) -> UInt8 {
+    return UInt8(extendingOrTruncating: value)
+}
+
+internal func uint32(truncating value: UInt64) -> UInt32 {
+    return UInt32(extendingOrTruncating: value)
+}
+
+internal func uint32(truncating value: Int) -> UInt32 {
+    return UInt32(extendingOrTruncating: value)
+}
+
+internal func int32(truncating value: UInt64) -> Int32 {
+    return Int32(extendingOrTruncating: value)
+}
+
+internal func int32(truncating value: Int64) -> Int32 {
+    return Int32(extendingOrTruncating: value)
+}
+
+internal func int32(truncating value: Int) -> Int32 {
+    return Int32(extendingOrTruncating: value)
+}
+
+internal func int(truncating value: Int64) -> Int {
+    return Int(extendingOrTruncating: value)
+}
+
+internal func int(truncating value: UInt64) -> Int {
+    return Int(extendingOrTruncating: value)
+}
+#else
+//
+// Swift 3 called this initializer "truncatingBitPattern"
+//
+// TODO: When Swift 5 comes out, delete this.
+internal func uint8(truncating value: UInt32) -> UInt8 {
+    return UInt8(truncatingBitPattern: value)
+}
+
+internal func uint8(truncating value: Int) -> UInt8 {
+    return UInt8(truncatingBitPattern: value)
+}
+
+internal func uint8(truncating value: UInt64) -> UInt8 {
+    return UInt8(truncatingBitPattern: value)
+}
+
+internal func uint32(truncating value: UInt64) -> UInt32 {
+    return UInt32(truncatingBitPattern: value)
+}
+
+internal func uint32(truncating value: Int) -> UInt32 {
+    return UInt32(truncatingBitPattern: value)
+}
+
+internal func int32(truncating value: UInt64) -> Int32 {
+    return Int32(truncatingBitPattern: value)
+}
+
+internal func int32(truncating value: Int64) -> Int32 {
+    return Int32(truncatingBitPattern: value)
+}
+
+internal func int32(truncating value: Int) -> Int32 {
+    return Int32(truncatingBitPattern: value)
+}
+
+internal func int(truncating value: Int64) -> Int {
+    return Int(truncatingBitPattern: value)
+}
+
+internal func int(truncating value: UInt64) -> Int {
+    return Int(truncatingBitPattern: value)
+}
+#endif

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -39,97 +39,51 @@ internal func div<T : SignedInteger>(_ a: T, _ b: T) -> T {
     return a >= 0 ? a / b : (a + 1) / b - 1
 }
 
-// Swift's standard library changed the name of the initializer
-// that truncates an integer to a narrower type.  To continue
-// to support Swift 3, we've introduced these functions to
-// handle that.
+#if !swift(>=4.0)
 //
-#if swift(>=4.0)
-//
+// Swift 3 called this initializer "truncatingBitPattern";
 // Swift 4 (prerelease) changed this initializer to
-// "extendingOrTruncating"
+// "extendingOrTruncating".
 //
-internal func uint8(truncating value: UInt32) -> UInt8 {
-    return UInt8(extendingOrTruncating: value)
+extension UInt8 {
+     internal init(extendingOrTruncating value: UInt32) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: Int) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: UInt64) {
+         self.init(truncatingBitPattern: value)
+     }
 }
 
-internal func uint8(truncating value: Int) -> UInt8 {
-    return UInt8(extendingOrTruncating: value)
+extension UInt32 {
+     internal init(extendingOrTruncating value: UInt64) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: Int) {
+         self.init(truncatingBitPattern: value)
+     }
 }
 
-internal func uint8(truncating value: UInt64) -> UInt8 {
-    return UInt8(extendingOrTruncating: value)
+extension Int32 {
+     internal init(extendingOrTruncating value: UInt64) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: Int64) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: Int) {
+         self.init(truncatingBitPattern: value)
+     }
 }
 
-internal func uint32(truncating value: UInt64) -> UInt32 {
-    return UInt32(extendingOrTruncating: value)
-}
-
-internal func uint32(truncating value: Int) -> UInt32 {
-    return UInt32(extendingOrTruncating: value)
-}
-
-internal func int32(truncating value: UInt64) -> Int32 {
-    return Int32(extendingOrTruncating: value)
-}
-
-internal func int32(truncating value: Int64) -> Int32 {
-    return Int32(extendingOrTruncating: value)
-}
-
-internal func int32(truncating value: Int) -> Int32 {
-    return Int32(extendingOrTruncating: value)
-}
-
-internal func int(truncating value: Int64) -> Int {
-    return Int(extendingOrTruncating: value)
-}
-
-internal func int(truncating value: UInt64) -> Int {
-    return Int(extendingOrTruncating: value)
-}
-#else
-//
-// Swift 3 called this initializer "truncatingBitPattern"
-//
-// TODO: When Swift 5 comes out, delete this.
-internal func uint8(truncating value: UInt32) -> UInt8 {
-    return UInt8(truncatingBitPattern: value)
-}
-
-internal func uint8(truncating value: Int) -> UInt8 {
-    return UInt8(truncatingBitPattern: value)
-}
-
-internal func uint8(truncating value: UInt64) -> UInt8 {
-    return UInt8(truncatingBitPattern: value)
-}
-
-internal func uint32(truncating value: UInt64) -> UInt32 {
-    return UInt32(truncatingBitPattern: value)
-}
-
-internal func uint32(truncating value: Int) -> UInt32 {
-    return UInt32(truncatingBitPattern: value)
-}
-
-internal func int32(truncating value: UInt64) -> Int32 {
-    return Int32(truncatingBitPattern: value)
-}
-
-internal func int32(truncating value: Int64) -> Int32 {
-    return Int32(truncatingBitPattern: value)
-}
-
-internal func int32(truncating value: Int) -> Int32 {
-    return Int32(truncatingBitPattern: value)
-}
-
-internal func int(truncating value: Int64) -> Int {
-    return Int(truncatingBitPattern: value)
-}
-
-internal func int(truncating value: UInt64) -> Int {
-    return Int(truncatingBitPattern: value)
+extension Int {
+     internal init(extendingOrTruncating value: Int64) {
+         self.init(truncatingBitPattern: value)
+     }
+     internal init(extendingOrTruncating value: UInt64) {
+         self.init(truncatingBitPattern: value)
+     }
 }
 #endif

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -149,7 +149,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = Int32(truncatingBitPattern: n)
+        value = int32(truncating: n)
     }
     mutating func decodeSingularInt32Field(value: inout Int32?) throws {
         try scanner.skipRequiredColon()
@@ -157,7 +157,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = Int32(truncatingBitPattern: n)
+        value = int32(truncating: n)
     }
     mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
         try scanner.skipRequiredColon()
@@ -176,14 +176,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > Int64(Int32.max) || n < Int64(Int32.min) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(Int32(truncatingBitPattern: n))
+                value.append(int32(truncating: n))
             }
         } else {
             let n = try scanner.nextSInt()
             if n > Int64(Int32.max) || n < Int64(Int32.min) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(Int32(truncatingBitPattern: n))
+            value.append(int32(truncating: n))
         }
     }
     mutating func decodeSingularInt64Field(value: inout Int64) throws {
@@ -221,7 +221,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = UInt32(truncatingBitPattern: n)
+        value = uint32(truncating: n)
     }
     mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
         try scanner.skipRequiredColon()
@@ -229,7 +229,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = UInt32(truncatingBitPattern: n)
+        value = uint32(truncating: n)
     }
     mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
         try scanner.skipRequiredColon()
@@ -248,14 +248,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > UInt64(UInt32.max) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(UInt32(truncatingBitPattern: n))
+                value.append(uint32(truncating: n))
             }
         } else {
             let n = try scanner.nextUInt()
             if n > UInt64(UInt32.max) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(UInt32(truncatingBitPattern: n))
+            value.append(uint32(truncating: n))
         }
     }
     mutating func decodeSingularUInt64Field(value: inout UInt64) throws {
@@ -439,7 +439,7 @@ internal struct TextFormatDecoder: Decoder {
         }
         let number = try scanner.nextSInt()
         if number >= Int64(Int32.min) && number <= Int64(Int32.max) {
-            let n = Int32(truncatingBitPattern: number)
+            let n = int32(truncating: number)
             if let e = E(rawValue: Int(n)) {
                 return e
             } else {

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -149,7 +149,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = int32(truncating: n)
+        value = Int32(extendingOrTruncating: n)
     }
     mutating func decodeSingularInt32Field(value: inout Int32?) throws {
         try scanner.skipRequiredColon()
@@ -157,7 +157,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = int32(truncating: n)
+        value = Int32(extendingOrTruncating: n)
     }
     mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
         try scanner.skipRequiredColon()
@@ -176,14 +176,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > Int64(Int32.max) || n < Int64(Int32.min) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(int32(truncating: n))
+                value.append(Int32(extendingOrTruncating: n))
             }
         } else {
             let n = try scanner.nextSInt()
             if n > Int64(Int32.max) || n < Int64(Int32.min) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(int32(truncating: n))
+            value.append(Int32(extendingOrTruncating: n))
         }
     }
     mutating func decodeSingularInt64Field(value: inout Int64) throws {
@@ -221,7 +221,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = uint32(truncating: n)
+        value = UInt32(extendingOrTruncating: n)
     }
     mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
         try scanner.skipRequiredColon()
@@ -229,7 +229,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = uint32(truncating: n)
+        value = UInt32(extendingOrTruncating: n)
     }
     mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
         try scanner.skipRequiredColon()
@@ -248,14 +248,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > UInt64(UInt32.max) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(uint32(truncating: n))
+                value.append(UInt32(extendingOrTruncating: n))
             }
         } else {
             let n = try scanner.nextUInt()
             if n > UInt64(UInt32.max) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(uint32(truncating: n))
+            value.append(UInt32(extendingOrTruncating: n))
         }
     }
     mutating func decodeSingularUInt64Field(value: inout UInt64) throws {
@@ -439,7 +439,7 @@ internal struct TextFormatDecoder: Decoder {
         }
         let number = try scanner.nextSInt()
         if number >= Int64(Int32.min) && number <= Int64(Int32.max) {
-            let n = int32(truncating: number)
+            let n = Int32(extendingOrTruncating: number)
             if let e = E(rawValue: Int(n)) {
                 return e
             } else {

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -203,7 +203,7 @@ internal struct TextFormatEncoder {
             append(staticText: "0x")
         } else {
             appendUIntHex(value: value >> 4, digits: digits - 1)
-            let d = UInt8(truncatingBitPattern: value % 16)
+            let d = uint8(truncating: value % 16)
             data.append(d < 10 ? asciiZero + d : asciiUpperA + d - 10)
         }
     }
@@ -243,19 +243,19 @@ internal struct TextFormatEncoder {
                 data.append(asciiZero + UInt8(c.value / 8 % 8))
                 data.append(asciiZero + UInt8(c.value % 8))
             case 0...127:  // ASCII
-                data.append(UInt8(truncatingBitPattern: c.value))
+                data.append(uint8(truncating: c.value))
             case 0x80...0x7ff:
                 data.append(0xc0 + UInt8(c.value / 64))
                 data.append(0x80 + UInt8(c.value % 64))
             case 0x800...0xffff:
-                data.append(0xe0 + UInt8(truncatingBitPattern: c.value >> 12))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: c.value & 0x3f))
+                data.append(0xe0 + uint8(truncating: c.value >> 12))
+                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + uint8(truncating: c.value & 0x3f))
             default:
-                data.append(0xf0 + UInt8(truncatingBitPattern: c.value >> 18))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 12) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(truncatingBitPattern: c.value & 0x3f))
+                data.append(0xf0 + uint8(truncating: c.value >> 18))
+                data.append(0x80 + uint8(truncating: (c.value >> 12) & 0x3f))
+                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + uint8(truncating: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -203,7 +203,7 @@ internal struct TextFormatEncoder {
             append(staticText: "0x")
         } else {
             appendUIntHex(value: value >> 4, digits: digits - 1)
-            let d = uint8(truncating: value % 16)
+            let d = UInt8(extendingOrTruncating: value % 16)
             data.append(d < 10 ? asciiZero + d : asciiUpperA + d - 10)
         }
     }
@@ -243,19 +243,19 @@ internal struct TextFormatEncoder {
                 data.append(asciiZero + UInt8(c.value / 8 % 8))
                 data.append(asciiZero + UInt8(c.value % 8))
             case 0...127:  // ASCII
-                data.append(uint8(truncating: c.value))
+                data.append(UInt8(extendingOrTruncating: c.value))
             case 0x80...0x7ff:
                 data.append(0xc0 + UInt8(c.value / 64))
                 data.append(0x80 + UInt8(c.value % 64))
             case 0x800...0xffff:
-                data.append(0xe0 + uint8(truncating: c.value >> 12))
-                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + uint8(truncating: c.value & 0x3f))
+                data.append(0xe0 + UInt8(extendingOrTruncating: c.value >> 12))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
             default:
-                data.append(0xf0 + uint8(truncating: c.value >> 18))
-                data.append(0x80 + uint8(truncating: (c.value >> 12) & 0x3f))
-                data.append(0x80 + uint8(truncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + uint8(truncating: c.value & 0x3f))
+                data.append(0xf0 + UInt8(extendingOrTruncating: c.value >> 18))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 12) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)

--- a/Tests/SwiftProtobufTests/Test_Duration.swift
+++ b/Tests/SwiftProtobufTests/Test_Duration.swift
@@ -250,9 +250,9 @@ class Test_Duration: XCTestCase, PBTestHelpers {
 
     func testGetters() throws {
         let t1 = Google_Protobuf_Duration(seconds: -123, nanos: -123456789)
-        XCTAssertEqualWithAccuracy(t1.timeInterval, -123.123456789, accuracy: 1e-30)
+        XCTAssertEqual(t1.timeInterval, -123.123456789)
 
         let t2 = Google_Protobuf_Duration(seconds: 123, nanos: 123456789)
-        XCTAssertEqualWithAccuracy(t2.timeInterval, 123.123456789, accuracy: 1e-30)
+        XCTAssertEqual(t2.timeInterval, 123.123456789)
     }
 }

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -539,10 +539,10 @@ class Test_JSON: XCTestCase, PBTestHelpers {
     }
 
     func testSingleString_controlCharacters() {
-        // This is known to fail on Swift Linux 3.1 and earlier,
+        // This is known to fail on Swift Linux 4.0 and earlier,
         // so skip it there.
         // See https://bugs.swift.org/browse/SR-4218 for details.
-#if !os(Linux) || swift(>=3.2)
+#if !os(Linux) || swift(>=4.1)
         // Verify that all C0 controls are correctly escaped
         assertJSONEncode("{\"singleString\":\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\"}") {(o: inout MessageTestType) in
             o.singleString = "\u{00}\u{01}\u{02}\u{03}\u{04}\u{05}\u{06}\u{07}"

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -581,10 +581,10 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
     }
 
     func testEncoding_singleString_controlCharacters() throws {
-        // This is known to fail on Swift Linux 3.1 and earlier,
+        // This is known to fail on Swift Linux 4.0 and earlier,
         // so skip it there.
         // See https://bugs.swift.org/browse/SR-4218 for details.
-#if !os(Linux) || swift(>=3.2)
+#if !os(Linux) || swift(>=4.1)
         assertTextFormatEncode("single_string: \"\\001\\002\\003\\004\\005\\006\\007\"\n") {
             (o: inout MessageTestType) in
             o.singleString = "\u{01}\u{02}\u{03}\u{04}\u{05}\u{06}\u{07}"

--- a/Tests/SwiftProtobufTests/Test_Timestamp.swift
+++ b/Tests/SwiftProtobufTests/Test_Timestamp.swift
@@ -417,11 +417,9 @@ class Test_Timestamp: XCTestCase, PBTestHelpers {
         let t1 = Google_Protobuf_Timestamp(seconds: 12345678, nanos: 12345678)
         XCTAssertEqual(t1.seconds, 12345678)
         XCTAssertEqual(t1.nanos, 12345678)
-        // There is a lot of double arithmetic here. These values are not going
-        // to be exact, of course.
-        XCTAssertEqualWithAccuracy(t1.timeIntervalSince1970, 12345678.012345678, accuracy: 1e-30)
-        XCTAssertEqualWithAccuracy(t1.timeIntervalSinceReferenceDate, -965961521.987654322, accuracy: 1e-30)
+        XCTAssertEqual(t1.timeIntervalSince1970, 12345678.012345678)
+        XCTAssertEqual(t1.timeIntervalSinceReferenceDate, -965961521.987654322)
         let d = t1.date
-        XCTAssertEqualWithAccuracy(d.timeIntervalSinceReferenceDate, -965961521.987654322, accuracy: 1e-30)
+        XCTAssertEqual(d.timeIntervalSinceReferenceDate, -965961521.987654322)
     }
 }


### PR DESCRIPTION
More incremental progress on Issue #585.

This addresses the renamed truncating initializers by introducing a simple layer of indirect functions (lowercase 'int(truncating:)', etc).  Hopefully, this can be ripped out again when we drop Swift 3.x support (maybe not until Swift 5 ships?).

It also disables certain String tests that tickle a bug that is still present in snapshots of Linux Swift 4.0.  Hopefully, the bug will get fixed in Swift 4.1.