### PR TITLE
Fix outdated package syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ you used to build the plugin above:
 
 ```swift
 dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from:"1.0.0")
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.0.0")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ you used to build the plugin above:
 
 ```swift
 dependencies: [
-        .Package(url: "https://github.com/apple/swift-protobuf.git", Version(1,0,0))
+        .package(url: "https://github.com/apple/swift-protobuf.git", from:"1.0.0")
 ]
 ```
 


### PR DESCRIPTION
I'm using string based versioning, but not sure that's the best or most up to date approach.