### PR TITLE
Issue 653: Accept both RFC4648 Section 4 and Section 5 Base 64 encodings

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -1,2 +1,1 @@
-Recommended.Proto3.JsonInput.BytesFieldBase64Url.JsonOutput
-Recommended.Proto3.JsonInput.BytesFieldBase64Url.ProtobufOutput
+# No known failures

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -682,26 +682,48 @@ class Test_JSON: XCTestCase, PBTestHelpers {
             o.optionalBytes = Data(bytes: [65])
         }
         assertJSONDecodeFails("{\"optionalBytes\":\"QQ=\"}")
-        assertJSONDecodeFails("{\"optionalBytes\":\"QQ\"}")
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"QQ\"}") {
+            $0.optionalBytes == Data(bytes: [65])
+        }
         assertJSONEncode("{\"optionalBytes\":\"QUI=\"}") {(o: inout MessageTestType) in
             o.optionalBytes = Data(bytes: [65, 66])
         }
-        assertJSONDecodeFails("{\"optionalBytes\":\"QUI\"}")
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"QUI\"}") {
+            $0.optionalBytes == Data(bytes: [65, 66])
+        }
         assertJSONEncode("{\"optionalBytes\":\"QUJD\"}") {(o: inout MessageTestType) in
             o.optionalBytes = Data(bytes: [65, 66, 67])
         }
         assertJSONEncode("{\"optionalBytes\":\"QUJDRA==\"}") {(o: inout MessageTestType) in
             o.optionalBytes = Data(bytes: [65, 66, 67, 68])
         }
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDRA===\"}")
         assertJSONDecodeFails("{\"optionalBytes\":\"QUJDRA=\"}")
-        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDRA\"}")
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"QUJDRA\"}") {
+            $0.optionalBytes == Data(bytes: [65, 66, 67, 68])
+        }
         assertJSONEncode("{\"optionalBytes\":\"QUJDREU=\"}") {(o: inout MessageTestType) in
             o.optionalBytes = Data(bytes: [65, 66, 67, 68, 69])
         }
-        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREU\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREU==\"}")
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"QUJDREU\"}") {
+            $0.optionalBytes == Data(bytes: [65, 66, 67, 68, 69])
+        }
         assertJSONEncode("{\"optionalBytes\":\"QUJDREVG\"}") {(o: inout MessageTestType) in
             o.optionalBytes = Data(bytes: [65, 66, 67, 68, 69, 70])
         }
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG=\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG==\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG===\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG====\"}")
+        // Accept both RFC4648 Section 4 and Section 5 base64 variants, but reject mixed coding:
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"-_-_\"}") {
+            $0.optionalBytes == Data(bytes: [251, 255, 191])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"+/+/\"}") {
+            $0.optionalBytes == Data(bytes: [251, 255, 191])
+        }
+        assertJSONDecodeFails("{\"optionalBytes\":\"-_+/\"}")
     }
 
     func testOptionalBytes2() {


### PR DESCRIPTION
Google's conformance test was recently updated to recommend that "-_"
be accepted as a valid Base-64 JSON encoding for a `bytes` field.

From this, we can infer:
* We should accept RFC 4648 Section 5 "URL and Filename Safe Alphabet"
  as well as the RFC 4648 Section 4 Base 64 encoding
* We should accept Base 64 strings that have no padding

Google's C++ implementation tries to decode each Base 64
variant separately, so does not allow mixed encodings; I also
reject mixed encodings here.

The implementation here accepts input with no padding characters
or input which is exactly padded to a multiple of four characters
but rejects any other amount of padding.  I believe this matches
the behavior of Google's C++ implementation.

The implementation here ignores space characters within the string.