### PR TITLE
Add internal `chars` wrapper

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -21,7 +21,7 @@ import Dispatch
 
 internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
   var url = typePrefix
-  if typePrefix.isEmpty || typePrefix.characters.last != "/" {
+  if typePrefix.isEmpty || typePrefix.chars.last != "/" {
     url += "/"
   }
   return url + typeName(fromMessage: message)

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -23,7 +23,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
   var digits = [Character]()
   var digitCount = 0
   var total = 0
-  var chars = text.characters.makeIterator()
+  var chars = text.chars.makeIterator()
   var seconds: Int64?
   var nanos: Int32 = 0
   while let c = chars.next() {

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -18,7 +18,7 @@
 
 private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
-  var chars = name.characters.makeIterator()
+  var chars = name.chars.makeIterator()
   while let c = chars.next() {
     switch c {
     case "_":
@@ -43,7 +43,7 @@ private func ProtoToJSON(name: String) -> String? {
 
 private func JSONToProto(name: String) -> String? {
   var path = String()
-  for c in name.characters {
+  for c in name.chars {
     switch c {
     case "_":
       return nil
@@ -61,7 +61,7 @@ private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()
-  for c: Character in names.characters {
+  for c: Character in names.chars {
     switch c {
     case ",":
       if fieldNameCount == 0 {

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -24,7 +24,7 @@ private func toJsonFieldName(_ s: String) -> String {
     var result = String()
     var capitalizeNext = false
 
-    for c in s.characters {
+    for c in s.chars {
         if c == "_" {
             capitalizeNext = true
         } else if capitalizeNext {

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -29,6 +29,21 @@ internal func utf8ToString(
   return utf8ToString(bytes: bytes.baseAddress! + start, count: end - start)
 }
 
+// Swift deprecated `String.CharacterView`
+// The following allows building with Swift >= 4.0.2 and >= 3.2.2
+// and keeps backwards compatibility
+internal extension String {
+  #if swift(>=3.2)
+  var chars: String {
+    return self
+  }
+  #else
+  var chars: String.CharacterView {
+    return self.characters
+  }
+  #endif
+}
+
 // Swift's support for working with UTF8 bytes directly has
 // evolved over time.  The following tries to choose the
 // best option depending on the version of Swift you're using.


### PR DESCRIPTION
Added a `chars` variable as internal String extension to wrap access to
String characters.
This should fix building for Swift 4.0.2 in XCode 9.1.