### PR TITLE
Sources: remove now deprecated 'characters'

### DIFF
--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -189,7 +189,7 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
     // conflict.  This can be resolved recursively by stripping
     // the disambiguator, sanitizing the root, then re-adding the
     // disambiguator:
-    let e = s.index(s.endIndex, offsetBy: -disambiguator.characters.count)
+    let e = s.index(s.endIndex, offsetBy: -disambiguator.count)
     #if swift(>=4.0)
       let truncated = String(s[..<e])
     #else
@@ -300,7 +300,7 @@ public enum NamingUtils {
     //  "pacakge.some_name" -> "Package_SomeName"
     var makeUpper = true
     var prefix = ""
-    for c in protoPackage.characters {
+    for c in protoPackage {
       if c == "_" {
         makeUpper = true
       } else if c == "." {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -21,7 +21,7 @@ import Dispatch
 
 internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
   var url = typePrefix
-  if typePrefix.isEmpty || typePrefix.characters.last != "/" {
+  if typePrefix.isEmpty || typePrefix.last != "/" {
     url += "/"
   }
   return url + typeName(fromMessage: message)

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -23,7 +23,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
   var digits = [Character]()
   var digitCount = 0
   var total = 0
-  var chars = text.characters.makeIterator()
+  var chars = text.makeIterator()
   var seconds: Int64?
   var nanos: Int32 = 0
   while let c = chars.next() {

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -18,7 +18,7 @@
 
 private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
-  var chars = name.characters.makeIterator()
+  var chars = name.makeIterator()
   while let c = chars.next() {
     switch c {
     case "_":
@@ -43,7 +43,7 @@ private func ProtoToJSON(name: String) -> String? {
 
 private func JSONToProto(name: String) -> String? {
   var path = String()
-  for c in name.characters {
+  for c in name {
     switch c {
     case "_":
       return nil
@@ -61,7 +61,7 @@ private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()
-  for c: Character in names.characters {
+  for c: Character in names {
     switch c {
     case ",":
       if fieldNameCount == 0 {

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -24,7 +24,7 @@ private func toJsonFieldName(_ s: String) -> String {
     var result = String()
     var capitalizeNext = false
 
-    for c in s.characters {
+    for c in s {
         if c == "_" {
             capitalizeNext = true
         } else if capitalizeNext {

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -15,7 +15,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
   var base = ""
   var suffix = ""
 
-  for c in pathname.characters {
+  for c in pathname {
     if c == "/" {
       dir += base + suffix + String(c)
       base = ""
@@ -27,7 +27,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
       suffix += String(c)
     }
   }
-  if suffix.characters.first != "." {
+  if suffix.first != "." {
     base += suffix
     suffix = ""
   }
@@ -47,7 +47,7 @@ func partition(string: String, atFirstOccurrenceOf substring: String) -> (String
 }
 
 func parseParameter(string: String?) -> [(key:String, value:String)] {
-  guard let string = string, string.characters.count > 0 else {
+  guard let string = string, string.count > 0 else {
     return []
   }
   let parts = string.components(separatedBy: ",")

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -138,7 +138,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         configureLargeObject(&m)
         let s = try m.jsonString()
         var truncated = ""
-        for c in s.characters {
+        for c in s {
             truncated.append(c)
             do {
                 _ = try MessageTestType(jsonString: truncated)


### PR DESCRIPTION
With latest Swift version and Xcode (9.1 beta), using `characters` now generates an error
```
Apple Swift version 4.0.1 (swiftlang-900.0.68 clang-900.0.38)
Target: x86_64-apple-macosx10.9
```