### PR TITLE
Support Swift 4 `characters` deprecation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:3.1
 // Package.swift - description
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors
@@ -9,6 +10,20 @@
 
 import PackageDescription
 
+#if swift(>=3.1)
+let package = Package(
+  name: "SwiftProtobuf",
+  targets: [
+    Target(name: "PluginLibrary",
+           dependencies: ["SwiftProtobuf"]),
+    Target(name: "protoc-gen-swift",
+           dependencies: ["PluginLibrary", "SwiftProtobuf"]),
+    Target(name: "Conformance",
+           dependencies: ["SwiftProtobuf"]),
+  ],
+  swiftLanguageVersions: [3, 4]
+)
+#else
 let package = Package(
   name: "SwiftProtobuf",
   targets: [
@@ -20,3 +35,4 @@ let package = Package(
            dependencies: ["SwiftProtobuf"]),
   ]
 )
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,3 @@
-// swift-tools-version:3.1
 // Package.swift - description
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors
@@ -10,20 +9,6 @@
 
 import PackageDescription
 
-#if swift(>=3.1)
-let package = Package(
-  name: "SwiftProtobuf",
-  targets: [
-    Target(name: "PluginLibrary",
-           dependencies: ["SwiftProtobuf"]),
-    Target(name: "protoc-gen-swift",
-           dependencies: ["PluginLibrary", "SwiftProtobuf"]),
-    Target(name: "Conformance",
-           dependencies: ["SwiftProtobuf"]),
-  ],
-  swiftLanguageVersions: [3, 4]
-)
-#else
 let package = Package(
   name: "SwiftProtobuf",
   targets: [
@@ -35,4 +20,3 @@ let package = Package(
            dependencies: ["SwiftProtobuf"]),
   ]
 )
-#endif

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -189,10 +189,11 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
     // conflict.  This can be resolved recursively by stripping
     // the disambiguator, sanitizing the root, then re-adding the
     // disambiguator:
-    let e = s.index(s.endIndex, offsetBy: -disambiguator.count)
     #if swift(>=4.0)
+      let e = s.index(s.endIndex, offsetBy: -disambiguator.count)
       let truncated = String(s[..<e])
     #else
+      let e = s.index(s.endIndex, offsetBy: -disambiguator.characters.count)
       let truncated = s.substring(to: e)
     #endif
     return sanitizeTypeName(truncated, disambiguator: disambiguator) + disambiguator
