### PR TITLE
Support logging the directory via an env variable.

### DIFF
--- a/Sources/protoc-gen-swift/FileIo.swift
+++ b/Sources/protoc-gen-swift/FileIo.swift
@@ -76,15 +76,6 @@ class Stdin {
 }
 
 
-func writeFileData(filename: String, data: [UInt8]) throws {
-  let url = URL(fileURLWithPath: filename)
-  #if os(Linux)
-    _ = try NSData(bytes: data, length: data.count).write(to: url)
-  #else
-    _ = try Data(bytes: data).write(to: url)
-  #endif
-}
-
 func readFileData(filename: String) throws -> Data {
     let url = URL(fileURLWithPath: filename)
     return try Data(contentsOf: url)

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -140,6 +140,18 @@ struct GeneratorPlugin {
       return 1
     }
 
+    // Support for loggin the request. Useful when protoc/protoc-gen-swift are
+    // being invoked from some build system/script. protoc-gen-swift supports
+    // loading a request as a command line argument to simplify debugging/etc.
+    if let dumpPath = ProcessInfo.processInfo.environment["PROTOC_GEN_SWIFT_LOG_REQUEST"], !dumpPath.isEmpty {
+      let dumpURL = URL(fileURLWithPath: dumpPath)
+      do {
+        try requestData.write(to: dumpURL)
+      } catch let e {
+        Stderr.print("Failed to write request to '\(dumpPath)', \(e)")
+      }
+    }
+
     let request: Google_Protobuf_Compiler_CodeGeneratorRequest
     do {
       request = try Google_Protobuf_Compiler_CodeGeneratorRequest(serializedData: requestData)


### PR DESCRIPTION
To help in debugging generation issues, add an env variable that
will get the request logged so it is easier to capture a request
from a build system/script.