### PR TITLE
Repeated field decode performance for Text & JSON

### DIFF
--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -74,6 +74,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextFloat()
       value.append(n)
@@ -108,6 +110,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextDouble()
       value.append(n)
@@ -150,6 +154,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextSInt()
       if n > Int64(Int32.max) || n < Int64(Int32.min) {
@@ -187,6 +193,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextSInt()
       value.append(n)
@@ -229,6 +237,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextUInt()
       if n > UInt64(UInt32.max) {
@@ -266,6 +276,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextUInt()
       value.append(n)
@@ -356,6 +368,9 @@ internal struct JSONDecoder: Decoder {
     if isMapKey {
       value = try scanner.nextQuotedBool()
     } else {
+      // Unlike other types, booleans are *only* quoted
+      // as map keys.  Reject quoted booleans when we're
+      // not looking for a map key.
       value = try scanner.nextBool()
     }
   }
@@ -380,6 +395,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsQuickly()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextBool()
       value.append(n)
@@ -414,6 +431,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsCarefully()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextQuotedString()
       value.append(n)
@@ -448,6 +467,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsCarefully()
+    value.reserveCapacity(count)
     while true {
       let n = try scanner.nextBytesValue()
       value.append(n)
@@ -485,6 +506,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsCarefully()
+    value.reserveCapacity(count)
     while true {
       let e: E = try scanner.nextEnumValue()
       value.append(e)
@@ -543,6 +566,8 @@ internal struct JSONDecoder: Decoder {
     if scanner.skipOptionalArrayEnd() {
       return
     }
+    let count = try scanner.countArrayElementsCarefully()
+    value.reserveCapacity(count)
     while true {
       if scanner.skipOptionalNull() {
         var appended = false

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1326,6 +1326,58 @@ internal struct JSONScanner {
     return result
   }
 
+  /// Returns the number of elements until the end of the array.
+  /// Assumes array start '[' has already been skipped.  Slower than
+  /// countArrayObjectsQuickly, but it's safe to use when the array
+  /// contains nested objects, strings, etc.
+  internal mutating func countArrayElementsCarefully() throws -> Int {
+    skipWhitespace()
+    let start = index
+    if skipOptionalArrayEnd() {
+      index = start
+      return 0
+    }
+    var count = 0
+    while true {
+      try skipValue()
+      count += 1
+      if skipOptionalArrayEnd() {
+        index = start
+        return count
+      }
+      try skipRequiredComma()
+    }
+  }
+
+  /// Counts array elements by just looking for commas.
+  /// Very fast, but can get confused by nested objects or
+  /// strings that have commas or square brackets in them.
+  /// Use this only when a stray comma or square bracket would
+  /// be considered an error.
+  internal mutating func countArrayElementsQuickly() throws -> Int {
+    let start = index
+    if skipOptionalArrayEnd() {
+      index = start
+      return 0
+    }
+
+    var i = index
+    var items = 1
+    while i != source.endIndex {
+      let u = source[i]
+      switch u {
+      case asciiComma:
+        items += 1
+      case asciiCloseSquareBracket:
+        return items
+      default:
+        break
+      }
+      source.formIndex(after: &i)
+    }
+    throw JSONDecodingError.truncated
+  }
+
   /// Return the next complete JSON structure as a string.
   /// For example, this might return "true", or "123.456",
   /// or "{\"foo\": 7, \"bar\": [8, 9]}"
@@ -1425,24 +1477,23 @@ internal struct JSONScanner {
   // they don't know; newer clients may reject the same input due to
   // schema mismatches or other issues.
   private mutating func skipString() throws {
-    if currentByte != asciiDoubleQuote {
-      throw JSONDecodingError.malformedString
+    guard hasMoreContent && currentByte == asciiDoubleQuote else {
+      throw JSONDecodingError.truncated
     }
     advance()
     while hasMoreContent {
       let c = currentByte
+      advance()
       switch c {
       case asciiDoubleQuote:
-        advance()
         return
       case asciiBackslash:
-        advance()
         guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
         advance()
       default:
-        advance()
+        break
       }
     }
     throw JSONDecodingError.truncated

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -96,18 +96,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedFloatField(value: inout [Float]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let n = try scanner.nextFloat()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextFloat()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextFloat()
@@ -125,18 +125,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedDoubleField(value: inout [Double]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let n = try scanner.nextDouble()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextDouble()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextDouble()
@@ -162,21 +162,21 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
-                if scanner.skipOptionalEndArray() {
-                    return
-                }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
                 let n = try scanner.nextSInt()
                 if n > Int64(Int32.max) || n < Int64(Int32.min) {
                     throw TextFormatDecodingError.malformedNumber
                 }
                 value.append(Int32(truncatingIfNeeded: n))
+                if scanner.skipOptionalEndArray() {
+                    return
+                }
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextSInt()
@@ -197,18 +197,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedInt64Field(value: inout [Int64]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let n = try scanner.nextSInt()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextSInt()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextSInt()
@@ -234,21 +234,21 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
-                if scanner.skipOptionalEndArray() {
-                    return
-                }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
                 let n = try scanner.nextUInt()
                 if n > UInt64(UInt32.max) {
                     throw TextFormatDecodingError.malformedNumber
                 }
                 value.append(UInt32(truncatingIfNeeded: n))
+                if scanner.skipOptionalEndArray() {
+                    return
+                }
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextUInt()
@@ -269,18 +269,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedUInt64Field(value: inout [UInt64]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let n = try scanner.nextUInt()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextUInt()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextUInt()
@@ -352,18 +352,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedBoolField(value: inout [Bool]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let n = try scanner.nextBool()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextBool()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextBool()
@@ -381,18 +381,16 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedStringField(value: inout [String]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
             while true {
+                let n = try scanner.nextStringValue()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextStringValue()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextStringValue()
@@ -410,18 +408,16 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedBytesField(value: inout [Data]) throws {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
             while true {
+                let n = try scanner.nextBytesValue()
+                value.append(n)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let n = try scanner.nextBytesValue()
-                value.append(n)
+                try scanner.skipRequiredComma()
             }
         } else {
             let n = try scanner.nextBytesValue()
@@ -465,18 +461,18 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws where E.RawValue == Int {
         try scanner.skipRequiredColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
+            let count = try scanner.countArrayElementsQuickly()
+            value.reserveCapacity(count + value.count)
             while true {
+                let e: E = try decodeEnum()
+                value.append(e)
                 if scanner.skipOptionalEndArray() {
                     return
                 }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
-                let e: E = try decodeEnum()
-                value.append(e)
+                try scanner.skipRequiredComma()
             }
         } else {
             let e: E = try decodeEnum()
@@ -504,16 +500,10 @@ internal struct TextFormatDecoder: Decoder {
     mutating func decodeRepeatedMessageField<M: Message>(value: inout [M]) throws {
         _ = scanner.skipOptionalColon()
         if scanner.skipOptionalBeginArray() {
-            var firstItem = true
+            if scanner.skipOptionalEndArray() {
+                return
+            }
             while true {
-                if scanner.skipOptionalEndArray() {
-                    return
-                }
-                if firstItem {
-                    firstItem = false
-                } else {
-                    try scanner.skipRequiredComma()
-                }
                 let terminator = try scanner.skipObjectStart()
                 var subDecoder = try TextFormatDecoder(messageType: M.self,scanner: scanner, terminator: terminator)
                 if M.self == Google_Protobuf_Any.self {
@@ -526,6 +516,10 @@ internal struct TextFormatDecoder: Decoder {
                     value.append(message)
                 }
                 scanner = subDecoder.scanner
+                if scanner.skipOptionalEndArray() {
+                    return
+                }
+                try scanner.skipRequiredComma()
             }
         } else {
             let terminator = try scanner.skipObjectStart()

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -1076,4 +1076,25 @@ internal struct TextFormatScanner {
         }
         throw TextFormatDecodingError.malformedText
     }
+
+    // This is fast, but only safe for arrays where the
+    // elements never have stray commas or close square brackets.
+    // In particular, never use this for arrays of strings!
+    internal mutating func countArrayElementsQuickly() throws -> Int {
+        let start = p
+        var count = 0
+        while p != end {
+            switch p[0] {
+            case asciiCloseSquareBracket:
+                p = start
+                return count
+            case asciiComma:
+                count += 1
+            default:
+                break
+            }
+            p += 1
+        }
+        throw TextFormatDecodingError.malformedText
+    }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -548,6 +548,7 @@ extension Test_JSON {
         ("testOptionalNestedEnum", testOptionalNestedEnum),
         ("testRepeatedInt32", testRepeatedInt32),
         ("testRepeatedString", testRepeatedString),
+        ("testRepeatedNestedEnum", testRepeatedNestedEnum),
         ("testRepeatedNestedMessage", testRepeatedNestedMessage),
         ("testOneof", testOneof)
     ]

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -797,6 +797,29 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         }
     }
 
+    func testRepeatedNestedEnum() {
+        assertJSONEncode("{\"repeatedNestedEnum\":[\"FOO\"]}") {(o: inout MessageTestType) in
+            o.repeatedNestedEnum = [.foo]
+        }
+        assertJSONEncode("{\"repeatedNestedEnum\":[\"FOO\",77]}") {(o: inout MessageTestType) in
+            o.repeatedNestedEnum = [.foo, .UNRECOGNIZED(77)]
+        }
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\": []}") {
+            $0.repeatedNestedEnum == []
+        }
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\": [77]}") {
+            $0.repeatedNestedEnum == [.UNRECOGNIZED(77)]
+        }
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\": [\"FOO\"]}") {
+            $0.repeatedNestedEnum == [.foo]
+        }
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\": [ \"FOO\" , 77 , \"FOO\" ]}") {
+            $0.repeatedNestedEnum == [.foo, .UNRECOGNIZED(77), .foo]
+        }
+        assertJSONDecodeFails("{\"repeatedNestedEnum\": [ \"FOO\" , ]}")
+        assertJSONDecodeFails("{\"repeatedNestedEnum\":[,]}")
+    }
+
     func testRepeatedNestedMessage() {
         assertJSONEncode("{\"repeatedNestedMessage\":[{\"bb\":1}]}") {(o: inout MessageTestType) in
             var sub = Proto3Unittest_TestAllTypes.NestedMessage()

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -1149,6 +1149,18 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.repeatedNestedEnum == [.bar, .baz]
         }
+        assertTextFormatDecodeSucceeds("repeated_nested_enum: []") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == []
+        }
+        assertTextFormatDecodeSucceeds("repeated_nested_enum: [2]") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == [.bar]
+        }
+        assertTextFormatDecodeSucceeds("repeated_nested_enum: [BAR]") {
+            (o: MessageTestType) in
+            return o.repeatedNestedEnum == [.bar]
+        }
 
         assertTextFormatDecodeFails("repeated_nested_enum: BAR\nrepeated_nested_enum: a\n")
     }


### PR DESCRIPTION
This provides almost a 2x performance improvement when decoding repeated fields that use array notation in Text and JSON formats.  (JSON always uses `[...]` array notation; TextFormat only uses it for packed fields.)

The change simply counts the array elements in advance so we can resize the array once.  For arrays of certain primitive types, this count can be as simple as counting comma characters.
