### PR TITLE
Fix clearX() methods mutating the underlying storage instead of uniquing

### DIFF
--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -123,14 +123,15 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
 
         guard hasFieldPresence else { return }
 
-        let storagePrefix = usesHeapStorage ? "_storage." : "self."
+        let immutableStoragePrefix = usesHeapStorage ? "_storage." : "self."
         p.print(
             "/// Returns true if `\(swiftName)` has been explicitly set.\n",
-            "\(visibility)var \(swiftHasName): Bool {return \(storagePrefix)\(underscoreSwiftName) != nil}\n")
+            "\(visibility)var \(swiftHasName): Bool {return \(immutableStoragePrefix)\(underscoreSwiftName) != nil}\n")
 
+        let mutableStoragePrefix = usesHeapStorage ? "_uniqueStorage()." : "self."
         p.print(
             "/// Clears the value of `\(swiftName)`. Subsequent reads from it will return its default value.\n",
-            "\(visibility)mutating func \(swiftClearName)() {\(storagePrefix)\(underscoreSwiftName) = nil}\n")
+            "\(visibility)mutating func \(swiftClearName)() {\(mutableStoragePrefix)\(underscoreSwiftName) = nil}\n")
     }
 
     func generateStorageClassClone(printer p: inout CodePrinter) {


### PR DESCRIPTION
The generated `clearX()` methods do not correctly COW unique the underlying storage for heap-backed types.

Consider:

```
var model1: MyProto
model1.nestedMessage = …
print(1, model1.nestedMessage)

var model2 = model1
model2.clearNestedMessage()
print(model1.nestedMessage)
print(model2.nestedMessage)
```

Before:

```
1, Module.MyProto.NestedMessage:
a: "a"
b: "b"
c: "c"

2, Module.MyProto.NestedMessage:

3, Module.MyProto.NestedMessage:

 ```

After:

```
1, Module.MyProto.NestedMessage:
a: "a"
b: "b"
c: "c"

2, Module.MyProto.NestedMessage:
a: "a"
b: "b"
c: "c"

3, Module.MyProto.NestedMessage:

 ```