### PR TITLE
Change `extendingOrTruncating` to `truncatingIfNeeded`

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -238,7 +238,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + Int(extendingOrTruncating: itemCount))
+                value.reserveCapacity(value.count + Int(truncatingIfNeeded: itemCount))
                 for _ in 1...itemCount {
                     value.append(try decodeFloat())
                 }
@@ -279,7 +279,7 @@ internal struct BinaryDecoder: Decoder {
                 if bodyBytes % itemSize != 0 || itemCount > UInt64(Int.max) {
                     throw BinaryDecodingError.truncated
                 }
-                value.reserveCapacity(value.count + Int(extendingOrTruncating: itemCount))
+                value.reserveCapacity(value.count + Int(truncatingIfNeeded: itemCount))
                 for _ in 1...itemCount {
                     let i = try decodeDouble()
                     value.append(i)
@@ -296,7 +296,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = Int32(extendingOrTruncating: varint)
+        value = Int32(truncatingIfNeeded: varint)
         consumed = true
     }
 
@@ -305,7 +305,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = Int32(extendingOrTruncating: varint)
+        value = Int32(truncatingIfNeeded: varint)
         consumed = true
     }
 
@@ -313,7 +313,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(Int32(extendingOrTruncating: varint))
+            value.append(Int32(truncatingIfNeeded: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -323,7 +323,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                value.append(Int32(extendingOrTruncating: varint))
+                value.append(Int32(truncatingIfNeeded: varint))
             }
             consumed = true
         default:
@@ -376,7 +376,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = UInt32(extendingOrTruncating: varint)
+        value = UInt32(truncatingIfNeeded: varint)
         consumed = true
     }
 
@@ -385,7 +385,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        value = UInt32(extendingOrTruncating: varint)
+        value = UInt32(truncatingIfNeeded: varint)
         consumed = true
     }
 
@@ -393,7 +393,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            value.append(UInt32(extendingOrTruncating: varint))
+            value.append(UInt32(truncatingIfNeeded: varint))
             consumed = true
         case WireFormat.lengthDelimited:
             var n: Int = 0
@@ -403,7 +403,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let t = try decoder.decodeVarint()
-                value.append(UInt32(extendingOrTruncating: t))
+                value.append(UInt32(truncatingIfNeeded: t))
             }
             consumed = true
         default:
@@ -454,7 +454,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = UInt32(extendingOrTruncating: varint)
+        let t = UInt32(truncatingIfNeeded: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -464,7 +464,7 @@ internal struct BinaryDecoder: Decoder {
             return
         }
         let varint = try decodeVarint()
-        let t = UInt32(extendingOrTruncating: varint)
+        let t = UInt32(truncatingIfNeeded: varint)
         value = ZigZag.decoded(t)
         consumed = true
     }
@@ -473,7 +473,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            let t = UInt32(extendingOrTruncating: varint)
+            let t = UInt32(truncatingIfNeeded: varint)
             value.append(ZigZag.decoded(t))
             consumed = true
         case WireFormat.lengthDelimited:
