### PR TITLE
Fix up direct equality generation for oneofs

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -412,7 +412,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if self.payload != rhs.payload {return false}
+    if lhs.payload != rhs.payload {return false}
     if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
     if lhs.messageType != rhs.messageType {return false}
     if lhs.testCategory != rhs.testCategory {return false}
@@ -490,7 +490,7 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   static func ==(lhs: Conformance_ConformanceResponse, rhs: Conformance_ConformanceResponse) -> Bool {
-    if self.result != rhs.result {return false}
+    if lhs.result != rhs.result {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -7604,7 +7604,7 @@ extension ProtobufUnittest_TestDeprecatedFields: SwiftProtobuf.Message, SwiftPro
 
   static func ==(lhs: ProtobufUnittest_TestDeprecatedFields, rhs: ProtobufUnittest_TestDeprecatedFields) -> Bool {
     if lhs._deprecatedInt32 != rhs._deprecatedInt32 {return false}
-    if self.oneofFields != rhs.oneofFields {return false}
+    if lhs.oneofFields != rhs.oneofFields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1916,7 +1916,7 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, 
 
   static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions, rhs: ProtobufUnittest_TestMessageWithCustomOptions) -> Bool {
     if lhs._field1 != rhs._field1 {return false}
-    if self.anOneof != rhs.anOneof {return false}
+    if lhs.anOneof != rhs.anOneof {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -326,7 +326,7 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -393,7 +393,7 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Me
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -220,7 +220,7 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -671,11 +671,11 @@ extension Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftP
   }
 
   static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration, rhs: Swift_Protobuf_OneofTraversalGeneration) -> Bool {
-    if self.oGood != rhs.oGood {return false}
-    if self.oConflictField != rhs.oConflictField {return false}
+    if lhs.oGood != rhs.oGood {return false}
+    if lhs.oConflictField != rhs.oConflictField {return false}
     if lhs._m != rhs._m {return false}
-    if self.oConflictExtensionsStart != rhs.oConflictExtensionsStart {return false}
-    if self.oConflictExtensionsEnd != rhs.oConflictExtensionsEnd {return false}
+    if lhs.oConflictExtensionsStart != rhs.oConflictExtensionsStart {return false}
+    if lhs.oConflictExtensionsEnd != rhs.oConflictExtensionsEnd {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -412,7 +412,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if self.payload != rhs.payload {return false}
+    if lhs.payload != rhs.payload {return false}
     if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
     if lhs.messageType != rhs.messageType {return false}
     if lhs.testCategory != rhs.testCategory {return false}
@@ -490,7 +490,7 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   static func ==(lhs: Conformance_ConformanceResponse, rhs: Conformance_ConformanceResponse) -> Bool {
-    if self.result != rhs.result {return false}
+    if lhs.result != rhs.result {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -366,14 +366,17 @@ class OneofGenerator {
         // First field causes the output.
         guard field === fields.first else { return }
 
+        let lhsProperty: String
         let otherStoredProperty: String
         if usesHeapStorage {
+          lhsProperty = "_storage.\(underscoreSwiftFieldName)"
           otherStoredProperty = "rhs_storage.\(underscoreSwiftFieldName)"
         } else {
+          lhsProperty = "lhs.\(swiftFieldName)"
           otherStoredProperty = "rhs.\(swiftFieldName)"
         }
 
-        p.print("if \(storedProperty) != \(otherStoredProperty) {return false}\n")
+        p.print("if \(lhsProperty) != \(otherStoredProperty) {return false}\n")
     }
 
     func generateIsInitializedCheck(printer p: inout CodePrinter, field: MemberFieldGenerator) {

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -412,7 +412,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if self.payload != rhs.payload {return false}
+    if lhs.payload != rhs.payload {return false}
     if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
     if lhs.messageType != rhs.messageType {return false}
     if lhs.testCategory != rhs.testCategory {return false}
@@ -490,7 +490,7 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
   }
 
   static func ==(lhs: Conformance_ConformanceResponse, rhs: Conformance_ConformanceResponse) -> Bool {
-    if self.result != rhs.result {return false}
+    if lhs.result != rhs.result {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -7604,7 +7604,7 @@ extension ProtobufUnittest_TestDeprecatedFields: SwiftProtobuf.Message, SwiftPro
 
   static func ==(lhs: ProtobufUnittest_TestDeprecatedFields, rhs: ProtobufUnittest_TestDeprecatedFields) -> Bool {
     if lhs._deprecatedInt32 != rhs._deprecatedInt32 {return false}
-    if self.oneofFields != rhs.oneofFields {return false}
+    if lhs.oneofFields != rhs.oneofFields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1916,7 +1916,7 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, 
 
   static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions, rhs: ProtobufUnittest_TestMessageWithCustomOptions) -> Bool {
     if lhs._field1 != rhs._field1 {return false}
-    if self.anOneof != rhs.anOneof {return false}
+    if lhs.anOneof != rhs.anOneof {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -326,7 +326,7 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -393,7 +393,7 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Me
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -220,7 +220,7 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
     if lhs.repeatedE != rhs.repeatedE {return false}
     if lhs.repeatedPackedE != rhs.repeatedPackedE {return false}
     if lhs.repeatedPackedUnexpectedE != rhs.repeatedPackedUnexpectedE {return false}
-    if self.o != rhs.o {return false}
+    if lhs.o != rhs.o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -671,11 +671,11 @@ extension Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftP
   }
 
   static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration, rhs: Swift_Protobuf_OneofTraversalGeneration) -> Bool {
-    if self.oGood != rhs.oGood {return false}
-    if self.oConflictField != rhs.oConflictField {return false}
+    if lhs.oGood != rhs.oGood {return false}
+    if lhs.oConflictField != rhs.oConflictField {return false}
     if lhs._m != rhs._m {return false}
-    if self.oConflictExtensionsStart != rhs.oConflictExtensionsStart {return false}
-    if self.oConflictExtensionsEnd != rhs.oConflictExtensionsEnd {return false}
+    if lhs.oConflictExtensionsStart != rhs.oConflictExtensionsStart {return false}
+    if lhs.oConflictExtensionsEnd != rhs.oConflictExtensionsEnd {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true


### PR DESCRIPTION
I think i did `make -j regenerate check` and there are still gaps in our deps, so the compile for the `check` happened before these sources got regenerated.
