### PR TITLE
Correct Swift 4.1 build break

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Array+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Array+Extensions.swift
@@ -36,8 +36,7 @@ extension Array {
   }
 }
 
-#if swift(>=4.2)
-#else  // swift(>=4.2)
+#if !swift(>=4.2)
 extension Array {
   func firstIndex(where predicate: (Element) throws -> Bool) rethrows -> Int? {
     var i = self.startIndex
@@ -50,4 +49,4 @@ extension Array {
     return nil
   }
 }
-#endif  // swift(>=4.2)
+#endif  // !swift(>=4.2)

--- a/Sources/SwiftProtobufPluginLibrary/Array+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Array+Extensions.swift
@@ -35,3 +35,19 @@ extension Array {
     }
   }
 }
+
+#if swift(>=4.2)
+#else  // swift(>=4.2)
+extension Array {
+  func firstIndex(where predicate: (Element) throws -> Bool) rethrows -> Int? {
+    var i = self.startIndex
+    while i < self.endIndex {
+      if try predicate(self[i]) {
+        return i
+      }
+      self.formIndex(after: &i)
+    }
+    return nil
+  }
+}
+#endif  // swift(>=4.2)


### PR DESCRIPTION
It looks like #822 added a call to Array.firstIndex, which was only
added in Swift 4.2. So builds are broken with Swift 4.1. This adds
firstIndex for Swifts prior to 4.2 to fix them.