### PR TITLE
Add swift_version to podspec

### DIFF
--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author = 'Apple Inc.'
   s.source = { :git => 'https://github.com/apple/swift-protobuf.git', :tag => s.version }
 
+  s.swift_version = '3.2'
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'


### PR DESCRIPTION
This fixes a warning in `pod lib lint`. I’m having trouble finding hard documentation on this, but cocoapods should set the `SWIFT_VERSION` on the framework target. From there, Xcode will handle compatability with different versions of Swift (https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Compatibility.html).

From Cocoapods:
```bash
$ pod lib lint

 -> SwiftProtobuf (1.0.3)
    - WARN  | swift: The validator used Swift 3.2 by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_version` attribute in your podspec. Note that usage of the `--swift-version` parameter or a `.swift-version` file is now deprecated.

[!] SwiftProtobuf did not pass validation, due to 1 warning (but you can use `--allow-warnings` to ignore it).
You can use the `--no-clean` option to inspect any issue.
```