### PR TITLE
Record the failing test because of WebSafeBase64 decode.

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -1,1 +1,2 @@
-# Nothing currently failing!
+Recommended.Proto3.JsonInput.BytesFieldBase64Url.JsonOutput
+Recommended.Proto3.JsonInput.BytesFieldBase64Url.ProtobufOutput


### PR DESCRIPTION
Needed until #653 is done.