### PR TITLE
Mark all visitMapField() methods as "throws"

### DIFF
--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -105,7 +105,7 @@ internal struct HashVisitor: Visitor {
     fieldType: _ProtobufMap<KeyType, ValueType>.Type,
     value: _ProtobufMap<KeyType, ValueType>.BaseType,
     fieldNumber: Int
-  ) {
+  ) throws {
     mix(fieldNumber)
     mixMap(map: value)
   }
@@ -115,7 +115,7 @@ internal struct HashVisitor: Visitor {
     fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type,
     value: _ProtobufEnumMap<KeyType, ValueType>.BaseType,
     fieldNumber: Int
-  ) where ValueType.RawValue == Int {
+  ) throws where ValueType.RawValue == Int {
     mix(fieldNumber)
     mixMap(map: value)
   }
@@ -125,7 +125,7 @@ internal struct HashVisitor: Visitor {
     fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type,
     value: _ProtobufMessageMap<KeyType, ValueType>.BaseType,
     fieldNumber: Int
-  ) {
+  ) throws {
     mix(fieldNumber)
     mixMap(map: value)
   }

--- a/Sources/SwiftProtobuf/SelectiveVisitor.swift
+++ b/Sources/SwiftProtobuf/SelectiveVisitor.swift
@@ -246,7 +246,7 @@ internal extension SelectiveVisitor {
     fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type,
     value: _ProtobufMessageMap<KeyType, ValueType>.BaseType,
     fieldNumber: Int
-  ) {
+  ) throws {
     assert(false)
   }
 


### PR DESCRIPTION
Note:  The Swift language does not require this; it's
not really a bug in our code.

But, it seems to be tickling a bug within the Swift compiler,
so it seems reasonable to make the code more consistent here.

This seems to fix #610 (builds failing with Carthage on Xcode9b2).