### PR TITLE
Xcode compatibility fixes...

### DIFF
--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -464,7 +464,7 @@ internal struct JSONDecoder: Decoder {
       value = nil
       return
     }
-    value = try scanner.nextEnumValue()
+    value = try scanner.nextEnumValue() as E
   }
 
   mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -65,7 +65,7 @@ private let asciiUpperZ = UInt8(ascii: "Z")
 private func fromHexDigit(_ c: UnicodeScalar) -> UInt32? {
   let n = c.value
   if n >= 48 && n <= 57 {
-    return n - 48
+    return UInt32(n - 48)
   }
   switch n {
   case 65, 97: return 10

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -70,10 +70,10 @@ private func fromHexDigit(_ c: UInt8) -> UInt8? {
     return c - asciiZero
   }
   if c >= asciiUpperA && c <= asciiUpperF {
-      return c - asciiUpperA + 10
+      return c - asciiUpperA + UInt8(10)
   }
   if c >= asciiLowerA && c <= asciiLowerF {
-      return c - asciiLowerA + 10
+      return c - asciiLowerA + UInt8(10)
   }
   return nil
 }

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -86,8 +86,8 @@ struct GeneratorPlugin {
     showVersion()
     print(Version.copyright)
     print("")
-    
-    let version = SwiftProtobuf.Version
+
+    let version = SwiftProtobuf.Version.self
     let packageVersion = "\(version.major),\(version.minor),\(version.revision)"
 
     let help = (

--- a/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
@@ -15,7 +15,7 @@ import SwiftProtobuf
 class Test_BinaryDelimited: XCTestCase {
 
   func testEverything() {
-#if swift(>=3.1) || os(OSX) || os(iOS)
+#if swift(>=3.1)
     // Don't need to test encode/decode since there are plenty of tests specific to that,
     // just test the delimited behaviors.
 

--- a/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
@@ -15,7 +15,7 @@ import SwiftProtobuf
 class Test_BinaryDelimited: XCTestCase {
 
   func testEverything() {
-#if swift(>=3.1)
+#if swift(>=3.1) || os(OSX) || os(iOS)
     // Don't need to test encode/decode since there are plenty of tests specific to that,
     // just test the delimited behaviors.
 

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -367,7 +367,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"singleUint64\":01}")
         assertJSONDecodeFails("{\"singleUint64\":\"01\"}")
         // But it does accept exponential (as long as result is integral)
-        assertJSONDecodeSucceeds("{\"singleUint64\":4.294967295e9}") {$0.singleUint64 == UInt32.max}
+        assertJSONDecodeSucceeds("{\"singleUint64\":4.294967295e9}") {$0.singleUint64 == UInt64(UInt32.max)}
         assertJSONDecodeSucceeds("{\"singleUint64\":1e3}") {$0.singleUint64 == 1000}
         assertJSONDecodeSucceeds("{\"singleUint64\":1.2e3}") {$0.singleUint64 == 1200}
         assertJSONDecodeSucceeds("{\"singleUint64\":1000e-2}") {$0.singleUint64 == 10}


### PR DESCRIPTION
Several minor fixes that correct warnings and compile errors seen in various versions of Xcode.  With this, we now build and pass tests on Xcode 8.1 (Swift 3.0.1), Xcode 8.2 (Swift 3.0.2), Xcode 8.3 (Swift 3.1) and a pre-release version of Xcode 9 (Swift 4).