@@ -300,7 +301,12 @@ public enum NamingUtils {
     //  "pacakge.some_name" -> "Package_SomeName"
     var makeUpper = true
     var prefix = ""
-    for c in protoPackage {
+#if swift(>=4.0)
+    let protoPackageChars = protoPackage
+#else
+    let protoPackageChars = protoPackage.characters
+#endif
+    for c in protoPackageChars {
       if c == "_" {
         makeUpper = true
       } else if c == "." {

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -189,7 +189,7 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
     // conflict.  This can be resolved recursively by stripping
     // the disambiguator, sanitizing the root, then re-adding the
     // disambiguator:
-    #if swift(>=4.0)
+    #if swift(>=3.2)
       let e = s.index(s.endIndex, offsetBy: -disambiguator.count)
       let truncated = String(s[..<e])
     #else
@@ -301,7 +301,7 @@ public enum NamingUtils {
     //  "pacakge.some_name" -> "Package_SomeName"
     var makeUpper = true
     var prefix = ""
-#if swift(>=4.0)
+#if swift(>=3.2)
     let protoPackageChars = protoPackage
 #else
     let protoPackageChars = protoPackage.characters

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -189,7 +189,7 @@ fileprivate func sanitizeTypeName(_ s: String, disambiguator: String) -> String 
     // conflict.  This can be resolved recursively by stripping
     // the disambiguator, sanitizing the root, then re-adding the
     // disambiguator:
-    let e = s.index(s.endIndex, offsetBy: -disambiguator.characters.count)
+    let e = s.index(s.endIndex, offsetBy: -disambiguator.count)
     #if swift(>=4.0)
       let truncated = String(s[..<e])
     #else
@@ -300,7 +300,7 @@ public enum NamingUtils {
     //  "pacakge.some_name" -> "Package_SomeName"
     var makeUpper = true
     var prefix = ""
-    for c in protoPackage.characters {
+    for c in protoPackage {
       if c == "_" {
         makeUpper = true
       } else if c == "." {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -21,7 +21,7 @@ import Dispatch
 
 internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
   var url = typePrefix
-  if typePrefix.isEmpty || typePrefix.characters.last != "/" {
+  if typePrefix.isEmpty || typePrefix.last != "/" {
     url += "/"
   }
   return url + typeName(fromMessage: message)

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -21,7 +21,12 @@ import Dispatch
 
 internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
   var url = typePrefix
-  if typePrefix.isEmpty || typePrefix.last != "/" {
+#if swift(>=4.0)
+  let needsSlash = typePrefix.isEmpty || typePrefix.last != "/"
+#else
+  let needsSlash = typePrefix.isEmpty || typePrefix.characters.last != "/"
+#endif
+  if needsSlash {
     url += "/"
   }
   return url + typeName(fromMessage: message)

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -21,7 +21,7 @@ import Dispatch
 
 internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
   var url = typePrefix
-#if swift(>=4.0)
+#if swift(>=3.2)
   let needsSlash = typePrefix.isEmpty || typePrefix.last != "/"
 #else
   let needsSlash = typePrefix.isEmpty || typePrefix.characters.last != "/"

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -23,7 +23,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
   var digits = [Character]()
   var digitCount = 0
   var total = 0
-  var chars = text.characters.makeIterator()
+  var chars = text.makeIterator()
   var seconds: Int64?
   var nanos: Int32 = 0
   while let c = chars.next() {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -23,7 +23,11 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
   var digits = [Character]()
   var digitCount = 0
   var total = 0
+#if swift(>=4.0)
   var chars = text.makeIterator()
+#else
+  var chars = text.characters.makeIterator()
+#endif
   var seconds: Int64?
   var nanos: Int32 = 0
   while let c = chars.next() {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -23,7 +23,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
   var digits = [Character]()
   var digitCount = 0
   var total = 0
-#if swift(>=4.0)
+#if swift(>=3.2)
   var chars = text.makeIterator()
 #else
   var chars = text.characters.makeIterator()

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -18,7 +18,7 @@
 
 private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
-  var chars = name.characters.makeIterator()
+  var chars = name.makeIterator()
   while let c = chars.next() {
     switch c {
     case "_":
@@ -43,7 +43,7 @@ private func ProtoToJSON(name: String) -> String? {
 
 private func JSONToProto(name: String) -> String? {
   var path = String()
-  for c in name.characters {
+  for c in name {
     switch c {
     case "_":
       return nil
@@ -61,7 +61,7 @@ private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()
-  for c: Character in names.characters {
+  for c: Character in names {
     switch c {
     case ",":
       if fieldNameCount == 0 {

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -18,7 +18,7 @@
 
 private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
-#if swift(>=4.0)
+#if swift(>=3.2)
   var chars = name.makeIterator()
 #else
   var chars = name.characters.makeIterator()
@@ -47,7 +47,7 @@ private func ProtoToJSON(name: String) -> String? {
 
 private func JSONToProto(name: String) -> String? {
   var path = String()
-#if swift(>=4.0)
+#if swift(>=3.2)
   let chars = name
 #else
   let chars = name.characters
@@ -70,7 +70,7 @@ private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()
-#if swift(>=4.0)
+#if swift(>=3.2)
   let namesChars = names
 #else
   let namesChars = names.characters

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -18,7 +18,11 @@
 
 private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
+#if swift(>=4.0)
   var chars = name.makeIterator()
+#else
+  var chars = name.characters.makeIterator()
+#endif
   while let c = chars.next() {
     switch c {
     case "_":
@@ -43,7 +47,12 @@ private func ProtoToJSON(name: String) -> String? {
 
 private func JSONToProto(name: String) -> String? {
   var path = String()
-  for c in name {
+#if swift(>=4.0)
+  let chars = name
+#else
+  let chars = name.characters
+#endif
+  for c in chars {
     switch c {
     case "_":
       return nil
@@ -61,7 +70,12 @@ private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()
-  for c: Character in names {
+#if swift(>=4.0)
+  let namesChars = names
+#else
+  let namesChars = names.characters
+#endif
+  for c: Character in namesChars {
     switch c {
     case ",":
       if fieldNameCount == 0 {

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -24,7 +24,7 @@ private func toJsonFieldName(_ s: String) -> String {
     var result = String()
     var capitalizeNext = false
 
-    for c in s.characters {
+    for c in s {
         if c == "_" {
             capitalizeNext = true
         } else if capitalizeNext {

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -23,8 +23,12 @@
 private func toJsonFieldName(_ s: String) -> String {
     var result = String()
     var capitalizeNext = false
-
-    for c in s {
+#if swift(>=4.0)
+    let chars = s
+#else
+    let chars = s.characters
+#endif
+    for c in chars {
         if c == "_" {
             capitalizeNext = true
         } else if capitalizeNext {

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -23,7 +23,7 @@
 private func toJsonFieldName(_ s: String) -> String {
     var result = String()
     var capitalizeNext = false
-#if swift(>=4.0)
+#if swift(>=3.2)
     let chars = s
 #else
     let chars = s.characters

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -14,7 +14,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
   var dir = ""
   var base = ""
   var suffix = ""
-#if swift(>=4.0)
+#if swift(>=3.2)
   let pathnameChars = pathname
 #else
   let pathnameChars = pathname.characters
@@ -31,7 +31,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
       suffix += String(c)
     }
   }
-#if swift(>=4.0)
+#if swift(>=3.2)
   let validSuffix = suffix.isEmpty || suffix.first == "."
 #else
   let validSuffix = suffix.isEmpty || suffix.characters.first == "."

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -14,8 +14,12 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
   var dir = ""
   var base = ""
   var suffix = ""
-
-  for c in pathname {
+#if swift(>=4.0)
+  let pathnameChars = pathname
+#else
+  let pathnameChars = pathname.characters
+#endif
+  for c in pathnameChars {
     if c == "/" {
       dir += base + suffix + String(c)
       base = ""
@@ -27,7 +31,12 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
       suffix += String(c)
     }
   }
-  if suffix.first != "." {
+#if swift(>=4.0)
+  let validSuffix = suffix.isEmpty || suffix.first == "."
+#else
+  let validSuffix = suffix.isEmpty || suffix.characters.first == "."
+#endif
+  if !validSuffix {
     base += suffix
     suffix = ""
   }
@@ -47,7 +56,7 @@ func partition(string: String, atFirstOccurrenceOf substring: String) -> (String
 }
 
 func parseParameter(string: String?) -> [(key:String, value:String)] {
-  guard let string = string, string.count > 0 else {
+  guard let string = string, !string.isEmpty else {
     return []
   }
   let parts = string.components(separatedBy: ",")

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -15,7 +15,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
   var base = ""
   var suffix = ""
 
-  for c in pathname.characters {
+  for c in pathname {
     if c == "/" {
       dir += base + suffix + String(c)
       base = ""
@@ -27,7 +27,7 @@ func splitPath(pathname: String) -> (dir:String, base:String, suffix:String) {
       suffix += String(c)
     }
   }
-  if suffix.characters.first != "." {
+  if suffix.first != "." {
     base += suffix
     suffix = ""
   }
@@ -47,7 +47,7 @@ func partition(string: String, atFirstOccurrenceOf substring: String) -> (String
 }
 
 func parseParameter(string: String?) -> [(key:String, value:String)] {
-  guard let string = string, string.characters.count > 0 else {
+  guard let string = string, string.count > 0 else {
     return []
   }
   let parts = string.components(separatedBy: ",")

--- a/Tests/SwiftProtobufTests/Test_GroupWithGroups.swift
+++ b/Tests/SwiftProtobufTests/Test_GroupWithGroups.swift
@@ -50,10 +50,10 @@ class Test_GroupWithinGroup: XCTestCase, PBTestHelpers {
         $0.subGroup3[0].subGroup4[0].sub4A == 1
     }
     // Empty group
-    assertDecodeSucceeds([27, 19, 20, 28]) {
-      $0.subGroup3.count == 1 &&
-        $0.subGroup3[0].subGroup4.count == 1 &&
-        $0.subGroup3[0].subGroup4[0] == MessageTestType.SubGroup3.SubGroup4()
+    assertDecodeSucceeds([27, 19, 20, 28]) { (o: MessageTestType) -> Bool in
+      o.subGroup3.count == 1 &&
+        o.subGroup3[0].subGroup4.count == 1 &&
+        o.subGroup3[0].subGroup4[0] == MessageTestType.SubGroup3.SubGroup4()
     }
     assertDecodeFails([8, 4, 27, 8, 5, 19, 8, 6, 20]) // End group missing.
     assertDecodeFails([8, 4, 27, 8, 5, 19, 8, 6, 28, 20]) // Wrong end groups (reversed).

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -137,7 +137,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         var m = MessageTestType()
         configureLargeObject(&m)
         let s = try m.jsonString()
-#if swift(>=4.0)
+#if swift(>=3.2)
         let chars = s
 #else
 	let chars = s.characters

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -138,7 +138,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         configureLargeObject(&m)
         let s = try m.jsonString()
         var truncated = ""
-        for c in s.characters {
+        for c in s {
             truncated.append(c)
             do {
                 _ = try MessageTestType(jsonString: truncated)

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -137,8 +137,13 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         var m = MessageTestType()
         configureLargeObject(&m)
         let s = try m.jsonString()
+#if swift(>=4.0)
+        let chars = s
+#else
+	let chars = s.characters
+#endif
         var truncated = ""
-        for c in s {
+        for c in chars {
             truncated.append(c)
             do {
                 _ = try MessageTestType(jsonString: truncated)


### PR DESCRIPTION
This is based on @zllak's patch, with added `#if swift` checks to handle older compilers.
