### PR TITLE
Allow 0 to be used for float values in the text protobuf format.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -674,11 +674,11 @@ internal struct TextFormatScanner {
             c = p[0]
         }
         switch c {
-        case asciiZero: // '0' as first character only if followed by '.'
+        case asciiZero: // '0' as first character is not allowed followed by digit
             p += 1
-            guard p != end else {p = start; return nil}
+            guard p != end else {break}
             c = p[0]
-            if c != asciiPeriod {
+            if c >= asciiZero && c <= asciiNine {
                 p = start
                 return nil
             }

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -413,6 +413,12 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeSucceeds("optional_double: 1.0\n") {(o: MessageTestType) in
             return o.optionalDouble == 1.0
         }
+        assertTextFormatDecodeSucceeds("optional_double: 1\n") {(o: MessageTestType) in
+            return o.optionalDouble == 1.0
+        }
+        assertTextFormatDecodeSucceeds("optional_double: 0\n") {(o: MessageTestType) in
+            return o.optionalDouble == 0.0
+        }
         assertTextFormatDecodeSucceeds("12: 1.0\n") {(o: MessageTestType) in
             return o.optionalDouble == 1.0
         }

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -315,6 +315,22 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == 1.0
         }
+        assertTextFormatDecodeSucceeds("optional_float: 11\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 11.0
+        }
+        assertTextFormatDecodeSucceeds("optional_float: 11f\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 11.0
+        }
+        assertTextFormatDecodeSucceeds("optional_float: 0\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 0.0
+        }
+        assertTextFormatDecodeSucceeds("optional_float: 0f\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 0.0
+        }
         assertTextFormatEncode("optional_float: inf\n") {(o: inout MessageTestType) in o.optionalFloat = Float.infinity}
         assertTextFormatEncode("optional_float: -inf\n") {(o: inout MessageTestType) in o.optionalFloat = -Float.infinity}
 


### PR DESCRIPTION
I don't think that there is a formal spec for the protobuf text format. However the main C++ implementation supports using 0 for a floating point value.
Currently the swift implementation does not allow it and fail with a "malformedNumber" error. However any other integer could be used which is not very consistent.
This PR tweaks the current check so that 0 can be used and also adds some unit tests for this behavior.

(note that it's the first time that I look at this codebase as I ran into the issue, so I may have overlooked some good reason to forbid 0 or some easier way to achieve this)