### PR TITLE
Remove the throwing docs.

### DIFF
--- a/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
@@ -24,7 +24,6 @@ extension Message {
   ///
   /// - Returns: A string containing the text format serialization of the
   ///   message.
-  /// - Throws: `TextFormatEncodingError` if encoding fails.
   public func textFormatString() -> String {
     var visitor = TextFormatEncodingVisitor(message: self)
     if let any = self as? Google_Protobuf_Any {

--- a/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
@@ -29,6 +29,9 @@ extension Message {
     if let any = self as? Google_Protobuf_Any {
       any._storage.textTraverse(visitor: &visitor)
     } else {
+      // Although the general traversal/encoding infrastructure supports
+      // throwing errors (needed for JSON/Binary WKTs support, binary format
+      // missing required fields); TextEncoding never actually does throw.
       try! traverse(visitor: &visitor)
     }
     return visitor.result


### PR DESCRIPTION
The method wasn't marked as throws, and no such error type exists.