### PR TITLE
Update some FileIo calls to FileHandle.

### DIFF
--- a/Sources/protoc-gen-swift/FileIo.swift
+++ b/Sources/protoc-gen-swift/FileIo.swift
@@ -20,9 +20,6 @@ import Foundation
   import Darwin.C
 #endif
 
-// Alias clib's write() so Stdout.write(bytes:) can call it.
-private let _write = write
-
 private func printToFd(_ s: String, fd: Int32, appendNewLine: Bool = true) {
   // Write UTF-8 bytes
   let bytes: [UInt8] = [UInt8](s.utf8)

--- a/Sources/protoc-gen-swift/FileIo.swift
+++ b/Sources/protoc-gen-swift/FileIo.swift
@@ -46,35 +46,7 @@ class Stderr {
 
 class Stdout {
   static func print(_ s: String) { printToFd(s, fd: 1) }
-  static func write(bytes: Data) {
-    bytes.withUnsafeBytes { (p: UnsafePointer<UInt8>) -> () in
-      _ = _write(1, p, bytes.count)
-    }
-  }
 }
-
-class Stdin {
-  static func readall() -> Data? {
-    let fd: Int32 = 0
-    let buffSize = 1024
-    var buff = [UInt8]()
-    var fragment = [UInt8](repeating: 0, count: buffSize)
-    while true {
-      let count = read(fd, &fragment, buffSize)
-      if count < 0 {
-        return nil
-      }
-      if count < buffSize {
-        if count > 0 {
-          buff += fragment[0..<count]
-        }
-        return Data(bytes: buff)
-      }
-      buff += fragment
-    }
-  }
-}
-
 
 func readFileData(filename: String) throws -> Data {
     let url = URL(fileURLWithPath: filename)

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -135,10 +135,7 @@ struct GeneratorPlugin {
   }
 
   private func generateFromStdin() -> Int32 {
-    guard let requestData = Stdin.readall() else {
-      Stderr.print("Failed to read request")
-      return 1
-    }
+    let requestData = FileHandle.standardInput.readDataToEndOfFile()
 
     // Support for loggin the request. Useful when protoc/protoc-gen-swift are
     // being invoked from some build system/script. protoc-gen-swift supports
@@ -263,7 +260,7 @@ struct GeneratorPlugin {
       Stderr.print("Failure while serializing response: \(e)")
       return false
     }
-    Stdout.write(bytes: serializedResponse)
+    FileHandle.standardOutput.write(serializedResponse)
     return true
   }
 


### PR DESCRIPTION
FileHandle.sandardInput and FileHandle.standardOutput are part of
Foundation, and are available in Swift 3.2.