### PR TITLE
Speed up .pb.swift generation

### DIFF
--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -171,7 +171,7 @@ fileprivate func isAllUnderscore(_ s: String) -> Bool {
   if s.isEmpty {
     return false
   }
-  for c in s.characters {
+  for c in s.unicodeScalars {
     if c != "_" {return false}
   }
   return true
@@ -198,90 +198,74 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
 }
 
 fileprivate func isCharacterUppercase(_ s: String, index: Int) -> Bool {
-  let start = s.index(s.startIndex, offsetBy: index)
-  if start == s.endIndex {
+  let scalars = s.unicodeScalars
+  let start = scalars.index(scalars.startIndex, offsetBy: index)
+  if start == scalars.endIndex {
     // it ended, so just say the next character wasn't uppercase.
     return false
   }
-  let end = s.index(after: start)
-  let sub = s[start..<end]
-  return sub != sub.lowercased()
+  return scalars[start].isUppercase
 }
 
-fileprivate let digits: Set<String> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+fileprivate func makeUnicodeScalarView(
+  from unicodeScalar: UnicodeScalar
+) -> String.UnicodeScalarView {
+  var view = String.UnicodeScalarView()
+  view.append(unicodeScalar)
+  return view
+}
+
 
 fileprivate func splitIdentifier(_ s: String) -> [String] {
-  var out = [String]()
-  var current = ""
-  var last = ""
+  var out: [String.UnicodeScalarView] = []
+  var current = String.UnicodeScalarView()
+  var last: UnicodeScalar = "\0"
   var lastIsUpper = false
   var lastIsLower = false
 
-  for _c in s.characters {
-    let c = String(_c)
-    let cIsUpper = (c != c.lowercased())
-    let cIsLower = (c != c.uppercased())
-    if digits.contains(c) {
-      if digits.contains(last) {
-        current += c
+  for scalar in s.unicodeScalars {
+    let isUpper = scalar.isUppercase
+    let isLower = scalar.isLowercase
+
+    if scalar.isDigit {
+      if last.isDigit {
+        current.append(scalar)
       } else {
         out.append(current)
-        current = c
+        current = makeUnicodeScalarView(from: scalar)
       }
-    } else if cIsUpper {
+    } else if isUpper {
       if lastIsUpper {
-        current += c.lowercased()
+        current.append(scalar.lowercased())
       } else {
         out.append(current)
-        current = c.lowercased()
+        current = makeUnicodeScalarView(from: scalar.lowercased())
       }
-    } else if cIsLower {
+    } else if isLower {
       if lastIsLower || lastIsUpper {
-        current += c
+        current.append(scalar)
       } else {
         out.append(current)
-        current = c
+        current = makeUnicodeScalarView(from: scalar)
       }
-    } else {
-      if last == "_" {
-        out.append(current)
-        current = last
-      }
-      if c != "_" {
-        out.append(current)
-        current = c
-      }
+    } else if last == "_" {
+      out.append(current)
+      current = makeUnicodeScalarView(from: last)
     }
-    last = c
-    lastIsUpper = cIsUpper
-    lastIsLower = cIsLower
+
+    last = scalar
+    lastIsUpper = isUpper
+    lastIsLower = isLower
   }
+
   out.append(current)
   if last == "_" {
-    out.append(last)
+    out.append(makeUnicodeScalarView(from: last))
   }
-  // An empty string will always get inserted first, so drop it.
-  return [String](out.dropFirst(1))
-}
 
-/// Only allow ASCII alphanumerics and underscore.
-fileprivate func basicSanitize(_ s: String) -> String {
-  var out = ""
-  for c in s.characters {
-    switch c {
-    case "A"..."Z": // A-Z
-      out.append(c)
-    case "a"..."z": // a-z
-      out.append(c)
-    case "0"..."9": // 0-9
-      out.append(c)
-    case "_":
-      out.append(c)
-    default:
-      break
-    }
-  }
-  return out
+  // An empty string will always get inserted first, so drop it.
+  let slice = out.dropFirst(1)
+  return slice.map(String.init)
 }
 
 fileprivate let upperInitials: Set<String> = ["url", "http", "https", "id"]
@@ -443,9 +427,12 @@ public enum NamingUtils {
 
   /// Use toUpperCamelCase() to get leading "HTTP", "URL", etc. correct.
   static func uppercaseFirstCharacter(_ s: String) -> String {
-    var out = s.characters
-    if let first = out.popFirst() {
-      return String(first).uppercased() + String(out)
+    let out = s.unicodeScalars
+    if let first = out.first {
+      var result = makeUnicodeScalarView(from: first.uppercased())
+      result.append(
+        contentsOf: out[out.index(after: out.startIndex)..<out.endIndex])
+      return String(result)
     } else {
       return s
     }
@@ -458,7 +445,7 @@ public enum NamingUtils {
       if upperInitials.contains(word) {
         out.append(word.uppercased())
       } else {
-        out.append(uppercaseFirstCharacter(basicSanitize(word)))
+        out.append(uppercaseFirstCharacter(word))
       }
     }
     return out
@@ -471,11 +458,11 @@ public enum NamingUtils {
     var forceLower = true
     for word in t {
       if forceLower {
-        out.append(basicSanitize(word).lowercased())
+        out.append(word.lowercased())
       } else if upperInitials.contains(word) {
         out.append(word.uppercased())
       } else {
-        out.append(uppercaseFirstCharacter(basicSanitize(word)))
+        out.append(uppercaseFirstCharacter(word))
       }
       forceLower = false
     }

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -477,4 +477,23 @@ public enum NamingUtils {
     return s.replacingOccurrences(of: ".", with: "_")
   }
 
+  /// This must be exactly the same as the corresponding code in the
+  /// SwiftProtobuf library.  Changing it will break compatibility of
+  /// the generated code with old library version.
+  public static func toJsonFieldName(_ s: String) -> String {
+    var result = String.UnicodeScalarView()
+    var capitalizeNext = false
+
+    for c in s.unicodeScalars {
+      if c == "_" {
+        capitalizeNext = true
+      } else if capitalizeNext {
+        result.append(c.uppercased())
+        capitalizeNext = false
+      } else {
+        result.append(c)
+      }
+    }
+    return String(result)
+  }
 }

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -219,6 +219,9 @@ fileprivate func makeUnicodeScalarView(
 fileprivate func splitIdentifier(_ s: String) -> [String] {
   var out: [String.UnicodeScalarView] = []
   var current = String.UnicodeScalarView()
+  // The exact value used to seed this doesn't matter (as long as it's not an
+  // underscore); we use it to avoid an extra optional unwrap in every loop
+  // iteration.
   var last: UnicodeScalar = "\0"
   var lastIsUpper = false
   var lastIsLower = false

--- a/Sources/PluginLibrary/UnicodeScalar+Extensions.swift
+++ b/Sources/PluginLibrary/UnicodeScalar+Extensions.swift
@@ -1,0 +1,67 @@
+// Sources/PluginLibrary/UnicodeScalar+Extensions.swift - Utilities for working with UnicodeScalars
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Internal utility functions and properties for working with UnicodeScalars.
+///
+/// NOTE: This is a purely internal extension that provides the limited
+/// functionality needed to manipulate ASCII characters that are represented as
+/// UnicodeScalars. It does not support the full range of Unicode code points.
+///
+// -----------------------------------------------------------------------------
+
+extension UnicodeScalar {
+
+  /// True if the receiver is a numeric digit.
+  ///
+  /// - Precondition: The receiver is 7-bit ASCII.
+  var isDigit: Bool {
+    precondition(value < 0x80, "Scalar must be 7-bit ASCII")
+    if case "0"..."9" = self { return true }
+    return false
+  }
+
+  /// True if the receiver is a lowercase character.
+  ///
+  /// - Precondition: The receiver is 7-bit ASCII.
+  var isLowercase: Bool {
+    precondition(value < 0x80, "Scalar must be 7-bit ASCII")
+    if case "a"..."z" = self { return true }
+    return false
+  }
+
+  /// True if the receiver is an uppercase character.
+  ///
+  /// - Precondition: The receiver is 7-bit ASCII.
+  var isUppercase: Bool {
+    precondition(value < 0x80, "Scalar must be 7-bit ASCII")
+    if case "A"..."Z" = self { return true }
+    return false
+  }
+
+  /// Returns the lowercased version of the receiver, or the receiver itself if
+  /// it is not a cased character.
+  ///
+  /// - Precondition: The receiver is 7-bit ASCII.
+  /// - Returns: The lowercased version of the receiver, or `self`.
+  func lowercased() -> UnicodeScalar {
+    if isUppercase { return UnicodeScalar(value + 0x20)! }
+    return self
+  }
+
+  /// Returns the uppercased version of the receiver, or the receiver itself if
+  /// it is not a cased character.
+  ///
+  /// - Precondition: The receiver is 7-bit ASCII.
+  /// - Returns: The uppercased version of the receiver, or `self`.
+  func uppercased() -> UnicodeScalar {
+    if isLowercase { return UnicodeScalar(value - 0x20)! }
+    return self
+  }
+}

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -76,7 +76,7 @@ class FieldGeneratorBase {
       /// The proto and JSON names are identical:
       return ".same(proto: \"\(protoName)\")"
     } else {
-      let libraryGeneratedJsonName = toJsonFieldName(protoName)
+      let libraryGeneratedJsonName = NamingUtils.toJsonFieldName(protoName)
       if jsonName == libraryGeneratedJsonName {
         /// The library will generate the same thing protoc gave, so
         /// we can let the library recompute this:
@@ -93,25 +93,4 @@ class FieldGeneratorBase {
     number = Int(descriptor.number)
     fieldDescriptor = descriptor
   }
-}
-
-/// This must be exactly the same as the corresponding code in the
-/// SwiftProtobuf library.  Changing it will break compatibility of
-/// the generated code with old library version.
-///
-private func toJsonFieldName(_ s: String) -> String {
-  var result = ""
-  var capitalizeNext = false
-
-  for c in s.characters {
-    if c == "_" {
-      capitalizeNext = true
-    } else if capitalizeNext {
-      result.append(String(c).uppercased())
-      capitalizeNext = false
-    } else {
-      result.append(String(c))
-    }
-  }
-  return result;
 }


### PR DESCRIPTION
These changes make .pb.swift generation by about 200–250% (using Instruments on some of our internal protos).

Some speed-ups came from rewriting name-transforming functions to use `UnicodeScalar` instead of `Character` and avoiding excess string creation. Some more performance got squeezed out of `CodePrinter` by dropping the index-scanning-and-slicing code and simply iterating over and appending the scalars passed into `print`. Appending single scalars one-by-one turns out to be faster after all.