### PR TITLE
Perf: Rework Text and JSON enum handling to take full advantage of NameMap

### DIFF
--- a/Performance/generators/cpp.sh
+++ b/Performance/generators/cpp.sh
@@ -31,6 +31,11 @@ function print_cpp_set_field() {
       echo "    message.add_field$num(std::string(20, (char)$((num))));"
       echo "  }"
       ;;
+    repeated\ enum)
+      echo "  for (auto i = 0; i < repeated_count; i++) {"
+      echo "    message.add_field$num(PerfMessage::FOO);"
+      echo "  }"
+      ;;
     repeated\ *)
       echo "  for (auto i = 0; i < repeated_count; i++) {"
       echo "    message.add_field$num($((200+num)));"
@@ -41,6 +46,9 @@ function print_cpp_set_field() {
       ;;
     bytes)
       echo "  message.set_field$num(std::string(20, (char)$((num))));"
+      ;;
+    enum)
+      echo "  message.set_field$num(PerfMessage::FOO);"
       ;;
     *)
       echo "  message.set_field$num($((200+num)));"

--- a/Performance/generators/proto.sh
+++ b/Performance/generators/proto.sh
@@ -18,11 +18,12 @@
 
 function print_proto_field() {
   num="$1"
+  _type=`echo $2 | sed -e 's/enum/PerfEnum/'`
 
   if [[ "$proto_syntax" == "2" ]] && [[ "$field_type" != repeated* ]]; then
-    type="optional $2"
+    type="optional $_type"
   else
-    type="$2"
+    type="$_type"
   fi
 
   if [[ -n "$packed" ]]; then
@@ -38,6 +39,13 @@ function generate_homogeneous_test_proto() {
 syntax = "proto$proto_syntax";
 
 message PerfMessage {
+  enum PerfEnum {
+    ZERO = 0;
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+    NEG = -1;
+  }
 EOF
 
   for field_number in $(seq 1 "$field_count"); do

--- a/Performance/generators/swift.sh
+++ b/Performance/generators/swift.sh
@@ -34,6 +34,11 @@ function print_swift_set_field() {
       echo "      message.field$num.append(\"$((200+num))\")"
       echo "    }"
       ;;
+    repeated\ enum)
+      echo "    for _ in 0..<repeatedCount {"
+      echo "      message.field$num.append(.foo)"
+      echo "    }"
+      ;;
     repeated\ *)
       echo "    for _ in 0..<repeatedCount {"
       echo "      message.field$num.append($((200+num)))"
@@ -47,6 +52,9 @@ function print_swift_set_field() {
       ;;
     string)
       echo "    message.field$num = \"$((200+num))\""
+      ;;
+    enum)
+      echo "    message.field$num = .foo"
       ;;
     *)
       echo "    message.field$num = $((200+num))"

--- a/Sources/SwiftProtobuf/Enum.swift
+++ b/Sources/SwiftProtobuf/Enum.swift
@@ -69,4 +69,12 @@ extension Enum {
     }
     self.init(rawValue: number)
   }
+
+  internal init?(rawUTF8: UnsafeBufferPointer<UInt8>) {
+    guard let nameProviding = Self.self as? _ProtoNameProviding.Type,
+      let number = nameProviding._protobuf_nameMap.number(forJSONName: rawUTF8) else {
+      return nil
+    }
+    self.init(rawValue: number)
+  }
 }

--- a/Sources/SwiftProtobuf/Enum.swift
+++ b/Sources/SwiftProtobuf/Enum.swift
@@ -70,6 +70,13 @@ extension Enum {
     self.init(rawValue: number)
   }
 
+  /// Internal convenience initializer that returns the enum value with the
+  /// given name, if it provides names.
+  ///
+  /// Since the text format and JSON names are always identical, we don't need
+  /// to distinguish them.
+  ///
+  /// - Parameter name: Buffer holding the UTF-8 bytes of the desired name.
   internal init?(rawUTF8: UnsafeBufferPointer<UInt8>) {
     guard let nameProviding = Self.self as? _ProtoNameProviding.Type,
       let number = nameProviding._protobuf_nameMap.number(forJSONName: rawUTF8) else {

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -463,17 +463,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalNull() {
       value = nil
       return
-    } else if let e: E = try scanner.nextOptionalStringEnum() {
-      value = e
-      return
-    } else {
-      let n = try scanner.nextSInt()
-      if let i = Int(exactly: n) {
-        value = E(rawValue: i)
-        return
-      }
     }
-    throw JSONDecodingError.unrecognizedEnumValue
+    value = try scanner.nextEnumValue()
   }
 
   mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws
@@ -481,19 +472,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalNull() {
       value = E()
       return
-    } else if let e: E = try scanner.nextOptionalStringEnum() {
-      value = e
-      return
-    } else {
-      let n = try scanner.nextSInt()
-      if let i = Int(exactly: n) {
-        if let v = E(rawValue: i) {
-          value = v
-          return
-        }
-      }
     }
-    throw JSONDecodingError.unrecognizedEnumValue
+    value = try scanner.nextEnumValue()
   }
 
   mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws
