### PR TITLE
Fix hashing issues for messages/groups in arrays.

### DIFF
--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -266,24 +266,20 @@ internal struct HashVisitor: Visitor {
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
     mix(fieldNumber)
-    #if swift(>=4.2)
-      mix(value.hashValue)
-    #else
-      for v in value {
-        mix(v.hashValue)
-      }
-    #endif
+    // TODO: Message doesn't add Hashable, _MessageImplementationBase does, so
+    // this can't use value.hashValue here, need to revisit this.
+    for v in value {
+      mix(v.hashValue)
+    }
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {
     mix(fieldNumber)
-    #if swift(>=4.2)
-      mix(value.hashValue)
-    #else
-      for v in value {
-        mix(v.hashValue)
-      }
-    #endif
+    // TODO: Message doesn't add Hashable, _MessageImplementationBase does, so
+    // this can't use value.hashValue here, need to revisit this.
+    for v in value {
+      mix(v.hashValue)
+    }
   }
 
   mutating func visitMapField<KeyType, ValueType: MapValueType>(


### PR DESCRIPTION
The original code here landed in f9972067d75361cd37e02723c5ec076c30da077a,
but because of SR-7993 and not having yet landed a Package.swift that
enabled 4.2 support, we weren't hitting this code yet.

Since the visitor api uses Message, it doesn't know they messages are
Hashable, the maps work because they get more complete type info to
pick up the conformance declared on the Base used by for generated
messages.

So...

Going back to manually mixing in the for Arrays, adding a Todo
to revisit this. But this gets master back to working if someone
tries to pull the code into a compiling context that is 4.2+.