### PR TITLE
Add a SwiftPM 4 version of the manifest.

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:4.0
+
+// Package.swift
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftProtobuf",
+  products: [
+    .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
+    .library(name: "SwiftProtobuf", type: .static, targets: ["SwiftProtobuf"]),
+  ],
+  targets: [
+    .target(name: "SwiftProtobuf"),
+    .target(name: "PluginLibrary",
+            dependencies: ["SwiftProtobuf"]),
+    .target(name: "protoc-gen-swift",
+            dependencies: ["PluginLibrary", "SwiftProtobuf"]),
+    .target(name: "Conformance",
+            dependencies: ["SwiftProtobuf"]),
+    .testTarget(name: "SwiftProtobufTests",
+                dependencies: ["SwiftProtobuf"]),
+    .testTarget(name: "PluginLibraryTests",
+                dependencies: ["PluginLibrary"]),
+  ],
+  swiftLanguageVersions: [3, 4]
+)


### PR DESCRIPTION
Looking at the SwiftPM docs:
  https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#version-specific-manifest-selection
this naming seems to be what is needed to support SwiftPM 3 getting
the old file while folks using SwiftPM 4 will get the new.

Hopefully this is a step in the direction of supporting folks only
having to build the parts they want, i.e. -
  https://github.com/apple/swift-protobuf/issues/125