### PR TITLE
Use _visitRepeated consistently for all repeated field types

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -134,7 +134,11 @@ internal struct JSONEncodingVisitor: Visitor {
     encoder.putBytesValue(value: value)
   }
 
-  private mutating func _visitRepeated<T>(value: [T], fieldNumber: Int, encode: (T) -> ()) throws {
+  private mutating func _visitRepeated<T>(
+    value: [T],
+    fieldNumber: Int,
+    encode: (inout JSONEncoder, T) throws -> ()
+  ) throws {
     try startField(for: fieldNumber)
     var comma = false
     encoder.startArray()
@@ -143,7 +147,7 @@ internal struct JSONEncodingVisitor: Visitor {
           encoder.comma()
       }
       comma = true
-      encode(v)
+      try encode(&encoder, v)
     }
     encoder.endArray()
   }
@@ -168,37 +172,43 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Float) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Float) in
       encoder.putFloatValue(value: v)
     }
   }
 
   mutating func visitRepeatedDoubleField(value: [Double], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Double) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Double) in
       encoder.putDoubleValue(value: v)
     }
   }
 
   mutating func visitRepeatedInt32Field(value: [Int32], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Int32) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Int32) in
       encoder.putInt32(value: v)
     }
   }
 
   mutating func visitRepeatedInt64Field(value: [Int64], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Int64) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Int64) in
       encoder.putInt64(value: v)
     }
   }
 
    mutating func visitRepeatedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: UInt32) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: UInt32) in
       encoder.putUInt32(value: v)
     }
   }
 
   mutating func visitRepeatedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: UInt64) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: UInt64) in
       encoder.putUInt64(value: v)
     }
   }
@@ -228,50 +238,43 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedBoolField(value: [Bool], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Bool) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Bool) in
       encoder.putBoolValue(value: v)
     }
   }
 
   mutating func visitRepeatedStringField(value: [String], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: String) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: String) in
       encoder.putStringValue(value: v)
     }
   }
 
   mutating func visitRepeatedBytesField(value: [Data], fieldNumber: Int) throws {
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) { (v: Data) in
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: Data) in
       encoder.putBytesValue(value: v)
     }
   }
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
-    try startField(for: fieldNumber)
-    var arraySeparator = String()
-    encoder.append(text: "[")
-    for v in value {
-      encoder.append(text: arraySeparator)
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: E) throws in
       if let n = v.name {
         encoder.appendQuoted(name: n)
       } else {
         encoder.putEnumInt(value: v.rawValue)
       }
-      arraySeparator = ","
     }
-    encoder.append(text: "]")
   }
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
-    try startField(for: fieldNumber)
-    var arraySeparator = String()
-    encoder.append(text: "[")
-    for v in value {
-      encoder.append(text: arraySeparator)
+    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
+      (encoder: inout JSONEncoder, v: M) throws in
       let json = try v.jsonUTF8Data()
       encoder.append(utf8Data: json)
-      arraySeparator = ","
     }
-    encoder.append(text: "]")
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {


### PR DESCRIPTION
This fixes the callback signature to avoid capture ambiguity and updates the repeated enum and message handlers to use the generic facility.