### PR TITLE
Update github references.

### DIFF
--- a/Documentation/CONFORMANCE_TESTS.md
+++ b/Documentation/CONFORMANCE_TESTS.md
@@ -18,7 +18,7 @@ these tests regularly.
 
 The conformance test suite requires Swift 3.1, standard command-line
 tools such as make and awk, and a full source checkout of
-[Google's protobuf project](https://github.com/google/protobuf).
+[Google's protobuf project](https://github.com/protocolbuffers/protobuf).
 
 The Makefile assumes by default that the protobuf project
 is checked out in an adjacent directory.

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -25,7 +25,7 @@ To use Swift with Protocol buffers, you'll need:
   with the latest version of Xcode.
 
 * Google's protoc compiler.  You can get recent versions from
-  [Google's github repository](https://github.com/google/protobuf).
+  [Google's github repository](https://github.com/protocolbuffers/protobuf).
 
 ### Build and Install
 

--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,7 @@ regenerate-conformance-protos: build ${PROTOC_GEN_SWIFT}
 check-for-protobuf-checkout:
 	@if [ ! -d "${GOOGLE_PROTOBUF_CHECKOUT}/src/google/protobuf" ]; then \
 	  echo "ERROR: ${GOOGLE_PROTOBUF_CHECKOUT} does not appear to be a checkout of"; \
-	  echo "ERROR:   github.com/google/protobuf. Please check it out or set"; \
+	  echo "ERROR:   github.com/protocolbuffers/protobuf. Please check it out or set"; \
 	  echo "ERROR:   GOOGLE_PROTOBUF_CHECKOUT to point to a checkout."; \
 	  exit 1; \
 	fi

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -43,8 +43,8 @@ fi
 # Directory containing this script
 readonly script_dir="."
 
-# Change this if your checkout of github.com/google/protobuf is in a different
-# location.
+# Change this if your checkout of github.com/protocolbuffers/protobuf is in a
+# different location.
 readonly GOOGLE_PROTOBUF_CHECKOUT=${GOOGLE_PROTOBUF_CHECKOUT:-"$script_dir/../../protobuf"}
 
 function usage() {

--- a/Protos/unittest_swift_naming.proto
+++ b/Protos/unittest_swift_naming.proto
@@ -910,9 +910,9 @@ enum EnumFieldNames2 {
 
     // protoc no longer allows enum naming that would differ only in underscores.
     // Initial commit:
-    //   https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
+    //   https://github.com/protocolbuffers/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
     // Change keep proto3 as error, but proto2 to just a warning:
-    //   https://github.com/google/protobuf/pull/2204
+    //   https://github.com/protocolbuffers/protobuf/pull/2204
     // So this is in a second enum so it won't cause issues with the '_' one;
     // but still ensure things generator correctly.
     __ = 1065;

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The SwiftProtobuf tests need a version of protoc which supports the
 `swift_prefix` option (introduced in protoc 3.2.0).
 It may work with earlier versions of protoc.
 You can get recent versions from
-[Google's github repository](https://github.com/google/protobuf).
+[Google's github repository](https://github.com/protocolbuffers/protobuf).
 
 ## Building and Installing the Code Generator Plugin
 

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -697,9 +697,9 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum {
 
   /// protoc no longer allows enum naming that would differ only in underscores.
   /// Initial commit:
-  ///   https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
+  ///   https://github.com/protocolbuffers/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
   /// Change keep proto3 as error, but proto2 to just a warning:
-  ///   https://github.com/google/protobuf/pull/2204
+  ///   https://github.com/protocolbuffers/protobuf/pull/2204
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
   case ____ // = 1065

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -65,8 +65,9 @@ class FileGenerator {
         //
         // The C++ FileDescriptor::GetSourceLocation(), says the location for
         // the file is an empty path. That never seems to have comments on it.
-        // https://github.com/google/protobuf/issues/2249 opened to figure out
-        // the right way to do this since the syntax entry is optional.
+        // https://github.com/protocolbuffers/protobuf/issues/2249 opened to
+        // figure out the right way to do this since the syntax entry is
+        // optional.
         let syntaxPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax)
         if let syntaxLocation = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
           let comments = syntaxLocation.asSourceComment(commentPrefix: "///",

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -67,7 +67,7 @@ class Test_Struct: XCTestCase, PBTestHelpers {
         do {
             let c1 = try ProtobufTestMessages_Proto3_TestAllTypesProto3(jsonString:"{\"optionalStruct\":null}")
             // null here decodes to an empty field.
-            // See github.com/google/protobuf Issue #1327
+            // See github.com/protocolbuffers/protobuf Issue #1327
             XCTAssertEqual(try c1.jsonString(), "{}")
         } catch let e {
             XCTFail("Didn't decode c1: \(e)")

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -697,9 +697,9 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum {
 
   /// protoc no longer allows enum naming that would differ only in underscores.
   /// Initial commit:
-  ///   https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
+  ///   https://github.com/protocolbuffers/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
   /// Change keep proto3 as error, but proto2 to just a warning:
-  ///   https://github.com/google/protobuf/pull/2204
+  ///   https://github.com/protocolbuffers/protobuf/pull/2204
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
   case ____ // = 1065


### PR DESCRIPTION
github.com/google/protobuf is now github.com/protocolbuffers/protobuf,
update all the references. There are redirects on github when this
happens, but seems better to point folks at the correct thing to
avoid confusion.