### PR TITLE
Accept too-large float values in Text format

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -800,10 +800,7 @@ internal struct TextFormatScanner {
 
     internal mutating func nextFloat() throws -> Float {
         if let d = tryParseFloatString() {
-            let n = Float(d)
-            if n.isFinite {
-                return n
-            }
+            return Float(d)
         }
         if skipOptionalNaN() {
             return Float.nan

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -334,6 +334,15 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatEncode("optional_float: inf\n") {(o: inout MessageTestType) in o.optionalFloat = Float.infinity}
         assertTextFormatEncode("optional_float: -inf\n") {(o: inout MessageTestType) in o.optionalFloat = -Float.infinity}
 
+        assertTextFormatDecodeSucceeds("optional_float: 3.4028235e+39\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == Float.infinity
+        }
+        assertTextFormatDecodeSucceeds("optional_float: -3.4028235e+39\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == -Float.infinity
+        }
+
         let b = Proto3Unittest_TestAllTypes.with {$0.optionalFloat = Float.nan}
         XCTAssertEqual("optional_float: nan\n", b.textFormatString())
 


### PR DESCRIPTION
Swift CI caught this recently:

The protobuf conformance suite recently added tests for
Text format.  One of their tests asserts that Text format
should accept too-large values for `float` fields
(in contrast with JSON, which rejects such values).

Add a new test assertion for this case and change
the TextFormat scanner to truncate large float
values rather than rejecting them.

More history:

The expected behavior changed in protocolbuffers/protobuf#5839 after it was originally committed in protocolbuffers/protobuf#5765

Specifically, see this edit:  https://github.com/protocolbuffers/protobuf/pull/5839/files#diff-892a679c750b4634959c71ca8930c5fc
