### PR TITLE
Be consistent about access level vs. static decls.

### DIFF
--- a/DevTools/LibraryVersions.py
+++ b/DevTools/LibraryVersions.py
@@ -42,9 +42,9 @@ def ValidateFiles():
 
   # Test Sources/SwiftProtobuf/Version.swift
   version_swift_content = open(_VERSION_SWIFT_PATH).read()
-  major_line = 'static public let major = %s\n' % major
-  minor_line = 'static public let minor = %s\n' % minor
-  revision_line = 'static public let revision = %s\n' % revision
+  major_line = 'public static let major = %s\n' % major
+  minor_line = 'public static let minor = %s\n' % minor
+  revision_line = 'public static let revision = %s\n' % revision
   had_major = major_line in version_swift_content
   had_minor = minor_line in version_swift_content
   had_revision = revision_line in version_swift_content
@@ -71,14 +71,14 @@ def UpdateFiles(version_string):
 
   # Update Sources/SwiftProtobuf/Version.swift
   version_swift_content = open(_VERSION_SWIFT_PATH).read()
-  version_swift_content = re.sub(r'static public let major = \d+\n',
-                                 'static public let major = %s\n' % major,
+  version_swift_content = re.sub(r'public static let major = \d+\n',
+                                 'public static let major = %s\n' % major,
                                  version_swift_content)
-  version_swift_content = re.sub(r'static public let minor = \d+\n',
-                                 'static public let minor = %s\n' % minor,
+  version_swift_content = re.sub(r'public static let minor = \d+\n',
+                                 'public static let minor = %s\n' % minor,
                                  version_swift_content)
-  version_swift_content = re.sub(r'static public let revision = \d+\n',
-                                 'static public let revision = %s\n' % revision,
+  version_swift_content = re.sub(r'public static let revision = \d+\n',
+                                 'public static let revision = %s\n' % revision,
                                  version_swift_content)
   open(_VERSION_SWIFT_PATH, 'w').write(version_swift_content)
 

--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -60,7 +60,7 @@ public struct Example: SwiftProtobuf.Message {
   //    $0.field1 = 7
   //    $0.field2 = ["foo", "bar"]
   // }
-  static public with(_ configurator: (inout Example) -> ());
+  public static with(_ configurator: (inout Example) -> ());
 
   // Messages can be serialized or deserialized to Data objects
   // using protobuf binary format.

--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -68,7 +68,7 @@ public protocol MapValueType: FieldType {
 ///
 public struct ProtobufFloat: FieldType, MapValueType {
     public typealias BaseType = Float
-    static public var proto3DefaultValue: Float {return 0.0}
+    public static var proto3DefaultValue: Float {return 0.0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularFloatField(value: &value)
     }
@@ -91,7 +91,7 @@ public struct ProtobufFloat: FieldType, MapValueType {
 ///
 public struct ProtobufDouble: FieldType, MapValueType {
     public typealias BaseType = Double
-    static public var proto3DefaultValue: Double {return 0.0}
+    public static var proto3DefaultValue: Double {return 0.0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularDoubleField(value: &value)
     }
@@ -114,7 +114,7 @@ public struct ProtobufDouble: FieldType, MapValueType {
 ///
 public struct ProtobufInt32: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int32
-    static public var proto3DefaultValue: Int32 {return 0}
+    public static var proto3DefaultValue: Int32 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularInt32Field(value: &value)
     }
@@ -138,7 +138,7 @@ public struct ProtobufInt32: FieldType, MapKeyType, MapValueType {
 
 public struct ProtobufInt64: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int64
-    static public var proto3DefaultValue: Int64 {return 0}
+    public static var proto3DefaultValue: Int64 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularInt64Field(value: &value)
     }
@@ -161,7 +161,7 @@ public struct ProtobufInt64: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufUInt32: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = UInt32
-    static public var proto3DefaultValue: UInt32 {return 0}
+    public static var proto3DefaultValue: UInt32 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularUInt32Field(value: &value)
     }
@@ -185,7 +185,7 @@ public struct ProtobufUInt32: FieldType, MapKeyType, MapValueType {
 
 public struct ProtobufUInt64: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = UInt64
-    static public var proto3DefaultValue: UInt64 {return 0}
+    public static var proto3DefaultValue: UInt64 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularUInt64Field(value: &value)
     }
@@ -208,7 +208,7 @@ public struct ProtobufUInt64: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufSInt32: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int32
-    static public var proto3DefaultValue: Int32 {return 0}
+    public static var proto3DefaultValue: Int32 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularSInt32Field(value: &value)
     }
@@ -232,7 +232,7 @@ public struct ProtobufSInt32: FieldType, MapKeyType, MapValueType {
 
 public struct ProtobufSInt64: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int64
-    static public var proto3DefaultValue: Int64 {return 0}
+    public static var proto3DefaultValue: Int64 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularSInt64Field(value: &value)
     }
@@ -255,7 +255,7 @@ public struct ProtobufSInt64: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufFixed32: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = UInt32
-    static public var proto3DefaultValue: UInt32 {return 0}
+    public static var proto3DefaultValue: UInt32 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularFixed32Field(value: &value)
     }
@@ -278,7 +278,7 @@ public struct ProtobufFixed32: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufFixed64: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = UInt64
-    static public var proto3DefaultValue: UInt64 {return 0}
+    public static var proto3DefaultValue: UInt64 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularFixed64Field(value: &value)
     }
@@ -301,7 +301,7 @@ public struct ProtobufFixed64: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufSFixed32: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int32
-    static public var proto3DefaultValue: Int32 {return 0}
+    public static var proto3DefaultValue: Int32 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularSFixed32Field(value: &value)
     }
@@ -324,7 +324,7 @@ public struct ProtobufSFixed32: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufSFixed64: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Int64
-    static public var proto3DefaultValue: Int64 {return 0}
+    public static var proto3DefaultValue: Int64 {return 0}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularSFixed64Field(value: &value)
     }
@@ -347,7 +347,7 @@ public struct ProtobufSFixed64: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufBool: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = Bool
-    static public var proto3DefaultValue: Bool {return false}
+    public static var proto3DefaultValue: Bool {return false}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularBoolField(value: &value)
     }
@@ -370,7 +370,7 @@ public struct ProtobufBool: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufString: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = String
-    static public var proto3DefaultValue: String {return String()}
+    public static var proto3DefaultValue: String {return String()}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularStringField(value: &value)
     }