@@ -506,20 +486,8 @@ internal struct JSONDecoder: Decoder {
       return
     }
     while true {
-      if let e: E = try scanner.nextOptionalStringEnum() {
-        value.append(e)
-      } else {
-        let n = try scanner.nextSInt()
-        if let i = Int(exactly: n) {
-          if let v = E(rawValue: i) {
-            value.append(v)
-          } else {
-            throw JSONDecodingError.unrecognizedEnumValue
-          }
-        } else {
-          throw JSONDecodingError.numberRange
-        }
-      }
+      let e: E = try scanner.nextEnumValue()
+      value.append(e)
       if scanner.skipOptionalArrayEnd() {
         return
       }

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -458,17 +458,14 @@ internal struct JSONDecoder: Decoder {
     }
   }
 
-
   mutating func decodeSingularEnumField<E: Enum>(value: inout E?) throws
   where E.RawValue == Int {
     if scanner.skipOptionalNull() {
       value = nil
       return
-    } else if let name = try scanner.nextOptionalQuotedString() {
-      if let v = E(name: name) {
-        value = v
-        return
-      }
+    } else if let e: E = try scanner.nextOptionalStringEnum() {
+      value = e
+      return
     } else {
       let n = try scanner.nextSInt()
       if let i = Int(exactly: n) {
@@ -484,11 +481,9 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalNull() {
       value = E()
       return
-    } else if let name = try scanner.nextOptionalQuotedString() {
-      if let v = E(name: name) {
-        value = v
-        return
-      }
+    } else if let e: E = try scanner.nextOptionalStringEnum() {
+      value = e
+      return
     } else {
       let n = try scanner.nextSInt()
       if let i = Int(exactly: n) {
@@ -511,12 +506,8 @@ internal struct JSONDecoder: Decoder {
       return
     }
     while true {
-      if let name = try scanner.nextOptionalQuotedString() {
-        if let v = E(name: name) {
-          value.append(v)
-        } else {
-          throw JSONDecodingError.unrecognizedEnumValue
-        }
+      if let e: E = try scanner.nextOptionalStringEnum() {
+        value.append(e)
       } else {
         let n = try scanner.nextSInt()
         if let i = Int(exactly: n) {

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -86,14 +86,10 @@ internal struct JSONEncoder {
         data.append(contentsOf: buff)
     }
 
-    /// Append a `_NameMap.Name` to the JSON text.  As with
-    /// StaticString above, a `_NameMap.Name` provides pre-converted
+    /// Append a `_NameMap.Name` to the JSON text surrounded by quotes.
+    /// As with StaticString above, a `_NameMap.Name` provides pre-converted
     /// UTF8 bytes, so this is much faster than appending a regular
     /// `String`.
-    internal mutating func append(name: _NameMap.Name) {
-        data.append(contentsOf: name.utf8Buffer)
-    }
-
     internal mutating func appendQuoted(name: _NameMap.Name) {
         data.append(asciiDoubleQuote)
         data.append(contentsOf: name.utf8Buffer)

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -94,6 +94,12 @@ internal struct JSONEncoder {
         data.append(contentsOf: name.utf8Buffer)
     }
 
+    internal mutating func appendQuoted(name: _NameMap.Name) {
+        data.append(asciiDoubleQuote)
+        data.append(contentsOf: name.utf8Buffer)
+        data.append(asciiDoubleQuote)
+    }
+
     /// Append a `String` to the JSON text.
     internal mutating func append(text: String) {
         data.append(contentsOf: text.utf8)
@@ -109,10 +115,8 @@ internal struct JSONEncoder {
         if let s = separator {
             data.append(s)
         }
-        data.append(asciiDoubleQuote)
-        // Append the StaticString's utf8 contents directly
-        append(name: name)
-        append(staticText: "\":")
+        appendQuoted(name: name)
+        data.append(asciiColon)
         separator = asciiComma
     }
 
@@ -139,6 +143,11 @@ internal struct JSONEncoder {
     internal mutating func endArray() {
         data.append(asciiCloseSquareBracket)
         separator = asciiComma
+    }
+
+    /// Append a comma `,` to the JSON.
+    internal mutating func comma() {
+        data.append(asciiComma)
     }
 
     /// Append an open curly brace `{` to the JSON.

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -136,20 +136,22 @@ internal struct JSONEncodingVisitor: Visitor {
 
   private mutating func _visitRepeated<T>(value: [T], fieldNumber: Int, encode: (T) -> ()) throws {
     try startField(for: fieldNumber)
-    var arraySeparator = String()
-    encoder.append(text: "[")
+    var comma = false
+    encoder.startArray()
     for v in value {
-      encoder.append(text: arraySeparator)
+      if comma {
+          encoder.comma()
+      }
+      comma = true
       encode(v)
-      arraySeparator = ","
     }
-    encoder.append(text: "]")
+    encoder.endArray()
   }
 
   mutating func visitSingularEnumField<E: Enum>(value: E, fieldNumber: Int) throws {
     try startField(for: fieldNumber)
     if let n = value.name {
-      encoder.putStringValue(value: String(describing: n))
+      encoder.appendQuoted(name: n)
     } else {
       encoder.putEnumInt(value: value.rawValue)
     }
@@ -250,7 +252,7 @@ internal struct JSONEncodingVisitor: Visitor {
     for v in value {
       encoder.append(text: arraySeparator)
       if let n = v.name {
-        encoder.putStringValue(value: String(describing: n))
+        encoder.appendQuoted(name: n)
       } else {
         encoder.putEnumInt(value: v.rawValue)
       }

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1151,7 +1151,7 @@ internal struct JSONScanner {
       throw JSONDecodingError.truncated
     }
     if currentByte != asciiDoubleQuote {
-      throw JSONDecodingError.malformedString
+      return nil
     }
     advance()
     let nameStart = index
@@ -1199,6 +1199,23 @@ internal struct JSONScanner {
       }
       try skipRequiredComma()
     }
+  }
+
+  internal mutating func nextOptionalStringEnum<E: Enum>() throws -> E? {
+    skipWhitespace()
+    if currentByte != asciiDoubleQuote {
+      return nil
+    }
+    if let name = try nextBareKey() {
+      if let e = E(rawUTF8: name) {
+        return e
+      }
+    } else if let name = parseOptionalQuotedString() {
+      if let e = E(name: name) {
+        return e
+      }
+    }
+    throw JSONDecodingError.unrecognizedEnumValue
   }
 
   /// Helper for skipping a single-character token.

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -431,7 +431,7 @@ internal struct TextFormatDecoder: Decoder {
 
     private mutating func decodeEnum<E: Enum>() throws -> E where E.RawValue == Int {
         if let name = try scanner.nextOptionalEnumName() {
-            if let b = E(name: name) {
+            if let b = E(rawUTF8: name) {
                 return b
             } else {
                 throw TextFormatDecodingError.unrecognizedEnumValue

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -838,12 +838,10 @@ internal struct TextFormatScanner {
         if p == end {
             throw TextFormatDecodingError.malformedText
         }
-        let start = p
         switch p[0] {
         case asciiLowerA...asciiLowerZ, asciiUpperA...asciiUpperZ:
             return parseUTF8Identifier()
         default:
-            p = start
             return nil
         }
     }

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -216,6 +216,25 @@ internal struct TextFormatScanner {
         }
     }
 
+    private mutating func parseUTF8Identifier() -> UnsafeBufferPointer<UInt8>? {
+        let start = p
+        loop: while p != end {
+            let c = p[0]
+            switch c {
+            case asciiLowerA...asciiLowerZ,
+                 asciiUpperA...asciiUpperZ,
+                 asciiZero...asciiNine,
+                 asciiUnderscore:
+                p += 1
+            default:
+                break loop
+            }
+        }
+        let s = UnsafeBufferPointer(start: start, count: p - start)
+        skipWhitespace()
+        return s
+    }
+
     private mutating func parseIdentifier() -> String? {
         let start = p
         loop: while p != end {
@@ -826,7 +845,7 @@ internal struct TextFormatScanner {
         throw TextFormatDecodingError.malformedText
     }
 
-    internal mutating func nextOptionalEnumName() throws -> String? {
+    internal mutating func nextOptionalEnumName() throws -> UnsafeBufferPointer<UInt8>? {
         skipWhitespace()
         if p == end {
             throw TextFormatDecodingError.malformedText
@@ -835,7 +854,7 @@ internal struct TextFormatScanner {
         let start = p
         switch c {
         case asciiLowerA...asciiLowerZ, asciiUpperA...asciiUpperZ:
-            if let s = parseIdentifier() {
+            if let s = parseUTF8Identifier() {
                 return s
             }
         default:

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -216,7 +216,10 @@ internal struct TextFormatScanner {
         }
     }
 
-    private mutating func parseUTF8Identifier() -> UnsafeBufferPointer<UInt8>? {
+    /// Return a buffer containing the raw UTF8 for an identifier.
+    /// Assumes that you already know the current byte is a valid
+    /// start of identifier.
+    private mutating func parseUTF8Identifier() -> UnsafeBufferPointer<UInt8> {
         let start = p
         loop: while p != end {
             let c = p[0]
@@ -235,23 +238,12 @@ internal struct TextFormatScanner {
         return s
     }
 
-    private mutating func parseIdentifier() -> String? {
-        let start = p
-        loop: while p != end {
-            let c = p[0]
-            switch c {
-            case asciiLowerA...asciiLowerZ,
-                 asciiUpperA...asciiUpperZ,
-                 asciiZero...asciiNine,
-                 asciiUnderscore:
-                p += 1
-            default:
-                break loop
-            }
-        }
-        let s = utf8ToString(bytes: start, count: p - start)
-        skipWhitespace()
-        return s
+    /// Return a String containing the next identifier.
+    private mutating func parseIdentifier() -> String {
+        let buff = parseUTF8Identifier()
+        let s = utf8ToString(bytes: buff.baseAddress!, count: buff.count)
+        // Force-unwrap is OK:  we never have invalid UTF8 at this point.
+        return s!
     }
 
     /// Parse the rest of an [extension_field_name] in the input, assuming the
@@ -829,15 +821,13 @@ internal struct TextFormatScanner {
         let c = p[0]
         switch c {
         case asciiZero, asciiOne, asciiLowerF, asciiUpperF, asciiLowerT, asciiUpperT:
-            if let s = parseIdentifier() {
-                switch s {
-                case "0", "f", "false", "False":
-                    return false
-                case "1", "t", "true", "True":
-                    return true
-                default:
-                    break
-                }
+            switch parseIdentifier() {
+            case "0", "f", "false", "False":
+                return false
+            case "1", "t", "true", "True":
+                return true
+            default:
+                break
             }
         default:
             break
@@ -850,18 +840,14 @@ internal struct TextFormatScanner {
         if p == end {
             throw TextFormatDecodingError.malformedText
         }
-        let c = p[0]
         let start = p
-        switch c {
+        switch p[0] {
         case asciiLowerA...asciiLowerZ, asciiUpperA...asciiUpperZ:
-            if let s = parseUTF8Identifier() {
-                return s
-            }
+            return parseUTF8Identifier()
         default:
-            break
+            p = start
+            return nil
         }
-        p = start
-        return nil
     }
 
     /// Any URLs are syntactically (almost) identical to extension
@@ -922,11 +908,7 @@ internal struct TextFormatScanner {
         case asciiLowerA...asciiLowerZ,
              asciiUpperA...asciiUpperZ,
              asciiOne...asciiNine: // a...z, A...Z, 1...9
-            if let s = parseIdentifier() {
-                return s
-            } else {
-                throw TextFormatDecodingError.malformedText
-            }
+            return parseIdentifier()
         default:
             throw TextFormatDecodingError.malformedText
         }
@@ -950,28 +932,13 @@ internal struct TextFormatScanner {
         switch c {
         case asciiLowerA...asciiLowerZ,
              asciiUpperA...asciiUpperZ: // a...z, A...Z
-            let start = p
-            p += 1
-            scanKeyLoop: while p != end {
-                let c = p[0]
-                switch c {
-                case asciiLowerA...asciiLowerZ,
-                     asciiUpperA...asciiUpperZ,
-                     asciiZero...asciiNine,
-                     asciiUnderscore: // a...z, A...Z, 0...9, _
-                    p += 1
-                default:
-                    break scanKeyLoop
-                }
-            }
-            let key = UnsafeBufferPointer(start: start, count: p - start)
-            skipWhitespace()
+            let key = parseUTF8Identifier()
             if let fieldNumber = names.number(forProtoName: key) {
                 return fieldNumber
             } else {
                 throw TextFormatDecodingError.unknownField
             }
-        case asciiOne...asciiNine:  // 1-9 (field numbers should be 0123, just 123)
+        case asciiOne...asciiNine:  // 1-9 (field numbers are 123, not 0123)
             var fieldNum = Int(c) - Int(asciiZero)
             p += 1
             while p != end {


### PR DESCRIPTION
On decode, we were converting the UTF-8 enum name into a String and
then NameMap was converting it back to UTF-8 for lookup.  The code now
short-circuits that, looking up the UTF-8 key directly on the NameMap.

This is a little tricky for JSON because a quoted enum key is allowed
to have backslash escapes.  This should be very rare since proto enum
names are always simple ASCII, so we can optimize by first trying a fast
path that returns UTF-8 for a key with no such escapes, then falling back
to a slower String decode if we must.

On encode, JSON repeated fields (including enums) were spending a lot
of unnecessary time converting constant strings such as "[" and ","
to/from UTF8.  This commit fixes that, with sizable performance gains
for all repeated field types in JSON.

I've also edited the Performance harness to support `enum` as a field
type.