### PR TITLE
Update SPM Integration Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,16 @@ After copying the `.pb.swift` files into your project, you will need to add the
 [SwiftProtobuf library](https://github.com/apple/swift-protobuf) to your
 project to support the generated code.
 If you are using the Swift Package Manager, add a dependency to your
-`Package.swift` file.  Adjust the `Version()` here to match the `[tag_name]`
-you used to build the plugin above:
+`Package.swift` file and import the `SwiftProtobuf` library into the desired
+targets.  Adjust the `"1.2.0"` here to match the `[tag_name]` you used to build
+the plugin above:
 
 ```swift
 dependencies: [
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.1.0")
+    .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.2.0")),
+],
+targets: [
+    .target(name: "MyTarget", dependencies: ["SwiftProtobuf"]),
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ the plugin above:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.2.0")),
+    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.2.0"),
 ],
 targets: [
     .target(name: "MyTarget", dependencies: ["SwiftProtobuf"]),


### PR DESCRIPTION
- Adds missing instructions to add `SwiftProtobuf` to the target
- Changes the versioning syntax from "from" to "exact"  in order to better match instructions of using the same library version as the generated code
- Updates the outdated "Version()" string from an old version of SPM