### PR TITLE
Obey common env vars to locate 'swift' and 'swiftc' commands

### DIFF
--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -32,6 +32,14 @@ set -eu
 
 cd "$(dirname $0)"
 
+# The 'swift' command is in the same directory as 'swiftc',
+# 'swiftc' is sometimes found via the common SWIFT_EXEC var:
+if [ -n "${SWIFT_EXEC:-}" ]; then
+    SWIFT=`dirname ${SWIFT_EXEC}`/swift
+else
+    SWIFT="swift"
+fi
+
 # Directory containing this script
 readonly script_dir="."
 
@@ -175,7 +183,7 @@ function build_swift_packages() {
     echo "Building runtime and plug-in with Swift Package Manager..."
 
     cd "$workdir" >/dev/null
-    swift build -c release >/dev/null
+    ${SWIFT} build -c release >/dev/null
     cp .build/release/protoc-gen-swift \
         ".build/release/protoc-gen-swift${plugin_suffix}"
   )

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -183,7 +183,7 @@ function build_swift_packages() {
     echo "Building runtime and plug-in with Swift Package Manager..."
 
     cd "$workdir" >/dev/null
-    ${SWIFT} build -c release >/dev/null
+    "${SWIFT}" build -c release >/dev/null
     cp .build/release/protoc-gen-swift \
         ".build/release/protoc-gen-swift${plugin_suffix}"
   )

--- a/Performance/runners/swift.sh
+++ b/Performance/runners/swift.sh
@@ -16,6 +16,14 @@
 #
 # -----------------------------------------------------------------------------
 
+# Use xcrun if it's present (macOS) or omit it if it's not (Linux)
+XCRUN=`which xcrun`
+if [ -n "${XCRUN:-}" ]; then
+    XCRUN="${XCRUN} -sdk macosx"
+fi
+# How to run 'swiftc': Use SWIFT_EXEC if it's set or just plain "swiftc"
+SWIFTC=${SWIFT_EXEC:-swiftc}
+
 function run_swift_harness() {
   # Wrapped in a subshell to prevent state from leaking out (important since
   # this gets run multiple times during a comparison).
@@ -39,13 +47,13 @@ function run_swift_harness() {
     # TODO: Make the dylib a product again in the package manifest and just use
     # that.
     echo "Building SwiftProtobuf dynamic library..."
-    ${SWIFT_EXEC:-swiftc} -emit-library -emit-module -O -wmo \
+    ${XCRUN} ${SWIFTC} -emit-library -emit-module -O -wmo \
         -o "$perf_dir/_generated/libSwiftProtobuf.dylib" \
         ${OTHER_SWIFT_FLAGS:-} \
         "$perf_dir/../Sources/SwiftProtobuf/"*.swift
 
     echo "Building Swift test harness..."
-    time ( ${SWIFT_EXEC:-swiftc} -O \
+    time ( ${XCRUN} ${SWIFTC} -O \
         -o "$harness" \
         -I "$perf_dir/_generated" \
         -L "$perf_dir/_generated" \

--- a/Performance/runners/swift.sh
+++ b/Performance/runners/swift.sh
@@ -17,12 +17,15 @@
 # -----------------------------------------------------------------------------
 
 # Use xcrun if it's present (macOS) or omit it if it's not (Linux)
+# Note: In practice, xcrun will always be in /usr/bin/xcrun,
+# so we don't bother trying to handle paths with spaces here.
 XCRUN=`which xcrun`
 if [ -n "${XCRUN:-}" ]; then
     XCRUN="${XCRUN} -sdk macosx"
 fi
 # How to run 'swiftc': Use SWIFT_EXEC if it's set or just plain "swiftc"
-SWIFTC=${SWIFT_EXEC:-swiftc}
+# Swift path could contain spaces, so we use quotes here.
+SWIFTC="${SWIFT_EXEC:-swiftc}"
 
 function run_swift_harness() {
   # Wrapped in a subshell to prevent state from leaking out (important since
@@ -47,13 +50,13 @@ function run_swift_harness() {
     # TODO: Make the dylib a product again in the package manifest and just use
     # that.
     echo "Building SwiftProtobuf dynamic library..."
-    ${XCRUN} ${SWIFTC} -emit-library -emit-module -O -wmo \
+    ${XCRUN} "${SWIFTC}" -emit-library -emit-module -O -wmo \
         -o "$perf_dir/_generated/libSwiftProtobuf.dylib" \
         ${OTHER_SWIFT_FLAGS:-} \
         "$perf_dir/../Sources/SwiftProtobuf/"*.swift
 
     echo "Building Swift test harness..."
-    time ( ${XCRUN} ${SWIFTC} -O \
+    time ( ${XCRUN} "${SWIFTC}" -O \
         -o "$harness" \
         -I "$perf_dir/_generated" \
         -L "$perf_dir/_generated" \

--- a/Performance/runners/swift.sh
+++ b/Performance/runners/swift.sh
@@ -39,16 +39,18 @@ function run_swift_harness() {
     # TODO: Make the dylib a product again in the package manifest and just use
     # that.
     echo "Building SwiftProtobuf dynamic library..."
-    xcrun -sdk macosx swiftc -emit-library -emit-module -O -wmo \
+    ${SWIFT_EXEC:-swiftc} -emit-library -emit-module -O -wmo \
         -o "$perf_dir/_generated/libSwiftProtobuf.dylib" \
+        ${OTHER_SWIFT_FLAGS:-} \
         "$perf_dir/../Sources/SwiftProtobuf/"*.swift
 
     echo "Building Swift test harness..."
-    time ( xcrun -sdk macosx swiftc -O \
+    time ( ${SWIFT_EXEC:-swiftc} -O \
         -o "$harness" \
         -I "$perf_dir/_generated" \
         -L "$perf_dir/_generated" \
         -lSwiftProtobuf \
+        ${OTHER_SWIFT_FLAGS:-} \
         "$gen_harness_path" \
         "$perf_dir/Harness.swift" \
         "$perf_dir/_generated/message.pb.swift" \


### PR DESCRIPTION
The Swift compiler folks have established some conventions for working with multiple versions of Swift on the same system.