### PR TITLE
Document Swift 5 support in the Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,5 +31,5 @@ let package = Package(
     .testTarget(name: "SwiftProtobufPluginLibraryTests",
                 dependencies: ["SwiftProtobufPluginLibrary"]),
   ],
-  swiftLanguageVersions: [.v3, .v4, .v4_2]
+  swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
 )


### PR DESCRIPTION
Per "swiftLanguageVersions best practices for libraries"
(https://forums.swift.org/t/swiftlanguageversions-best-practices-for-libraries/18443),
using the string form should allow us to eventually just have a Package.swift and
not need to do versioning of the file again until there is some new SwiftPM feature
we really need.