### PR TITLE
Shim XCTAssertNoThrow for older versions of Swift.

### DIFF
--- a/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
@@ -12,6 +12,22 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
+#if !swift(>=3.1)
+// Xcode 8.1 had Swift 3.0, and that version of XCTest doesn't have
+// XCTAssertNoThrow, so shim it so the tests can build/run there.
+fileprivate func XCTAssertNoThrow(
+  _ expression: @autoclosure () throws -> Void,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  do {
+    try expression()
+  } catch let e {
+    XCTFail("Should not have thrown: \(e)", file: file, line: line)
+  }
+}
+#endif
+
 class Test_BinaryDelimited: XCTestCase {
 
   func testEverything() {


### PR DESCRIPTION
XCTAssertNoThrow got added in Xcode 8.2, but there isn't a good way
to test the Xcode version (or XCTest version), so instead use the
Swift version to figure out when to shim it so the test builds/runs.