### PR TITLE
Fix Json map encoding for float, sint, fixed, sfixed

### DIFF
--- a/Sources/SwiftProtobuf/JSONMapEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONMapEncodingVisitor.swift
@@ -42,6 +42,13 @@ internal struct JSONMapEncodingVisitor: SelectiveVisitor {
       encoder.append(staticText: ":")
   }
 
+  mutating func visitSingularFloatField(value: Float, fieldNumber: Int) throws {
+      // Doubles/Floats can never be map keys, only values
+      assert(fieldNumber == 2)
+      startValue()
+      encoder.putFloatValue(value: value)
+  }
+
   mutating func visitSingularDoubleField(value: Double, fieldNumber: Int) throws {
       // Doubles/Floats can never be map keys, only values
       assert(fieldNumber == 2)
@@ -86,6 +93,30 @@ internal struct JSONMapEncodingVisitor: SelectiveVisitor {
           startValue()
       }
       encoder.putUInt64(value: value)
+  }
+
+  mutating func visitSingularSInt32Field(value: Int32, fieldNumber: Int) throws {
+      try visitSingularInt32Field(value: value, fieldNumber: fieldNumber)
+  }
+
+  mutating func visitSingularSInt64Field(value: Int64, fieldNumber: Int) throws {
+      try visitSingularInt64Field(value: value, fieldNumber: fieldNumber)
+  }
+
+  mutating func visitSingularFixed32Field(value: UInt32, fieldNumber: Int) throws {
+      try visitSingularUInt32Field(value: value, fieldNumber: fieldNumber)
+  }
+
+  mutating func visitSingularFixed64Field(value: UInt64, fieldNumber: Int) throws {
+      try visitSingularUInt64Field(value: value, fieldNumber: fieldNumber)
+  }
+
+  mutating func visitSingularSFixed32Field(value: Int32, fieldNumber: Int) throws {
+      try visitSingularInt32Field(value: value, fieldNumber: fieldNumber)
+  }
+
+  mutating func visitSingularSFixed64Field(value: Int64, fieldNumber: Int) throws {
+      try visitSingularInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   mutating func visitSingularBoolField(value: Bool, fieldNumber: Int) throws {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -699,11 +699,22 @@ extension Test_MapFields_Access_Proto3 {
 extension Test_Map_JSON {
     static var allTests = [
         ("testMapInt32Int32", testMapInt32Int32),
+        ("testMapInt64Int64", testMapInt64Int64),
+        ("testMapUInt32UInt32", testMapUInt32UInt32),
+        ("testMapUInt64UInt64", testMapUInt64UInt64),
+        ("testMapSInt32SInt32", testMapSInt32SInt32),
+        ("testMapSInt64SInt64", testMapSInt64SInt64),
+        ("testFixed32Fixed32", testFixed32Fixed32),
+        ("testFixed64Fixed64", testFixed64Fixed64),
+        ("testSFixed32SFixed32", testSFixed32SFixed32),
+        ("testSFixed64SFixed64", testSFixed64SFixed64),
+        ("test_mapInt32Float", test_mapInt32Float),
+        ("test_mapInt32Double", test_mapInt32Double),
+        ("test_mapBoolBool", test_mapBoolBool),
         ("testMapStringString", testMapStringString),
         ("testMapInt32Bytes", testMapInt32Bytes),
         ("testMapInt32Enum", testMapInt32Enum),
-        ("testMapInt32Message", testMapInt32Message),
-        ("test_mapBoolBool", test_mapBoolBool)
+        ("testMapInt32Message", testMapInt32Message)
     ]
 }
 

--- a/Tests/SwiftProtobufTests/Test_Map_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_Map_JSON.swift
@@ -57,6 +57,92 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"mapInt32Int32\":{\"1\":2}} X")
     }
 
+    func testMapInt64Int64() throws {
+        assertJSONEncode("{\"mapInt64Int64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
+            o.mapInt64Int64 = [1:2]
+        }
+    }
+
+    func testMapUInt32UInt32() throws {
+        assertJSONEncode("{\"mapUint32Uint32\":{\"1\":2}}") {(o: inout MessageTestType) in
+            o.mapUint32Uint32 = [1:2]
+        }
+    }
+
+    func testMapUInt64UInt64() throws {
+        assertJSONEncode("{\"mapUint64Uint64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
+            o.mapUint64Uint64 = [1:2]
+        }
+    }
+
+    func testMapSInt32SInt32() throws {
+        assertJSONEncode("{\"mapSint32Sint32\":{\"1\":2}}") {(o: inout MessageTestType) in
+            o.mapSint32Sint32 = [1:2]
+        }
+    }
+
+    func testMapSInt64SInt64() throws {
+        assertJSONEncode("{\"mapSint64Sint64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
+            o.mapSint64Sint64 = [1:2]
+        }
+    }
+
+    func testFixed32Fixed32() throws {
+        assertJSONEncode("{\"mapFixed32Fixed32\":{\"1\":2}}") {(o: inout MessageTestType) in
+            o.mapFixed32Fixed32 = [1:2]
+        }
+    }
+
+    func testFixed64Fixed64() throws {
+        assertJSONEncode("{\"mapFixed64Fixed64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
+            o.mapFixed64Fixed64 = [1:2]
+        }
+    }
+
+    func testSFixed32SFixed32() throws {
+        assertJSONEncode("{\"mapSfixed32Sfixed32\":{\"1\":2}}") {(o: inout MessageTestType) in
+            o.mapSfixed32Sfixed32 = [1:2]
+        }
+    }
+
+    func testSFixed64SFixed64() throws {
+        assertJSONEncode("{\"mapSfixed64Sfixed64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
+            o.mapSfixed64Sfixed64 = [1:2]
+        }
+    }
+
+    func test_mapInt32Float() {
+        assertJSONDecodeSucceeds("{\"mapInt32Float\":{\"1\":1}}") {
+            $0.mapInt32Float == [1: Float(1.0)]
+        }
+
+        assertJSONEncode("{\"mapInt32Float\":{\"1\":1}}") {
+            $0.mapInt32Float[1] = Float(1.0)
+        }
+    }
+
+    func test_mapInt32Double() {
+        assertJSONDecodeSucceeds("{\"mapInt32Double\":{\"1\":1}}") {
+            $0.mapInt32Double == [1: Double(1.0)]
+        }
+
+        assertJSONEncode("{\"mapInt32Double\":{\"1\":1}}") {
+            $0.mapInt32Double[1] = Double(1.0)
+        }
+
+    }
+
+    func test_mapBoolBool() {
+        assertDecodeSucceeds([106, 4, 8, 0, 16, 0]) {
+            $0.mapBoolBool == [false: false]
+        }
+        assertJSONDecodeSucceeds("{\"mapBoolBool\": {\"true\": true, \"false\": false}}") {
+            $0.mapBoolBool == [true: true, false: false]
+        }
+        assertJSONDecodeFails("{\"mapBoolBool\": {true: true}}")
+        assertJSONDecodeFails("{\"mapBoolBool\": {false: false}}")
+    }
+
     func testMapStringString() throws {
         assertJSONEncode("{\"mapStringString\":{\"3\":\"4\"}}") {(o: inout MessageTestType) in
             o.mapStringString = ["3":"4"]
@@ -110,16 +196,5 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
             sub8.c = 8
             return $0.mapInt32ForeignMessage == [7:sub7, 8:sub8]
         }
-    }
-
-    func test_mapBoolBool() {
-        assertDecodeSucceeds([106, 4, 8, 0, 16, 0]) {
-            $0.mapBoolBool == [false: false]
-        }
-        assertJSONDecodeSucceeds("{\"mapBoolBool\": {\"true\": true, \"false\": false}}") {
-            $0.mapBoolBool == [true: true, false: false]
-        }
-        assertJSONDecodeFails("{\"mapBoolBool\": {true: true}}")
-        assertJSONDecodeFails("{\"mapBoolBool\": {false: false}}")
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Map_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_Map_JSON.swift
@@ -41,6 +41,18 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
         // Decode should work same regardless of order
         assertJSONDecodeSucceeds("{\"mapInt32Int32\":{\"1\":2, \"3\":4}}") {$0.mapInt32Int32 == [1:2, 3:4]}
         assertJSONDecodeSucceeds("{\"mapInt32Int32\":{\"3\":4,\"1\":2}}") {$0.mapInt32Int32 == [1:2, 3:4]}
+        // In range values succeed
+        assertJSONDecodeSucceeds("{\"mapInt32Int32\":{\"2147483647\":2147483647}}") {
+            $0.mapInt32Int32 == [2147483647:2147483647]
+        }
+        assertJSONDecodeSucceeds("{\"mapInt32Int32\":{\"-2147483648\":-2147483648}}") {
+            $0.mapInt32Int32 == [-2147483648:-2147483648]
+        }
+        // Out of range values fail
+        assertJSONDecodeFails("{\"mapInt32Int32\":{\"2147483647\":2147483648}}")
+        assertJSONDecodeFails("{\"mapInt32Int32\":{\"2147483648\":2147483647}}")
+        assertJSONDecodeFails("{\"mapInt32Int32\":{\"-2147483649\":2147483647}}")
+        assertJSONDecodeFails("{\"mapInt32Int32\":{\"2147483647\":-2147483649}}")
         // JSON RFC does not allow trailing comma
         assertJSONDecodeFails("{\"mapInt32Int32\":{\"3\":4,\"1\":2,}}")
         // Int values should support being quoted or unquoted
@@ -61,11 +73,24 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
         assertJSONEncode("{\"mapInt64Int64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
             o.mapInt64Int64 = [1:2]
         }
+        assertJSONEncode("{\"mapInt64Int64\":{\"9223372036854775807\":\"-9223372036854775808\"}}") {(o: inout MessageTestType) in
+            o.mapInt64Int64 = [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeSucceeds("{\"mapInt64Int64\":{\"9223372036854775807\":-9223372036854775808}}") {
+            $0.mapInt64Int64 == [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeFails("{\"mapInt64Int64\":{\"9223372036854775807\":9223372036854775808}}")
     }
 
     func testMapUInt32UInt32() throws {
         assertJSONEncode("{\"mapUint32Uint32\":{\"1\":2}}") {(o: inout MessageTestType) in
             o.mapUint32Uint32 = [1:2]
+        }
+        assertJSONDecodeFails("{\"mapUint32Uint32\":{\"1\":-2}}")
+        assertJSONDecodeFails("{\"mapUint32Uint32\":{\"-1\":2}}")
+        assertJSONDecodeFails("{\"mapUint32Uint32\":{1:2}}")
+        assertJSONDecodeSucceeds("{\"mapUint32Uint32\":{\"1\":\"2\"}}") {
+            $0.mapUint32Uint32 == [1:2]
         }
     }
 
@@ -73,42 +98,112 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
         assertJSONEncode("{\"mapUint64Uint64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
             o.mapUint64Uint64 = [1:2]
         }
+        assertJSONEncode("{\"mapUint64Uint64\":{\"1\":\"18446744073709551615\"}}") {(o: inout MessageTestType) in
+            o.mapUint64Uint64 = [1:18446744073709551615 as UInt64]
+        }
+        assertJSONDecodeSucceeds("{\"mapUint64Uint64\":{\"1\":18446744073709551615}}") {
+            $0.mapUint64Uint64 == [1:18446744073709551615 as UInt64]
+        }
+        assertJSONDecodeFails("{\"mapUint64Uint64\":{\"1\":\"18446744073709551616\"}}")
+        assertJSONDecodeFails("{\"mapUint64Uint64\":{1:\"18446744073709551615\"}}")
     }
 
     func testMapSInt32SInt32() throws {
         assertJSONEncode("{\"mapSint32Sint32\":{\"1\":2}}") {(o: inout MessageTestType) in
             o.mapSint32Sint32 = [1:2]
         }
+        assertJSONDecodeSucceeds("{\"mapSint32Sint32\":{\"1\":\"-2\"}}") {
+            $0.mapSint32Sint32 == [1:-2]
+        }
+        assertJSONDecodeFails("{\"mapSint32Sint32\":{1:-2}}")
+        // In range values succeed
+        assertJSONDecodeSucceeds("{\"mapSint32Sint32\":{\"2147483647\":2147483647}}") {
+            $0.mapSint32Sint32 == [2147483647:2147483647]
+        }
+        assertJSONDecodeSucceeds("{\"mapSint32Sint32\":{\"-2147483648\":-2147483648}}") {
+            $0.mapSint32Sint32 == [-2147483648:-2147483648]
+        }
+        // Out of range values fail
+        assertJSONDecodeFails("{\"mapSint32Sint32\":{\"2147483647\":2147483648}}")
+        assertJSONDecodeFails("{\"mapSint32Sint32\":{\"2147483648\":2147483647}}")
+        assertJSONDecodeFails("{\"mapSint32Sint32\":{\"-2147483649\":2147483647}}")
+        assertJSONDecodeFails("{\"mapSint32Sint32\":{\"2147483647\":-2147483649}}")
     }
 
     func testMapSInt64SInt64() throws {
         assertJSONEncode("{\"mapSint64Sint64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
             o.mapSint64Sint64 = [1:2]
         }
+        assertJSONEncode("{\"mapSint64Sint64\":{\"9223372036854775807\":\"-9223372036854775808\"}}") {(o: inout MessageTestType) in
+            o.mapSint64Sint64 = [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeSucceeds("{\"mapSint64Sint64\":{\"9223372036854775807\":-9223372036854775808}}") {
+            $0.mapSint64Sint64 == [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeFails("{\"mapSint64Sint64\":{\"9223372036854775807\":9223372036854775808}}")
     }
 
     func testFixed32Fixed32() throws {
         assertJSONEncode("{\"mapFixed32Fixed32\":{\"1\":2}}") {(o: inout MessageTestType) in
             o.mapFixed32Fixed32 = [1:2]
         }
+        assertJSONEncode("{\"mapFixed32Fixed32\":{\"0\":0}}") {(o: inout MessageTestType) in
+            o.mapFixed32Fixed32 = [0:0]
+        }
+        // In range values succeed
+        assertJSONDecodeSucceeds("{\"mapFixed32Fixed32\":{\"4294967295\":4294967295}}") {
+            $0.mapFixed32Fixed32 == [4294967295:4294967295]
+        }
+        // Out of range values fail
+        assertJSONDecodeFails("{\"mapFixed32Fixed32\":{\"4294967295\":4294967296}}")
+        assertJSONDecodeFails("{\"mapFixed32Fixed32\":{\"4294967296\":4294967295}}")
+        assertJSONDecodeFails("{\"mapFixed32Fixed32\":{\"-1\":4294967295}}")
+        assertJSONDecodeFails("{\"mapFixed32Fixed32\":{\"4294967295\":-1}}")
     }
 
     func testFixed64Fixed64() throws {
         assertJSONEncode("{\"mapFixed64Fixed64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
             o.mapFixed64Fixed64 = [1:2]
         }
+        assertJSONEncode("{\"mapFixed64Fixed64\":{\"1\":\"18446744073709551615\"}}") {(o: inout MessageTestType) in
+            o.mapFixed64Fixed64 = [1:18446744073709551615 as UInt64]
+        }
+        assertJSONDecodeSucceeds("{\"mapFixed64Fixed64\":{\"1\":18446744073709551615}}") {
+            $0.mapFixed64Fixed64 == [1:18446744073709551615 as UInt64]
+        }
+        assertJSONDecodeFails("{\"mapFixed64Fixed64\":{\"1\":\"18446744073709551616\"}}")
+        assertJSONDecodeFails("{\"mapFixed64Fixed64\":{1:\"18446744073709551615\"}}")
     }
 
     func testSFixed32SFixed32() throws {
         assertJSONEncode("{\"mapSfixed32Sfixed32\":{\"1\":2}}") {(o: inout MessageTestType) in
             o.mapSfixed32Sfixed32 = [1:2]
         }
+        // In range values succeed
+        assertJSONDecodeSucceeds("{\"mapSfixed32Sfixed32\":{\"2147483647\":2147483647}}") {
+            $0.mapSfixed32Sfixed32 == [2147483647:2147483647]
+        }
+        assertJSONDecodeSucceeds("{\"mapSfixed32Sfixed32\":{\"-2147483648\":-2147483648}}") {
+            $0.mapSfixed32Sfixed32 == [-2147483648:-2147483648]
+        }
+        // Out of range values fail
+        assertJSONDecodeFails("{\"mapSfixed32Sfixed32\":{\"2147483647\":2147483648}}")
+        assertJSONDecodeFails("{\"mapSfixed32Sfixed32\":{\"2147483648\":2147483647}}")
+        assertJSONDecodeFails("{\"mapSfixed32Sfixed32\":{\"-2147483649\":2147483647}}")
+        assertJSONDecodeFails("{\"mapSfixed32Sfixed32\":{\"2147483647\":-2147483649}}")
     }
 
     func testSFixed64SFixed64() throws {
         assertJSONEncode("{\"mapSfixed64Sfixed64\":{\"1\":\"2\"}}") {(o: inout MessageTestType) in
             o.mapSfixed64Sfixed64 = [1:2]
         }
+        assertJSONEncode("{\"mapSfixed64Sfixed64\":{\"9223372036854775807\":\"-9223372036854775808\"}}") {(o: inout MessageTestType) in
+            o.mapSfixed64Sfixed64 = [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeSucceeds("{\"mapSfixed64Sfixed64\":{\"9223372036854775807\":-9223372036854775808}}") {
+            $0.mapSfixed64Sfixed64 == [9223372036854775807: -9223372036854775808]
+        }
+        assertJSONDecodeFails("{\"mapSfixed64Sfixed64\":{\"9223372036854775807\":9223372036854775808}}")
     }
 
     func test_mapInt32Float() {
@@ -118,6 +213,10 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
 
         assertJSONEncode("{\"mapInt32Float\":{\"1\":1}}") {
             $0.mapInt32Float[1] = Float(1.0)
+        }
+
+        assertJSONDecodeSucceeds("{\"mapInt32Float\":{\"1\":3.141592}}") {
+            $0.mapInt32Float[1] == 3.141592 as Float
         }
     }
 
@@ -130,6 +229,9 @@ class Test_Map_JSON: XCTestCase, PBTestHelpers {
             $0.mapInt32Double[1] = Double(1.0)
         }
 
+        assertJSONDecodeSucceeds("{\"mapInt32Double\":{\"1\":3.141592}}") {
+            $0.mapInt32Double[1] == 3.141592
+        }
     }
 
     func test_mapBoolBool() {


### PR DESCRIPTION
Due to a lack of tests, some recent refactoring broke the JSON map
encoding for float, double, sint, fixed, and sfixed data types.

This adds the missing tests and fixes the implementation.

Thanks to Gianluca Guida for pointing out the Float issue and proposing a fix.
