### PR TITLE
Update some plugin code for Swift 4.

### DIFF
--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -190,7 +190,11 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
     // the disambiguator, sanitizing the root, then re-adding the
     // disambiguator:
     let e = s.index(s.endIndex, offsetBy: -disambiguator.characters.count)
-    let truncated = s.substring(to: e)
+    #if swift(>=4.0)
+      let truncated = String(s[..<e])
+    #else
+      let truncated = s.substring(to: e)
+    #endif
     return sanitizeTypeName(truncated, disambiguator: disambiguator) + disambiguator
   } else {
     return s
@@ -366,7 +370,11 @@ public enum NamingUtils {
 
       let count = fromChars.distance(from: fromChars.startIndex, to: fromIndex)
       let idx = from.index(from.startIndex, offsetBy: count)
-      return from[idx..<from.endIndex]
+      #if swift(>=4.0)
+        return String(from[idx..<from.endIndex])
+      #else
+        return from[idx..<from.endIndex]
+      #endif
     }
   }
 

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -38,7 +38,12 @@ func partition(string: String, atFirstOccurrenceOf substring: String) -> (String
   guard let index = string.range(of: substring)?.lowerBound else {
     return (string, "")
   }
-  return (string.substring(to: index), string.substring(from: string.index(after: index)))
+  #if swift(>=4.0)
+    return (String(string[..<index]),
+            String(string[string.index(after: index)...]))
+  #else
+    return (string.substring(to: index), string.substring(from: string.index(after: index)))
+  #endif
 }
 
 func parseParameter(string: String?) -> [(key:String, value:String)] {


### PR DESCRIPTION
Warnings:
```
Sources/PluginLibrary/NamingUtils.swift:193:23: 'substring(to:)' is deprecated: Please use String slicing subscript with a 'partial range upto' operator.
Sources/protoc-gen-swift/StringUtils.swift:41:18: 'substring(to:)' is deprecated: Please use String slicing subscript with a 'partial range upto' operator.
Sources/protoc-gen-swift/StringUtils.swift:41:47: 'substring(from:)' is deprecated: Please use String slicing subscript with a 'partial range from' operator.
```
Errors:
```
Sources/PluginLibrary/NamingUtils.swift:369:14: Subscripts returning String were obsoleted in Swift 4; explicitly construct a String from subscripted result
```
