### PR TITLE
Swift5: Fix warnings about loss of precision

### DIFF
--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -538,11 +538,11 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertRoundTripJSON {$0.optionalFloat = 1e-10}
         assertRoundTripJSON {$0.optionalFloat = 1e-20}
         assertRoundTripJSON {$0.optionalFloat = 1e-30}
-        assertRoundTripJSON {$0.optionalFloat = 1e-40}
-        assertRoundTripJSON {$0.optionalFloat = 1e-50}
-        assertRoundTripJSON {$0.optionalFloat = 1e-60}
-        assertRoundTripJSON {$0.optionalFloat = 1e-100}
-        assertRoundTripJSON {$0.optionalFloat = 1e-200}
+        assertRoundTripJSON {$0.optionalFloat = Float(1e-40)}
+        assertRoundTripJSON {$0.optionalFloat = Float(1e-50)}
+        assertRoundTripJSON {$0.optionalFloat = Float(1e-60)}
+        assertRoundTripJSON {$0.optionalFloat = Float(1e-100)}
+        assertRoundTripJSON {$0.optionalFloat = Float(1e-200)}
         assertRoundTripJSON {$0.optionalFloat = Float.pi}
         assertRoundTripJSON {$0.optionalFloat = 123456.789123456789123}
         assertRoundTripJSON {$0.optionalFloat = 1999.9999999999}

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -355,11 +355,11 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         // protobuf conformance requires subnormals to be handled
         assertTextFormatDecodeSucceeds("optional_float: 1.17549e-39\n") {
             (o: MessageTestType) in
-            return o.optionalFloat == 1.17549e-39
+            return o.optionalFloat == Float(1.17549e-39)
         }
         assertTextFormatDecodeSucceeds("optional_float: -1.17549e-39\n") {
             (o: MessageTestType) in
-            return o.optionalFloat == -1.17549e-39
+            return o.optionalFloat == Float(-1.17549e-39)
         }
         // protobuf conformance requires integer forms larger than Int64 to be accepted
         assertTextFormatDecodeSucceeds("optional_float: 18446744073709551616\n") {
@@ -420,17 +420,17 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertRoundTripText {$0.optionalFloat = 1e-10}
         assertRoundTripText {$0.optionalFloat = 1e-20}
         assertRoundTripText {$0.optionalFloat = 1e-30}
-        assertRoundTripText {$0.optionalFloat = 1e-40}
-        assertRoundTripText {$0.optionalFloat = 1e-50}
-        assertRoundTripText {$0.optionalFloat = 1e-60}
-        assertRoundTripText {$0.optionalFloat = 1e-100}
-        assertRoundTripText {$0.optionalFloat = 1e-200}
+        assertRoundTripText {$0.optionalFloat = Float(1e-40)}
+        assertRoundTripText {$0.optionalFloat = Float(1e-50)}
+        assertRoundTripText {$0.optionalFloat = Float(1e-60)}
+        assertRoundTripText {$0.optionalFloat = Float(1e-100)}
+        assertRoundTripText {$0.optionalFloat = Float(1e-200)}
         assertRoundTripText {$0.optionalFloat = Float.pi}
         assertRoundTripText {$0.optionalFloat = 123456.789123456789123}
         assertRoundTripText {$0.optionalFloat = 1999.9999999999}
         assertRoundTripText {$0.optionalFloat = 1999.9}
         assertRoundTripText {$0.optionalFloat = 1999.99}
-        assertRoundTripText {$0.optionalFloat = 1999.99}
+        assertRoundTripText {$0.optionalFloat = 1999.999}
         assertRoundTripText {$0.optionalFloat = 3.402823567e+38}
         assertRoundTripText {$0.optionalFloat = 1.1754944e-38}
     }


### PR DESCRIPTION
Technically, an assignment such as:
```
    var f: Float
    f = 1e-50
```
is an implicit conversion from a Double literal to a Float.
Swift 5 now warns when such conversions lose precision.

To suppress these, I've added a few explicit conversions to obtain:
```
    f = Float(1e-50)
```
In particular, note that no conditionals are needed, since the
updated code works back to (at least) Swift 4.0.