### PR TITLE
Perf: pre-size arrays for binary packed fields

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -318,7 +318,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -358,7 +358,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -398,7 +398,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -436,7 +436,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -479,7 +479,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -520,7 +520,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -730,7 +730,7 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
@@ -853,7 +853,7 @@ internal struct BinaryDecoder: Decoder {
             var n: Int = 0
             var extras: [Int32]?
             let p = try getFieldBodyBytes(count: &n)
-            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            let ints = Varint.countVarintsInBuffer(start: p, count: n)
             value.reserveCapacity(value.count + ints)
             var subdecoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !subdecoder.complete {

--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -318,6 +318,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
@@ -356,6 +358,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
@@ -394,6 +398,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
@@ -430,6 +436,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
@@ -471,6 +479,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
@@ -510,6 +520,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
@@ -718,6 +730,8 @@ internal struct BinaryDecoder: Decoder {
         case WireFormat.lengthDelimited:
             var n: Int = 0
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
@@ -839,6 +853,8 @@ internal struct BinaryDecoder: Decoder {
             var n: Int = 0
             var extras: [Int32]?
             let p = try getFieldBodyBytes(count: &n)
+            let ints = Varint.countVarintsInBuffer(start: p, bytes: n)
+            value.reserveCapacity(value.count + ints)
             var subdecoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !subdecoder.complete {
                 let u64 = try subdecoder.decodeVarint()

--- a/Sources/SwiftProtobuf/Varint.swift
+++ b/Sources/SwiftProtobuf/Varint.swift
@@ -89,4 +89,19 @@ internal enum Varint {
   static func encodedSize(of value: UInt64) -> Int {
     return encodedSize(of: Int64(bitPattern: value))
   }
+
+  /// Counts the number of distinct varints in a packed byte buffer.
+  static func countVarintsInBuffer(start: UnsafePointer<UInt8>, bytes: Int) -> Int {
+    // Every varint has exactly one byte with value < 128.
+    // So we just count those...
+    var ints = 0
+    var n = bytes
+    while n > 0 {
+      if start[n] < 128 {
+        ints += 1
+      }
+      n -= 1
+    }
+    return ints
+  }
 }

--- a/Sources/SwiftProtobuf/Varint.swift
+++ b/Sources/SwiftProtobuf/Varint.swift
@@ -91,16 +91,17 @@ internal enum Varint {
   }
 
   /// Counts the number of distinct varints in a packed byte buffer.
-  static func countVarintsInBuffer(start: UnsafePointer<UInt8>, bytes: Int) -> Int {
-    // Every varint has exactly one byte with value < 128.
-    // So we just count those...
+  static func countVarintsInBuffer(start: UnsafePointer<UInt8>, count: Int) -> Int {
+    // We don't need to decode all the varints to count how many there
+    // are.  Just observe that every varint has exactly one byte with
+    // value < 128. So we just count those...
+    var n = 0
     var ints = 0
-    var n = bytes
-    while n > 0 {
+    while n < count {
       if start[n] < 128 {
         ints += 1
       }
-      n -= 1
+      n += 1
     }
     return ints
   }


### PR DESCRIPTION
Decoding packed varint fields was spending a lot of time appending to the arrays.

With this change, binary decoding of `100 'repeated int32'` is now on par with the C++ implementation.
