### PR TITLE
Improve docs on Swift version support.

### DIFF
--- a/Documentation/INTERNALS.md
+++ b/Documentation/INTERNALS.md
@@ -15,6 +15,19 @@ As a result, this document is probably already out of date;
 pull requests that correct this document to better match the actual
 behavior are always appreciated.
 
+## Swift Language Support
+
+The goal is to always support "one full major version”, which basically
+means if the current official release of Swift is `X.Y`, the library will
+support back to `X-1.Y`.  That is, when Swift 4.1 gets released, the minimum
+for support gets moved up to 3.1.
+
+When the minimum Swift version gets updated, update:
+- The `README.md` in the root of the project
+- Audit all the `#if` directives in the code and tests that use at
+  `swift(...)` to check the version being compiled against, and
+  remove the ones that are no longer needed.
+
 ## Field Storage
 
 The generated message structs follow one of several different patterns

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ your project as explained below.
 
 To use Swift with Protocol buffers, you'll need:
 
-* A recent Swift 3 compiler that includes the Swift Package Manager.  The Swift
-protobuf project is being developed and tested against the latest release version of
-Swift available from [Swift.org](https://swift.org)
+* A Swift 3.0.1 or later compiler (Xcode 8.1 or later).  Support is included
+for the Swift Package Manager; or using the included Xcode project. The Swift
+protobuf project is being developed and tested against the latest release
+version of Swift available from [Swift.org](https://swift.org)
 
 * Google's protoc compiler.  The Swift protoc plugin is being actively
 developed and tested against the latest protobuf sources.


### PR DESCRIPTION
- Spell out the Xcode version it maps too.
- Document what should happen when changing the min Swift version.