### PR TITLE
Issue #743: Correctly handle escaped slashes in JSON byte data

### DIFF
--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -80,8 +80,11 @@ private func fromHexDigit(_ c: UnicodeScalar) -> UInt32? {
   }
 }
 
-// Decode both the RFC 4648 section 4 Base 64 encoding and the
-// RFC 4648 section 5 Base 64 variant.
+// Decode both the RFC 4648 section 4 Base 64 encoding and the RFC
+// 4648 section 5 Base 64 variant.  The section 5 variant is also
+// known as "base64url" or the "URL-safe alphabet".
+// Note that both "-" and "+" decode to 62 and "/" and "_" both
+// decode as 63.
 let base64Values: [Int] = [
 /* 0x00 */ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 /* 0x10 */ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -546,7 +546,7 @@ extension Test_JSON {
         ("testOptionalString", testOptionalString),
         ("testOptionalString_controlCharacters", testOptionalString_controlCharacters),
         ("testOptionalBytes", testOptionalBytes),
-        ("testOptionalBytes2", testOptionalBytes2),
+        ("testOptionalBytes_escapes", testOptionalBytes_escapes),
         ("testOptionalBytes_roundtrip", testOptionalBytes_roundtrip),
         ("testOptionalNestedMessage", testOptionalNestedMessage),
         ("testOptionalNestedEnum", testOptionalNestedEnum),

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -734,6 +734,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
             $0.optionalBytes == Data(bytes: [251, 255, 191])
         }
         assertJSONDecodeFails("{\"optionalBytes\":\"-_+/\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"-_+\\/\"}")
     }
 
     func testOptionalBytes_escapes() {

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -731,10 +731,44 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"optionalBytes\":\"-_+/\"}")
     }
 
-    func testOptionalBytes2() {
-        assertJSONDecodeSucceeds("{\"optionalBytes\":\"QUJD\"}") {
-            $0.optionalBytes == Data(bytes: [65, 66, 67])
+    func testOptionalBytes_escapes() {
+        // Many JSON encoders escape "/":
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"\\/w==\"}") {
+            $0.optionalBytes == Data(bytes: [255])
         }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"\\/w\"}") {
+            $0.optionalBytes == Data(bytes: [255])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"\\/\\/\"}") {
+            $0.optionalBytes == Data(bytes: [255])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"a\\/\"}") {
+            $0.optionalBytes == Data(bytes: [107])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"ab\\/\"}") {
+            $0.optionalBytes == Data(bytes: [105, 191])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"abc\\/\"}") {
+            $0.optionalBytes == Data(bytes: [105, 183, 63])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"\\/a\"}") {
+            $0.optionalBytes == Data(bytes: [253])
+        }
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\"\\/\\/\\/\\/\"}") {
+            $0.optionalBytes == Data(bytes: [255, 255, 255])
+        }
+        // Most backslash escapes decode to values that are
+        // not legal in base-64 encoded strings
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\b\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\f\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\n\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\r\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\t\"}")
+        assertJSONDecodeFails("{\"optionalBytes\":\"a\\\"\"}")
+
+        // TODO: For completeness, we should support \u1234 escapes
+        // assertJSONDecodeSucceeds("{\"optionalBytes\":\"\u0061\u0062\"}")
+        // assertJSONDecodeFails("{\"optionalBytes\":\"\u1234\u5678\"}")
     }
 
     func testOptionalBytes_roundtrip() throws {

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -721,7 +721,12 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG==\"}")
         assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG===\"}")
         assertJSONDecodeFails("{\"optionalBytes\":\"QUJDREVG====\"}")
-        // Accept both RFC4648 Section 4 and Section 5 base64 variants, but reject mixed coding:
+        // Google's parser accepts and ignores spaces:
+        assertJSONDecodeSucceeds("{\"optionalBytes\":\" Q U J D R E U \"}") {
+            $0.optionalBytes == Data(bytes: [65, 66, 67, 68, 69])
+        }
+        // Accept both RFC4648 Section 4 "base64" and Section 5
+        // "URL-safe base64" variants, but reject mixed coding:
         assertJSONDecodeSucceeds("{\"optionalBytes\":\"-_-_\"}") {
             $0.optionalBytes == Data(bytes: [251, 255, 191])
         }


### PR DESCRIPTION
Protobuf JSON is designed to be easily implemented on top of standard
JSON encoders.  For historical reasons, such encoders often encode "/"
(which commonly occurs in base-64 data) as "\/".

I overlooked support for backslash escapes when parsing byte data.

This adds tests and support for all the simple backslash escapes.
It turns out that "\/" is the only one that is legal in base-64 data,
so we simply fail if we encounter \b \f \n \r \t \" \\ or any invalid
sequence.

Note: This does not support \u1234 hexadecimal escapes.  (I don't
expect to ever see those in practice, so I doubt this is a problem.)