### PR TITLE
swift build does not support --clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,6 @@ install: build
 	${INSTALL} ${PROTOC_GEN_SWIFT} ${BINDIR}
 
 clean:
-	-swift build --clean
 	-swift package clean
 	rm -rf .build _test ${PROTOC_GEN_SWIFT} DescriptorTestData.bin \
 	  Performance/_generated Performance/_results Protos/mined_words.txt \


### PR DESCRIPTION
I notice this error when building/cleaning `swift-protobuf` with `make`:

```
swift build --clean
error: unknown option --clean; use --help to list available options
make: [clean] Error 1 (ignored)
```