@@ -393,7 +393,7 @@ public struct ProtobufString: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufBytes: FieldType, MapValueType {
     public typealias BaseType = Data
-    static public var proto3DefaultValue: Data {return Internal.emptyData}
+    public static var proto3DefaultValue: Data {return Internal.emptyData}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularBytesField(value: &value)
     }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -104,7 +104,7 @@ extension Google_Protobuf_Any {
     ///
     /// Returns: true if the type was registered, false if something
     ///   else was already registered for the messageName.
-    @discardableResult static public func register(messageType: Message.Type) -> Bool {
+    @discardableResult public static func register(messageType: Message.Type) -> Bool {
         let messageTypeName = messageType.protoMessageName
         var result: Bool = false
         serialQueue.sync {
@@ -122,13 +122,13 @@ extension Google_Protobuf_Any {
     }
 
     /// Returns the Message.Type expected for the given type URL.
-    static public func messageType(forTypeURL url: String) -> Message.Type? {
+    public static func messageType(forTypeURL url: String) -> Message.Type? {
       let messageTypeName = typeName(fromURL: url)
       return messageType(forMessageName: messageTypeName)
     }
 
     /// Returns the Message.Type expected for the given proto message name.
-    static public func messageType(forMessageName name: String) -> Message.Type? {
+    public static func messageType(forMessageName name: String) -> Message.Type? {
         var result: Message.Type?
         serialQueue.sync {
             result = knownTypes[name]

--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -17,12 +17,12 @@ import Foundation
 // Expose version information about the library.
 public struct Version {
   /// Major version.
-  static public let major = 1
+  public static let major = 1
   /// Minor version.
-  static public let minor = 2
+  public static let minor = 2
   /// Revision number.
-  static public let revision = 0
+  public static let revision = 0
 
   /// String form of the version number.
-  static public let versionString = "\(major).\(minor).\(revision)"
+  public static let versionString = "\(major).\(minor).\(revision)"
 }


### PR DESCRIPTION
Always put the access level before the `static` in decls.