### PR TITLE
Swiftpm tweaks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:4.2
+
+// Package.swift
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftProtobuf",
+  products: [
+    .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
+    .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"]),
+    .library(name: "SwiftProtobufPluginLibrary", targets: ["SwiftProtobufPluginLibrary"]),
+  ],
+  targets: [
+    .target(name: "SwiftProtobuf"),
+    .target(name: "SwiftProtobufPluginLibrary",
+            dependencies: ["SwiftProtobuf"]),
+    .target(name: "protoc-gen-swift",
+            dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"]),
+    .target(name: "Conformance",
+            dependencies: ["SwiftProtobuf"]),
+    .testTarget(name: "SwiftProtobufTests",
+                dependencies: ["SwiftProtobuf"]),
+    .testTarget(name: "SwiftProtobufPluginLibraryTests",
+                dependencies: ["SwiftProtobufPluginLibrary"]),
+  ],
+  swiftLanguageVersions: [.v3, .v4, .v4_2]
+)

--- a/Package@swift-3.swift
+++ b/Package@swift-3.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:3.0
+
 // Package.swift - description
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors


### PR DESCRIPTION
This is trying to get things into better shape for Swift 5.

@dierksen found that the existing release fail to build because the `Package.swift` we have ends up being assumed to be version 3.  But trunk [SwiftPM already dropped support for that](https://forums.swift.org/t/removing-packagedescription-api-v3-master-branch/14109).

Assuming the ideas [RFC: Tools version with version-specific manifests](https://forums.swift.org/t/rfc-tools-version-with-version-specific-manifests/18224) happens, then we should be generally good with this change.

So factoring in the advice from [swiftLanguageVersions best practices for libraries](https://forums.swift.org/t/swiftlanguageversions-best-practices-for-libraries/18443), I believe the path forward with this change is:

1. Remove our `Swift@swift-#.swift` files as we drop support for those older versions.
2. Only add `.version("#.#")` values to `Package.swift` so we don't require a newer version to understand the non string values.
3. Only create a `Swift@swift-#.swift` when something new gets added to SwiftPM that we want to take advantage of.  And when that happens, the current `Package.swift` would get renamed to capture a version number and the `Package.swift` would get its tools version updated to where the new feature landed that we need to take advantage of.