@@ -484,7 +484,7 @@ internal struct BinaryDecoder: Decoder {
             var decoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !decoder.complete {
                 let varint = try decoder.decodeVarint()
-                let t = UInt32(extendingOrTruncating: varint)
+                let t = UInt32(truncatingIfNeeded: varint)
                 value.append(ZigZag.decoded(t))
             }
             consumed = true
@@ -824,7 +824,7 @@ internal struct BinaryDecoder: Decoder {
              return
          }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
+        if let v = E(rawValue: Int(Int32(truncatingIfNeeded: varint))) {
             value = v
             consumed = true
         }
@@ -835,7 +835,7 @@ internal struct BinaryDecoder: Decoder {
              return
         }
         let varint = try decodeVarint()
-        if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
+        if let v = E(rawValue: Int(Int32(truncatingIfNeeded: varint))) {
             value = v
             consumed = true
         }
@@ -845,7 +845,7 @@ internal struct BinaryDecoder: Decoder {
         switch fieldWireFormat {
         case WireFormat.varint:
             let varint = try decodeVarint()
-            if let v = E(rawValue: Int(Int32(extendingOrTruncating: varint))) {
+            if let v = E(rawValue: Int(Int32(truncatingIfNeeded: varint))) {
                 value.append(v)
                 consumed = true
             }
@@ -858,7 +858,7 @@ internal struct BinaryDecoder: Decoder {
             var subdecoder = BinaryDecoder(forReadingFrom: p, count: n, parent: self)
             while !subdecoder.complete {
                 let u64 = try subdecoder.decodeVarint()
-                let i32 = Int32(extendingOrTruncating: u64)
+                let i32 = Int32(truncatingIfNeeded: u64)
                 if let v = E(rawValue: Int(i32)) {
                     value.append(v)
                 } else if !options.discardUnknownFields {
@@ -1417,7 +1417,7 @@ internal struct BinaryDecoder: Decoder {
         }
         let t = try decodeVarint()
         if t < UInt64(UInt32.max) {
-            guard let tag = FieldTag(rawValue: UInt32(extendingOrTruncating: t)) else {
+            guard let tag = FieldTag(rawValue: UInt32(truncatingIfNeeded: t)) else {
                 throw BinaryDecodingError.malformedProtobuf
             }
             fieldWireFormat = tag.wireFormat

--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -211,7 +211,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += tagSize
-    let dataSize = Varint.encodedSize(of: Int32(extendingOrTruncating: value.rawValue))
+    let dataSize = Varint.encodedSize(of: Int32(truncatingIfNeeded: value.rawValue))
     serializedSize += dataSize
   }
 
@@ -221,7 +221,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
                            wireFormat: .varint).encodedSize
     serializedSize += value.count * tagSize
     for v in value {
-      let dataSize = Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
+      let dataSize = Varint.encodedSize(of: Int32(truncatingIfNeeded: v.rawValue))
       serializedSize += dataSize
     }
   }
@@ -237,7 +237,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     serializedSize += tagSize
     var dataSize = 0
     for v in value {
-      dataSize += Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
+      dataSize += Varint.encodedSize(of: Int32(truncatingIfNeeded: v.rawValue))
     }
     serializedSize += Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -254,7 +254,7 @@ internal struct BinaryEncodingVisitor: Visitor {
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
-      packedSize += Varint.encodedSize(of: Int32(extendingOrTruncating: v.rawValue))
+      packedSize += Varint.encodedSize(of: Int32(truncatingIfNeeded: v.rawValue))
     }
     encoder.putVarInt(value: packedSize)
     for v in value {

--- a/Sources/SwiftProtobuf/FieldTag.swift
+++ b/Sources/SwiftProtobuf/FieldTag.swift
@@ -63,7 +63,7 @@ internal struct FieldTag: RawRepresentable {
 
   /// Creates a new tag by composing the given field number and wire format.
   init(fieldNumber: Int, wireFormat: WireFormat) {
-    self.rawValue = UInt32(extendingOrTruncating: fieldNumber) << 3 |
+    self.rawValue = UInt32(truncatingIfNeeded: fieldNumber) << 3 |
       UInt32(wireFormat.rawValue)
   }
 }

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -127,7 +127,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = Int32(extendingOrTruncating: n)
+    value = Int32(truncatingIfNeeded: n)
   }
 
   mutating func decodeSingularInt32Field(value: inout Int32?) throws {
@@ -139,7 +139,7 @@ internal struct JSONDecoder: Decoder {
     if n > Int64(Int32.max) || n < Int64(Int32.min) {
       throw JSONDecodingError.numberRange
     }
-    value = Int32(extendingOrTruncating: n)
+    value = Int32(truncatingIfNeeded: n)
   }
 
   mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
@@ -155,7 +155,7 @@ internal struct JSONDecoder: Decoder {
       if n > Int64(Int32.max) || n < Int64(Int32.min) {
         throw JSONDecodingError.numberRange
       }
-      value.append(Int32(extendingOrTruncating: n))
+      value.append(Int32(truncatingIfNeeded: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }
@@ -206,7 +206,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = UInt32(extendingOrTruncating: n)
+    value = UInt32(truncatingIfNeeded: n)
   }
 
   mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
@@ -218,7 +218,7 @@ internal struct JSONDecoder: Decoder {
     if n > UInt64(UInt32.max) {
       throw JSONDecodingError.numberRange
     }
-    value = UInt32(extendingOrTruncating: n)
+    value = UInt32(truncatingIfNeeded: n)
   }
 
   mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
@@ -234,7 +234,7 @@ internal struct JSONDecoder: Decoder {
       if n > UInt64(UInt32.max) {
         throw JSONDecodingError.numberRange
       }
-      value.append(UInt32(extendingOrTruncating: n))
+      value.append(UInt32(truncatingIfNeeded: n))
       if scanner.skipOptionalArrayEnd() {
         return
       }

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -311,19 +311,19 @@ internal struct JSONEncoder {
                 data.append(hexDigits[Int(c.value / 16)])
                 data.append(hexDigits[Int(c.value & 15)])
             case 23...126:
-                data.append(UInt8(extendingOrTruncating: c.value))
+                data.append(UInt8(truncatingIfNeeded: c.value))
             case 0x80...0x7ff:
-                data.append(0xc0 + UInt8(extendingOrTruncating: c.value >> 6))
-                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
+                data.append(0xc0 + UInt8(truncatingIfNeeded: c.value >> 6))
+                data.append(0x80 + UInt8(truncatingIfNeeded: c.value & 0x3f))
             case 0x800...0xffff:
-                data.append(0xe0 + UInt8(extendingOrTruncating: c.value >> 12))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
+                data.append(0xe0 + UInt8(truncatingIfNeeded: c.value >> 12))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: c.value & 0x3f))
             default:
-                data.append(0xf0 + UInt8(extendingOrTruncating: c.value >> 18))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 12) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
+                data.append(0xf0 + UInt8(truncatingIfNeeded: c.value >> 18))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 12) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -178,9 +178,9 @@ private func parseBytes(
                 n |= k
                 chars += 1
                 if chars == 4 {
-                    p[0] = UInt8(extendingOrTruncating: n >> 16)
-                    p[1] = UInt8(extendingOrTruncating: n >> 8)
-                    p[2] = UInt8(extendingOrTruncating: n)
+                    p[0] = UInt8(truncatingIfNeeded: n >> 16)
+                    p[1] = UInt8(truncatingIfNeeded: n >> 8)
+                    p[2] = UInt8(truncatingIfNeeded: n)
                     p += 3
                     chars = 0
                     n = 0
@@ -215,13 +215,13 @@ private func parseBytes(
         }
         switch chars {
         case 3:
-            p[0] = UInt8(extendingOrTruncating: n >> 10)
-            p[1] = UInt8(extendingOrTruncating: n >> 2)
+            p[0] = UInt8(truncatingIfNeeded: n >> 10)
+            p[1] = UInt8(truncatingIfNeeded: n >> 2)
             if padding == 1 || padding == 0 {
                 return
             }
         case 2:
-            p[0] = UInt8(extendingOrTruncating: n >> 4)
+            p[0] = UInt8(truncatingIfNeeded: n >> 4)
             if padding == 2 || padding == 0 {
                 return
             }

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -43,46 +43,46 @@ internal func div<T : SignedInteger>(_ a: T, _ b: T) -> T {
 //
 // Swift 3 called this initializer "truncatingBitPattern";
 // Swift 4 (prerelease) changed this initializer to
-// "extendingOrTruncating".
+// "truncatingIfNeeded".
 //
 extension UInt8 {
-     internal init(extendingOrTruncating value: UInt32) {
+     internal init(truncatingIfNeeded value: UInt32) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: Int) {
+     internal init(truncatingIfNeeded value: Int) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: UInt64) {
+     internal init(truncatingIfNeeded value: UInt64) {
          self.init(truncatingBitPattern: value)
      }
 }
 
 extension UInt32 {
-     internal init(extendingOrTruncating value: UInt64) {
+     internal init(truncatingIfNeeded value: UInt64) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: Int) {
+     internal init(truncatingIfNeeded value: Int) {
          self.init(truncatingBitPattern: value)
      }
 }
 
 extension Int32 {
-     internal init(extendingOrTruncating value: UInt64) {
+     internal init(truncatingIfNeeded value: UInt64) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: Int64) {
+     internal init(truncatingIfNeeded value: Int64) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: Int) {
+     internal init(truncatingIfNeeded value: Int) {
          self.init(truncatingBitPattern: value)
      }
 }
 
 extension Int {
-     internal init(extendingOrTruncating value: Int64) {
+     internal init(truncatingIfNeeded value: Int64) {
          self.init(truncatingBitPattern: value)
      }
-     internal init(extendingOrTruncating value: UInt64) {
+     internal init(truncatingIfNeeded value: UInt64) {
          self.init(truncatingBitPattern: value)
      }
 }

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -42,8 +42,7 @@ internal func div<T : SignedInteger>(_ a: T, _ b: T) -> T {
 #if !swift(>=4.0)
 //
 // Swift 3 called this initializer "truncatingBitPattern";
-// Swift 4 (prerelease) changed this initializer to
-// "truncatingIfNeeded".
+// Swift 4 changed this initializer to "truncatingIfNeeded".
 //
 extension UInt8 {
      internal init(truncatingIfNeeded value: UInt32) {

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -149,7 +149,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = Int32(extendingOrTruncating: n)
+        value = Int32(truncatingIfNeeded: n)
     }
     mutating func decodeSingularInt32Field(value: inout Int32?) throws {
         try scanner.skipRequiredColon()
@@ -157,7 +157,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > Int64(Int32.max) || n < Int64(Int32.min) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = Int32(extendingOrTruncating: n)
+        value = Int32(truncatingIfNeeded: n)
     }
     mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
         try scanner.skipRequiredColon()
@@ -176,14 +176,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > Int64(Int32.max) || n < Int64(Int32.min) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(Int32(extendingOrTruncating: n))
+                value.append(Int32(truncatingIfNeeded: n))
             }
         } else {
             let n = try scanner.nextSInt()
             if n > Int64(Int32.max) || n < Int64(Int32.min) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(Int32(extendingOrTruncating: n))
+            value.append(Int32(truncatingIfNeeded: n))
         }
     }
     mutating func decodeSingularInt64Field(value: inout Int64) throws {
@@ -221,7 +221,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = UInt32(extendingOrTruncating: n)
+        value = UInt32(truncatingIfNeeded: n)
     }
     mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
         try scanner.skipRequiredColon()
@@ -229,7 +229,7 @@ internal struct TextFormatDecoder: Decoder {
         if n > UInt64(UInt32.max) {
             throw TextFormatDecodingError.malformedNumber
         }
-        value = UInt32(extendingOrTruncating: n)
+        value = UInt32(truncatingIfNeeded: n)
     }
     mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
         try scanner.skipRequiredColon()
@@ -248,14 +248,14 @@ internal struct TextFormatDecoder: Decoder {
                 if n > UInt64(UInt32.max) {
                     throw TextFormatDecodingError.malformedNumber
                 }
-                value.append(UInt32(extendingOrTruncating: n))
+                value.append(UInt32(truncatingIfNeeded: n))
             }
         } else {
             let n = try scanner.nextUInt()
             if n > UInt64(UInt32.max) {
                 throw TextFormatDecodingError.malformedNumber
             }
-            value.append(UInt32(extendingOrTruncating: n))
+            value.append(UInt32(truncatingIfNeeded: n))
         }
     }
     mutating func decodeSingularUInt64Field(value: inout UInt64) throws {
@@ -439,7 +439,7 @@ internal struct TextFormatDecoder: Decoder {
         }
         let number = try scanner.nextSInt()
         if number >= Int64(Int32.min) && number <= Int64(Int32.max) {
-            let n = Int32(extendingOrTruncating: number)
+            let n = Int32(truncatingIfNeeded: number)
             if let e = E(rawValue: Int(n)) {
                 return e
             } else {

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -203,7 +203,7 @@ internal struct TextFormatEncoder {
             append(staticText: "0x")
         } else {
             appendUIntHex(value: value >> 4, digits: digits - 1)
-            let d = UInt8(extendingOrTruncating: value % 16)
+            let d = UInt8(truncatingIfNeeded: value % 16)
             data.append(d < 10 ? asciiZero + d : asciiUpperA + d - 10)
         }
     }
@@ -243,19 +243,19 @@ internal struct TextFormatEncoder {
                 data.append(asciiZero + UInt8(c.value / 8 % 8))
                 data.append(asciiZero + UInt8(c.value % 8))
             case 0...127:  // ASCII
-                data.append(UInt8(extendingOrTruncating: c.value))
+                data.append(UInt8(truncatingIfNeeded: c.value))
             case 0x80...0x7ff:
                 data.append(0xc0 + UInt8(c.value / 64))
                 data.append(0x80 + UInt8(c.value % 64))
             case 0x800...0xffff:
-                data.append(0xe0 + UInt8(extendingOrTruncating: c.value >> 12))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
+                data.append(0xe0 + UInt8(truncatingIfNeeded: c.value >> 12))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: c.value & 0x3f))
             default:
-                data.append(0xf0 + UInt8(extendingOrTruncating: c.value >> 18))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 12) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: (c.value >> 6) & 0x3f))
-                data.append(0x80 + UInt8(extendingOrTruncating: c.value & 0x3f))
+                data.append(0xf0 + UInt8(truncatingIfNeeded: c.value >> 18))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 12) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: (c.value >> 6) & 0x3f))
+                data.append(0x80 + UInt8(truncatingIfNeeded: c.value & 0x3f))
             }
         }
         data.append(asciiDoubleQuote)


### PR DESCRIPTION
Swift 4 prerelease (until Xcode 9 beta 4 at least) has been using the
former name for the truncating initializer and just recently switched
to the latter term.

Unlike PR#662, this also updates MathUtils.swift so that we
preserve compatibility with Swift 3.  It also omits any changes
to the xcodeproj files.

Tested using command-line tools with Xcode 8.1, 8.2., 8.3, and 9.0 GM Seed (9A235).