### PR TITLE
Swift 5: adopt new Data.withUnsafeBytes API

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -55,14 +55,20 @@ public enum BinaryDelimited {
     let serialized = try message.serializedData(partial: partial)
     let totalSize = Varint.encodedSize(of: UInt64(serialized.count)) + serialized.count
     var data = Data(count: totalSize)
-    data.withUnsafeMutableBytes { (pointer: UnsafeMutablePointer<UInt8>) in
-      var encoder = BinaryEncoder(forWritingInto: pointer)
-      encoder.putBytesValue(value: serialized)
+    data.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
+      if let baseAddress = body.baseAddress, body.count > 0 {
+        let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+        var encoder = BinaryEncoder(forWritingInto: pointer)
+        encoder.putBytesValue(value: serialized)
+      }
     }
 
     var written: Int = 0
-    data.withUnsafeBytes { (pointer: UnsafePointer<UInt8>) in
-      written = stream.write(pointer, maxLength: totalSize)
+    data.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+      if let baseAddress = body.baseAddress, body.count > 0 {
+        let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+        written = stream.write(pointer, maxLength: totalSize)
+      }
     }
 
     if written != totalSize {
@@ -154,8 +160,11 @@ public enum BinaryDelimited {
 
     var data = Data(count: length)
     var bytesRead: Int = 0
-    data.withUnsafeMutableBytes { (pointer: UnsafeMutablePointer<UInt8>) in
-      bytesRead = stream.read(pointer, maxLength: length)
+    data.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
+      if let baseAddress = body.baseAddress, body.count > 0 {
+        let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+        bytesRead = stream.read(pointer, maxLength: length)
+      }
     }
 
     if bytesRead != length {

--- a/Sources/SwiftProtobuf/Data+Extensions.swift
+++ b/Sources/SwiftProtobuf/Data+Extensions.swift
@@ -1,0 +1,33 @@
+// Sources/SwiftProtobuf/Data+Extensions.swift - Extension exposing new Data API
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Extension exposing new Data API to Swift versions < 5.0.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+#if !swift(>=5.0)
+internal extension Data {
+    func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
+        let c = count
+        return try withUnsafeBytes { (p: UnsafePointer<UInt8>) throws -> T in
+            try body(UnsafeRawBufferPointer(start: p, count: c))
+        }
+    }
+
+    mutating func withUnsafeMutableBytes<T>(_ body: (UnsafeMutableRawBufferPointer) throws -> T) rethrows -> T {
+        let c = count
+        return try withUnsafeMutableBytes { (p: UnsafeMutablePointer<UInt8>) throws -> T in
+            try body(UnsafeMutableRawBufferPointer(start: p, count: c))
+        }
+    }
+}
+#endif

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -66,15 +66,19 @@ extension Google_Protobuf_Any {
     self.init()
     if !textFormatString.isEmpty {
       if let data = textFormatString.data(using: String.Encoding.utf8) {
-        try data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
-          var textDecoder = try TextFormatDecoder(
-            messageType: Google_Protobuf_Any.self,
-            utf8Pointer: bytes,
-            count: data.count,
-            extensions: extensions)
-          try decodeTextFormat(decoder: &textDecoder)
-          if !textDecoder.complete {
-            throw TextFormatDecodingError.trailingGarbage
+        try data.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+          if let baseAddress = body.baseAddress, body.count > 0 {
+            let bytes = baseAddress.assumingMemoryBound(to: UInt8.self)
+
+            var textDecoder = try TextFormatDecoder(
+              messageType: Google_Protobuf_Any.self,
+              utf8Pointer: bytes,
+              count: body.count,
+              extensions: extensions)
+            try decodeTextFormat(decoder: &textDecoder)
+            if !textDecoder.complete {
+              throw TextFormatDecodingError.trailingGarbage
+            }
           }
         }
       }

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -333,10 +333,13 @@ internal struct JSONEncoder {
     internal mutating func putBytesValue(value: Data) {
         data.append(asciiDoubleQuote)
         if value.count > 0 {
-            value.withUnsafeBytes { (p: UnsafePointer<UInt8>) in
+            value.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+              if let baseAddress = body.baseAddress, body.count > 0 {
+                let p = baseAddress.assumingMemoryBound(to: UInt8.self)
+
                 var t: Int = 0
                 var bytesInGroup: Int = 0
-                for i in 0..<value.count {
+                for i in 0..<body.count {
                     if bytesInGroup == 3 {
                         data.append(base64Digits[(t >> 18) & 63])
                         data.append(base64Digits[(t >> 12) & 63])
@@ -369,6 +372,7 @@ internal struct JSONEncoder {
                 default:
                     break
                 }
+              }
             }
         }
         data.append(asciiDoubleQuote)

--- a/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
@@ -91,14 +91,19 @@ extension Message {
     fromJSONUTF8Data jsonUTF8Data: Data,
     options: JSONDecodingOptions = JSONDecodingOptions()
   ) throws -> [Self] {
-    return try jsonUTF8Data.withUnsafeBytes { (bytes:UnsafePointer<UInt8>) in
+    return try jsonUTF8Data.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
       var array = [Self]()
-      let buffer = UnsafeBufferPointer(start: bytes, count: jsonUTF8Data.count)
-      var decoder = JSONDecoder(source: buffer, options: options)
-      try decoder.decodeRepeatedMessageField(value: &array)
-      if !decoder.scanner.complete {
-        throw JSONDecodingError.trailingGarbage
+
+      if let baseAddress = body.baseAddress, body.count > 0 {
+        let bytes = baseAddress.assumingMemoryBound(to: UInt8.self)
+        let buffer = UnsafeBufferPointer(start: bytes, count: body.count)
+        var decoder = JSONDecoder(source: buffer, options: options)
+        try decoder.decodeRepeatedMessageField(value: &array)
+        if !decoder.scanner.complete {
+          throw JSONDecodingError.trailingGarbage
+        }
       }
+
       return array
     }
   }

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -263,36 +263,40 @@ internal struct TextFormatEncoder {
 
     mutating func putBytesValue(value: Data) {
         data.append(asciiDoubleQuote)
-        value.withUnsafeBytes { (p: UnsafePointer<UInt8>) in
-            for i in 0..<value.count {
-                let c = p[i]
-                switch c {
-                // Special two-byte escapes
-                case 8:
-                    append(staticText: "\\b")
-                case 9:
-                    append(staticText: "\\t")
-                case 10:
-                    append(staticText: "\\n")
-                case 11:
-                    append(staticText: "\\v")
-                case 12:
-                    append(staticText: "\\f")
-                case 13:
-                    append(staticText: "\\r")
-                case 34:
-                    append(staticText: "\\\"")
-                case 92:
-                    append(staticText: "\\\\")
-                case 32...126:  // printable ASCII
-                    data.append(c)
-                default: // Octal form for non-printable chars
-                    data.append(asciiBackslash)
-                    data.append(asciiZero + UInt8(c / 64))
-                    data.append(asciiZero + UInt8(c / 8 % 8))
-                    data.append(asciiZero + UInt8(c % 8))
-                }
+        value.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+          if let baseAddress = body.baseAddress, body.count > 0 {
+            let p = baseAddress.assumingMemoryBound(to: UInt8.self)
+
+            for i in 0..<body.count {
+              let c = p[i]
+              switch c {
+              // Special two-byte escapes
+              case 8:
+                append(staticText: "\\b")
+              case 9:
+                append(staticText: "\\t")
+              case 10:
+                append(staticText: "\\n")
+              case 11:
+                append(staticText: "\\v")
+              case 12:
+                append(staticText: "\\f")
+              case 13:
+                append(staticText: "\\r")
+              case 34:
+                append(staticText: "\\\"")
+              case 92:
+                append(staticText: "\\\\")
+              case 32...126:  // printable ASCII
+                data.append(c)
+              default: // Octal form for non-printable chars
+                data.append(asciiBackslash)
+                data.append(asciiZero + UInt8(c / 64))
+                data.append(asciiZero + UInt8(c / 8 % 8))
+                data.append(asciiZero + UInt8(c % 8))
+              }
             }
+          }
         }
         data.append(asciiDoubleQuote)
     }

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -356,78 +356,80 @@ internal struct TextFormatScanner {
     /// verified the correctness.  So we get to avoid error checks here.
     private mutating func parseBytesFromString(terminator: UInt8, into data: inout Data) {
       data.withUnsafeMutableBytes {
-        (dataPointer: UnsafeMutablePointer<UInt8>) in
-        var out = dataPointer
-        while p[0] != terminator {
-          let byte = p[0]
-          p += 1
-          switch byte {
-          case asciiBackslash: //  "\\"
-            let escaped = p[0]
+        (body: UnsafeMutableRawBufferPointer) in
+        if let baseAddress = body.baseAddress, body.count > 0 {
+          var out = baseAddress.assumingMemoryBound(to: UInt8.self)
+          while p[0] != terminator {
+            let byte = p[0]
             p += 1
-            switch escaped {
-            case asciiZero...asciiSeven: // '0'...'7'
-              // C standard allows 1, 2, or 3 octal digits.
-              let digit1Value = escaped - asciiZero
-              let digit2 = p[0]
-              if digit2 >= asciiZero, digit2 <= asciiSeven {
-                p += 1
-                let digit2Value = digit2 - asciiZero
-                let digit3 = p[0]
-                if digit3 >= asciiZero, digit3 <= asciiSeven {
+            switch byte {
+            case asciiBackslash: //  "\\"
+              let escaped = p[0]
+              p += 1
+              switch escaped {
+              case asciiZero...asciiSeven: // '0'...'7'
+                // C standard allows 1, 2, or 3 octal digits.
+                let digit1Value = escaped - asciiZero
+                let digit2 = p[0]
+                if digit2 >= asciiZero, digit2 <= asciiSeven {
                   p += 1
-                  let digit3Value = digit3 - asciiZero
-                  out[0] = digit1Value &* 64 + digit2Value * 8 + digit3Value
-                  out += 1
+                  let digit2Value = digit2 - asciiZero
+                  let digit3 = p[0]
+                  if digit3 >= asciiZero, digit3 <= asciiSeven {
+                    p += 1
+                    let digit3Value = digit3 - asciiZero
+                    out[0] = digit1Value &* 64 + digit2Value * 8 + digit3Value
+                    out += 1
+                  } else {
+                    out[0] = digit1Value * 8 + digit2Value
+                    out += 1
+                  }
                 } else {
-                  out[0] = digit1Value * 8 + digit2Value
+                  out[0] = digit1Value
                   out += 1
                 }
-              } else {
-                out[0] = digit1Value
+              case asciiLowerX: // 'x' hexadecimal escape
+                // We already validated, so we know there's at least one digit:
+                var n = fromHexDigit(p[0])!
+                p += 1
+                if let digit = fromHexDigit(p[0]) {
+                  n = n &* 16 &+ digit
+                  p += 1
+                }
+                out[0] = n
+                out += 1
+              case asciiLowerA: // \a ("alert")
+                out[0] = asciiBell
+                out += 1
+              case asciiLowerB: // \b
+                out[0] = asciiBackspace
+                out += 1
+              case asciiLowerF: // \f
+                out[0] = asciiFormFeed
+                out += 1
+              case asciiLowerN: // \n
+                out[0] = asciiNewLine
+                out += 1
+              case asciiLowerR: // \r
+                out[0] = asciiCarriageReturn
+                out += 1
+              case asciiLowerT: // \t
+                out[0] = asciiTab
+                out += 1
+              case asciiLowerV: // \v
+                out[0] = asciiVerticalTab
+                out += 1
+              default:
+                out[0] = escaped
                 out += 1
               }
-            case asciiLowerX: // 'x' hexadecimal escape
-              // We already validated, so we know there's at least one digit:
-              var n = fromHexDigit(p[0])!
-              p += 1
-              if let digit = fromHexDigit(p[0]) {
-                n = n &* 16 &+ digit
-                p += 1
-              }
-              out[0] = n
-              out += 1
-            case asciiLowerA: // \a ("alert")
-              out[0] = asciiBell
-              out += 1
-            case asciiLowerB: // \b
-              out[0] = asciiBackspace
-              out += 1
-            case asciiLowerF: // \f
-              out[0] = asciiFormFeed
-              out += 1
-            case asciiLowerN: // \n
-              out[0] = asciiNewLine
-              out += 1
-            case asciiLowerR: // \r
-              out[0] = asciiCarriageReturn
-              out += 1
-            case asciiLowerT: // \t
-              out[0] = asciiTab
-              out += 1
-            case asciiLowerV: // \v
-              out[0] = asciiVerticalTab
-              out += 1
             default:
-              out[0] = escaped
+              out[0] = byte
               out += 1
             }
-          default:
-            out[0] = byte
-            out += 1
           }
+          p += 1 // Consume terminator
         }
-        p += 1 // Consume terminator
       }
     }
 

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -288,6 +288,10 @@
 		DB2E0AFF1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
 		DB2E0B001EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
 		DB2E0B011EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		E7038A24224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A25224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A26224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A27224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
 		ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
 		ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
 		ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
@@ -738,6 +742,7 @@
 		BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto3.swift; sourceTree = "<group>"; };
 		DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSON_Array.swift; sourceTree = "<group>"; };
 		DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		E7038A23224D7F1000B68775 /* Data+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_enum_proto3.pb.swift; sourceTree = "<group>"; };
 		F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryDecodingOptions.swift; sourceTree = "<group>"; };
 		F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BinaryDecodingOptions.swift; sourceTree = "<group>"; };
@@ -969,6 +974,7 @@
 				AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */,
 				9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */,
 				F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */,
+				E7038A23224D7F1000B68775 /* Data+Extensions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */,
 				9C1BD4BE1E7C51FB0064CD53 /* DoubleFormatter.swift */,
 				__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */,
@@ -1496,6 +1502,7 @@
 				9C1BD4C01E7C51FB0064CD53 /* DoubleFormatter.swift in Sources */,
 				AA86F6FB1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				F41BA4141E79BE54004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				E7038A25224D7F1000B68775 /* Data+Extensions.swift in Sources */,
 				9C2F238C1D7780D1008524F2 /* MessageExtension.swift in Sources */,
 				9C667A961E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
 				9C2F238D1D7780D1008524F2 /* Decoder.swift in Sources */,
@@ -1581,6 +1588,7 @@
 				9C84E4931E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				9C1BD4BF1E7C51FB0064CD53 /* DoubleFormatter.swift in Sources */,
 				8DC1CA0D1E54B80800CA8A26 /* MathUtils.swift in Sources */,
+				E7038A24224D7F1000B68775 /* Data+Extensions.swift in Sources */,
 				F41BA4131E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
 				AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				AAABA40B1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
@@ -1784,6 +1792,7 @@
 				9C84E4951E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				9C1BD4C11E7C51FB0064CD53 /* DoubleFormatter.swift in Sources */,
 				F4F4F11F1E5C7563006C6CAD /* MathUtils.swift in Sources */,
+				E7038A26224D7F1000B68775 /* Data+Extensions.swift in Sources */,
 				F41BA4151E79BE55004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
 				F44F937E1DAEA76700BC5B85 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
 				9C667A971E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
@@ -1987,6 +1996,7 @@
 				9C84E4961E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				9C1BD4C21E7C51FB0064CD53 /* DoubleFormatter.swift in Sources */,
 				ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				E7038A27224D7F1000B68775 /* Data+Extensions.swift in Sources */,
 				F41BA4161E79BE56004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
 				AA86F6FD1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				9C667A981E4C203D008B974F /* BinaryDecodingError.swift in Sources */,


### PR DESCRIPTION
Unfortunately I wasn't able to use the `#if compiler(>=5.0)` flag since the project supports older swift versions where this directive is not available.