### PR TITLE
Remove the specific protoc version check.

### DIFF
--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -250,16 +250,9 @@ struct GeneratorPlugin {
       Stderr.print("WARNING: unknown version of protoc, use 3.2.x or later to ensure JSON support is correct.")
       return
     }
-    let compilerVersion = request.compilerVersion
-
-    // Expect 3.1.x or 3.3.x - Yes we have to rev this with new release, but
-    // that seems like the best thing at the moment.
-    let isExpectedVersion = (compilerVersion.major == 3) &&
-      (compilerVersion.minor >= 1) &&
-      (compilerVersion.minor <= 3)
-    if !isExpectedVersion {
-      Stderr.print("WARNING: untested version of protoc (\(compilerVersion.versionString)).")
-    }
+    // 3.2.x is what added the compiler_version, so there is no need to
+    // ensure that the version of protoc being used is newer, if the field
+    // is there, the JSON support should be good.
   }
 
   private func sendReply(response: Google_Protobuf_Compiler_CodeGeneratorResponse) -> Bool {


### PR DESCRIPTION
We haven't seen any other issues, so we'll go ahead and drop the check.