### PR TITLE
The empty string is a valid JSON encoding for a FieldMask.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -58,6 +58,8 @@ private func JSONToProto(name: String) -> String? {
 }
 
 private func parseJSONFieldNames(names: String) -> [String]? {
+  // An empty field mask is the empty string (no paths).
+  guard !names.isEmpty else { return [] }
   var fieldNameCount = 0
   var fieldName = String()
   var split = [String]()


### PR DESCRIPTION
protocolbuffers/protobuf#5605 and protocolbuffers/protobuf#4734 have
some of the background.

Fixes #834