### PR TITLE
Use automatic linkage for the library product

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -15,7 +15,7 @@ let package = Package(
   name: "SwiftProtobuf",
   products: [
     .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
-    .library(name: "SwiftProtobuf", type: .static, targets: ["SwiftProtobuf"]),
+    .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"]),
     .library(name: "SwiftProtobufPluginLibrary", targets: ["SwiftProtobufPluginLibrary"]),
   ],
   targets: [


### PR DESCRIPTION
The Swift Package Manager documentation for [products](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md#products) recommends that library products use automatic linkage (the default) "so the Package Manager can decide appropriate linkage." Indeed, declaring static linkage slows down builds by forcing the creation of an intermediate static library `libSwiftProtobuf.a`. In automatic linkage SwiftPM elides the creation of this library and links SwiftProtobuf object files directly into the final executable. This has the same effect as using a static library with the advantage of making the overall build faster.