### PR TITLE
Suppress known-broken test on Swift Linux 4.1 and earlier

### DIFF
--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -639,10 +639,10 @@ class Test_JSON: XCTestCase, PBTestHelpers {
     }
 
     func testOptionalString_controlCharacters() {
-        // This is known to fail on Swift Linux 4.0 and earlier,
+        // This is known to fail on Swift Linux 4.1 and earlier,
         // so skip it there.
         // See https://bugs.swift.org/browse/SR-4218 for details.
-#if !os(Linux) || swift(>=4.1)
+#if !os(Linux) || swift(>=4.2)
         // Verify that all C0 controls are correctly escaped
         assertJSONEncode("{\"optionalString\":\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\"}") {(o: inout MessageTestType) in
             o.optionalString = "\u{00}\u{01}\u{02}\u{03}\u{04}\u{05}\u{06}\u{07}"

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -596,10 +596,10 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
     }
 
     func testEncoding_optionalString_controlCharacters() throws {
-        // This is known to fail on Swift Linux 4.0 and earlier,
+        // This is known to fail on Swift Linux 4.1 and earlier,
         // so skip it there.
         // See https://bugs.swift.org/browse/SR-4218 for details.
-#if !os(Linux) || swift(>=4.1)
+#if !os(Linux) || swift(>=4.2)
         assertTextFormatEncode("optional_string: \"\\001\\002\\003\\004\\005\\006\\007\"\n") {
             (o: inout MessageTestType) in
             o.optionalString = "\u{01}\u{02}\u{03}\u{04}\u{05}\u{06}\u{07}"


### PR DESCRIPTION
This is a longstanding bug in String.== on Linux.  Unlike macOS, the
Linux Swift considers certain C0 control characters to be equal to the
empty string.  This breaks some of the SwiftProtobuf tests.

The conditionals here suppress this test on Swift Linux below a certain
version cutoff.  Someday, this bug will get fixed and we can stop bumping
the cutoff here.

See https://bugs.swift.org/browse/SR-4218 for details of the bug.