### PR TITLE
Check for unknown fields in the Conformance Requests.

### DIFF
--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -60,6 +60,13 @@ func buildResponse(serializedData: Data) -> Conformance_ConformanceResponse {
         return response
     }
 
+    // Detect when something gets added to the conformance request that isn't
+    // supported yet.
+    if !request.unknownFields.data.isEmpty {
+        response.runtimeError = "ConformanceRequest had unknown fields; regenerate conformance.pb.swift and see what support needs to be added."
+        return response
+    }
+
     let msgType: SwiftProtobuf.Message.Type
     switch request.messageType {
     case "":

--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -62,8 +62,10 @@ func buildResponse(serializedData: Data) -> Conformance_ConformanceResponse {
 
     // Detect when something gets added to the conformance request that isn't
     // supported yet.
-    if !request.unknownFields.data.isEmpty {
-        response.runtimeError = "ConformanceRequest had unknown fields; regenerate conformance.pb.swift and see what support needs to be added."
+    guard request.unknownFields.data.isEmpty else {
+        response.runtimeError =
+            "ConformanceRequest had unknown fields; regenerate conformance.pb.swift and"
+            + " see what support needs to be added."
         return response
     }
 


### PR DESCRIPTION
Error if there are any.  Simply regenerating conformance.pb.swift will
"work around" the failure, but the real thing is to look at the new
fields and add support.