### PR TITLE
Fixed bad output in showHelp()

### DIFF
--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -24,5 +24,5 @@ public struct Version {
   static public let revision = 905
 
   /// String form of the version number.
-  static public let versionString = "\(major).\(minor).\(revision)"
+  static public let versionString = "\(major),\(minor),\(revision)"
 }

--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -24,5 +24,5 @@ public struct Version {
   static public let revision = 905
 
   /// String form of the version number.
-  static public let versionString = "\(major),\(minor),\(revision)"
+  static public let versionString = "\(major).\(minor).\(revision)"
 }

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -106,7 +106,7 @@ struct GeneratorPlugin {
         + "\n"
         + "   dependencies: [\n"
         + "     .Package(url: \"https://github.com/apple/swift-protobuf\",\n"
-        + "              Version(\(SwiftProtobuf.Version.versionString))\n"
+        + "              Version(\(SwiftProtobuf.Version.versionString)))\n"
         + "   ]\n"
         + "\n"
         + "\n"

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -86,6 +86,9 @@ struct GeneratorPlugin {
     showVersion()
     print(Version.copyright)
     print("")
+    
+    let version = SwiftProtobuf.Version
+    let packageVersion = "\(version.major),\(version.minor),\(version.revision)"
 
     let help = (
       "Note:  This is a plugin for protoc and should not normally be run\n"
@@ -106,7 +109,7 @@ struct GeneratorPlugin {
         + "\n"
         + "   dependencies: [\n"
         + "     .Package(url: \"https://github.com/apple/swift-protobuf\",\n"
-        + "              Version(\(SwiftProtobuf.Version.versionString)))\n"
+        + "              Version(\(packageVersion)))\n"
         + "   ]\n"
         + "\n"
         + "\n"


### PR DESCRIPTION
Currently, `protoc-gen-swift -h` outputs the following, which does not compile, due to a syntax error and incorrectly-formatted version number:

```swift
Package.swift:

   dependencies: [
     .Package(url: "https://github.com/apple/swift-protobuf",
              Version(0.9.904)
   ]
```

This pull request changes the version number to the correct format and adds the missing closing `)`:

```swift
Package.swift:

   dependencies: [
     .Package(url: "https://github.com/apple/swift-protobuf",
              Version(0,9,905))
   ]
```