### PR TITLE
A couple of fixes for Swift 4.1

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -137,7 +137,7 @@ public extension Google_Protobuf_FieldMask {
   ///   defined using the JSON names for the fields.
   public init?(jsonPaths: String...) {
     // TODO: This should fail if any of the conversions from JSON fails
-    self.init(protoPaths: jsonPaths.flatMap(JSONToProto))
+    self.init(protoPaths: jsonPaths.compactMap(JSONToProto))
   }
 
   // It would be nice if to have an initializer that accepted Swift property

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -605,8 +605,7 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message {
     get {return _storage._value ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._value = newValue}
   }
-  /// Returns true if `value` has been explicitly set.
-  public var hasValue: Bool {return _storage._value != nil}
+  
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
   public mutating func clearValue() {_storage._value = nil}
 
@@ -648,6 +647,11 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message {
   }
 
   fileprivate var _storage = _StorageClass.defaultInstance
+}
+
+extension Google_Protobuf_Option {
+    /// Returns true if `value` has been explicitly set.
+    public var hasValue: Bool {return _storage._value != nil}
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.


### PR DESCRIPTION
This breaks compatibility with `Swift 4.0`, I can work on that next week, I just wanted to have an initial version compiling with `4.1` I can start working with.