### PR TITLE
Tweak to oneofs on Descriptors.

### DIFF
--- a/Sources/PluginLibrary/Descriptor.swift
+++ b/Sources/PluginLibrary/Descriptor.swift
@@ -385,14 +385,16 @@ public final class FieldDescriptor {
   public private(set) weak var extensionScope: Descriptor?
 
   /// The index in a oneof this field is in.
-  public var oneofIndex: Int32? {
-    if proto.hasOneofIndex {
-      return proto.oneofIndex
+  public let oneofIndex: Int32?
+
+  /// The oneof this field is a member of.
+  public var oneof: OneofDescriptor? {
+    if let oneofIndex = oneofIndex {
+      assert(!isExtension)
+      return containingType!.oneofs[Int(oneofIndex)]
     }
     return nil
   }
-  /// The oneof this field is a member of.
-  public private(set) weak var oneof: OneofDescriptor?
 
   /// When this is a message field, the message's desciptor.
   public private(set) weak var messageType: Descriptor!
@@ -429,6 +431,13 @@ public final class FieldDescriptor {
     self.proto = proto
     self.index = index
     self.isExtension = isExtension
+    if proto.hasOneofIndex {
+      assert(!isExtension)
+      oneofIndex = proto.oneofIndex
+    } else {
+      oneofIndex = nil
+    }
+
   }
 
   fileprivate func bind(file: FileDescriptor, registry: Registry, containingType: Descriptor?) {
@@ -449,10 +458,6 @@ public final class FieldDescriptor {
       enumType = registry.enumDescriptor(name: proto.typeName)
     default:
       break
-    }
-
-    if let oneofIndex = oneofIndex {
-      oneof = containingType?.oneofs[Int(oneofIndex)]
     }
   }
 }

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -105,7 +105,7 @@ extension FieldDescriptor {
     if label == .repeated {  // Covers both Arrays and Maps
       return false
     }
-    if oneof != nil {
+    if oneofIndex != nil {
       // When in a oneof, no presence is provided.
       return false
     }


### PR DESCRIPTION
The oneofIndex is used as the more common test and happens as part of
bind anyways, so do it during init and cache the result. Instead do
the descriptor lookup for the oneof on demand since it isn't used
nearly as often.

This means the lookup only has to happen when generating a file and
not when building the the descriptor graph for imported files which
will never care about the oneofs in other files.