### PR TITLE
Accept duplicate entries rather than throwing an error.

### DIFF
--- a/Sources/PluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/PluginLibrary/ProtoFileToModuleMappings.swift
@@ -62,11 +62,15 @@ public struct ProtoFileToModuleMappings {
       }
       for path in mapping.protoFilePath {
         if let existing = builder[path] {
-          throw LoadError.duplicateProtoPathMapping(path: path,
-                                                    firstModule: existing,
-                                                    secondModule: mapping.moduleName)
+          if existing != mapping.moduleName {
+            throw LoadError.duplicateProtoPathMapping(path: path,
+                                                      firstModule: existing,
+                                                      secondModule: mapping.moduleName)
+          }
+          // Was a repeat, just allow it.
+        } else {
+          builder[path] = mapping.moduleName
         }
-        builder[path] = mapping.moduleName
       }
     }
     self.mappings = builder

--- a/Tests/PluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/PluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -51,6 +51,14 @@ class Test_ProtoFileToModuleMappings: XCTestCase {
       // Two mapping {}, different modules.
       ("mapping { module_name: \"one\", proto_file_path: \"a\" }\n" +
        "mapping { module_name: \"two\", proto_file_path: \"b\" }", 2, 2),
+
+      // Same file listed twice; odd, but ok since no conflict.
+      ("mapping { module_name: \"foo\", proto_file_path: [\"abc\", \"abc\"] }", 1, 1),
+
+      // Same module/file listing; odd, but ok since no conflict.
+      ("mapping { module_name: \"foo\", proto_file_path: [\"mno\", \"abc\"] }\n" +
+       "mapping { module_name: \"foo\", proto_file_path: [\"abc\", \"xyz\"] }", 3, 1),
+
     ]
 
     for (idx, (configText, expectMappings, expectedModules)) in tests.enumerated() {
@@ -101,16 +109,9 @@ class Test_ProtoFileToModuleMappings: XCTestCase {
 
       // Duplicates
 
-      ("mapping { module_name: \"foo\", proto_file_path: [\"abc\", \"abc\"] }",
-       .duplicateProtoPathMapping(path: "abc", firstModule: "foo", secondModule: "foo")),
-
       ("mapping { module_name: \"foo\", proto_file_path: \"abc\" }\n" +
        "mapping { module_name: \"bar\", proto_file_path: \"abc\" }",
        .duplicateProtoPathMapping(path: "abc", firstModule: "foo", secondModule: "bar")),
-
-      ("mapping { module_name: \"foo\", proto_file_path: \"abc\" }\n" +
-       "mapping { module_name: \"foo\", proto_file_path: \"abc\" }",
-       .duplicateProtoPathMapping(path: "abc", firstModule: "foo", secondModule: "foo")),
 
       ("mapping { module_name: \"foo\", proto_file_path: \"abc\" }\n" +
        "mapping { module_name: \"bar\", proto_file_path: \"xyz\" }\n" +


### PR DESCRIPTION
While they aren't needed, they also don't hurt. When hooking into
build systems/script and using a tree of protos, it can be simpler as
you move up the tree to just merge things and they thus might have
dups, so allow them whey they don't cause conflicts.