### PR TITLE
TextFormat conformance: Add option to suppress unknown field printing

### DIFF
--- a/Protos/conformance/conformance.proto
+++ b/Protos/conformance/conformance.proto
@@ -119,6 +119,10 @@ message ConformanceRequest {
 
   // Specify details for how to encode jspb.
   JspbEncodingConfig jspb_encoding_options = 6;
+
+  // This can be used in json and text format. If true, testee should print
+  // unknown fields instead of ignore. This feature is optional.
+  bool print_unknown_fields = 9;
 }
 
 // Represents a single test case's output.

--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -276,6 +276,13 @@ struct Conformance_ConformanceRequest {
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
   mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
 
+  /// This can be used in json and text format. If true, testee should print
+  /// unknown fields instead of ignore. This feature is optional.
+  var printUnknownFields: Bool {
+    get {return _storage._printUnknownFields}
+    set {_uniqueStorage()._printUnknownFields = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The payload (whether protobuf of JSON) is always for a
@@ -537,6 +544,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     4: .standard(proto: "message_type"),
     5: .standard(proto: "test_category"),
     6: .standard(proto: "jspb_encoding_options"),
+    9: .standard(proto: "print_unknown_fields"),
   ]
 
   fileprivate class _StorageClass {
@@ -545,6 +553,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     var _messageType: String = String()
     var _testCategory: Conformance_TestCategory = .unspecifiedTest
     var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
+    var _printUnknownFields: Bool = false
 
     static let defaultInstance = _StorageClass()
 
@@ -556,6 +565,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       _messageType = source._messageType
       _testCategory = source._testCategory
       _jspbEncodingOptions = source._jspbEncodingOptions
+      _printUnknownFields = source._printUnknownFields
     }
   }
 
@@ -595,6 +605,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
           if let v = v {_storage._payload = .textPayload(v)}
+        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
         default: break
         }
       }
@@ -631,6 +642,9 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       case nil: break
       default: break
       }
+      if _storage._printUnknownFields != false {
+        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -645,6 +659,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
         if _storage._messageType != rhs_storage._messageType {return false}
         if _storage._testCategory != rhs_storage._testCategory {return false}
         if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
+        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -276,6 +276,13 @@ struct Conformance_ConformanceRequest {
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
   mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
 
+  /// This can be used in json and text format. If true, testee should print
+  /// unknown fields instead of ignore. This feature is optional.
+  var printUnknownFields: Bool {
+    get {return _storage._printUnknownFields}
+    set {_uniqueStorage()._printUnknownFields = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The payload (whether protobuf of JSON) is always for a
@@ -537,6 +544,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     4: .standard(proto: "message_type"),
     5: .standard(proto: "test_category"),
     6: .standard(proto: "jspb_encoding_options"),
+    9: .standard(proto: "print_unknown_fields"),
   ]
 
   fileprivate class _StorageClass {
@@ -545,6 +553,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     var _messageType: String = String()
     var _testCategory: Conformance_TestCategory = .unspecifiedTest
     var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
+    var _printUnknownFields: Bool = false
 
     static let defaultInstance = _StorageClass()
 
@@ -556,6 +565,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       _messageType = source._messageType
       _testCategory = source._testCategory
       _jspbEncodingOptions = source._jspbEncodingOptions
+      _printUnknownFields = source._printUnknownFields
     }
   }
 
@@ -595,6 +605,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
           if let v = v {_storage._payload = .textPayload(v)}
+        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
         default: break
         }
       }
@@ -631,6 +642,9 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       case nil: break
       default: break
       }
+      if _storage._printUnknownFields != false {
+        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -645,6 +659,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
         if _storage._messageType != rhs_storage._messageType {return false}
         if _storage._testCategory != rhs_storage._testCategory {return false}
         if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
+        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -152,7 +152,9 @@ func buildResponse(serializedData: Data) -> Conformance_ConformanceResponse {
             "ConformanceRequest had a requested_output_format of JSPB WireFormat; that"
             + " isn't supposed to happen with opensource."
     case .textFormat:
-        response.textPayload = testMessage.textFormatString()
+        var textFormatOptions = TextFormatEncodingOptions()
+        textFormatOptions.printUnknownFields = request.printUnknownFields
+        response.textPayload = testMessage.textFormatString(options: textFormatOptions)
     case .unspecified:
         response.runtimeError = "Request asked for the 'unspecified' result, that isn't valid."
     case .UNRECOGNIZED(let v):

--- a/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
@@ -25,7 +25,24 @@ extension Message {
   /// - Returns: A string containing the text format serialization of the
   ///   message.
   public func textFormatString() -> String {
-    var visitor = TextFormatEncodingVisitor(message: self)
+    // This is implemented as a separate zero-argument function
+    // to preserve binary compatibility.
+    return textFormatString(options: TextFormatEncodingOptions())
+  }
+
+  /// Returns a string containing the Protocol Buffer text format serialization
+  /// of the message.
+  ///
+  /// Unlike binary encoding, presence of required fields is not enforced when
+  /// serializing to JSON.
+  ///
+  /// - Returns: A string containing the text format serialization of the message.
+  /// - Parameters:
+  ///   - options: The TextFormatEncodingOptions to use.
+  public func textFormatString(
+    options: TextFormatEncodingOptions
+  ) -> String {
+    var visitor = TextFormatEncodingVisitor(message: self, options: options)
     if let any = self as? Google_Protobuf_Any {
       any._storage.textTraverse(visitor: &visitor)
     } else {

--- a/Sources/SwiftProtobuf/TextFormatEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingOptions.swift
@@ -1,0 +1,22 @@
+// Sources/SwiftProtobuf/TextFormatEncodingOptions.swift - Text format encoding options
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Text format encoding options
+///
+// -----------------------------------------------------------------------------
+
+/// Options for TextFormatEncoding.
+public struct TextFormatEncodingOptions {
+
+  /// Default: Do print unknown fields using numeric notation
+  public var printUnknownFields: Bool = true
+
+  public init() {}
+}

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
@@ -31,6 +31,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_fixed64() throws {
@@ -45,6 +50,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_lengthDelimited_string() throws {
@@ -59,6 +69,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_lengthDelimited_message() throws {
@@ -74,6 +89,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_lengthDelimited_notmessage() throws {
@@ -90,6 +110,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_lengthDelimited_nested_message() throws {
@@ -104,6 +129,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_group() throws {
@@ -118,6 +148,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_nested_group() throws {
@@ -132,6 +167,11 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 
     func test_unknown_fixed32() throws {
@@ -146,5 +186,10 @@ class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         } catch TextFormatDecodingError.unknownField {
             // This is what should have happened.
         }
+
+        var options = TextFormatEncodingOptions()
+        options.printUnknownFields = false
+        let textWithoutUnknowns = msg.textFormatString(options: options)
+        XCTAssertEqual(textWithoutUnknowns, "")
     }
 }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -276,6 +276,13 @@ struct Conformance_ConformanceRequest {
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
   mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
 
+  /// This can be used in json and text format. If true, testee should print
+  /// unknown fields instead of ignore. This feature is optional.
+  var printUnknownFields: Bool {
+    get {return _storage._printUnknownFields}
+    set {_uniqueStorage()._printUnknownFields = newValue}
+  }
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The payload (whether protobuf of JSON) is always for a
@@ -537,6 +544,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     4: .standard(proto: "message_type"),
     5: .standard(proto: "test_category"),
     6: .standard(proto: "jspb_encoding_options"),
+    9: .standard(proto: "print_unknown_fields"),
   ]
 
   fileprivate class _StorageClass {
@@ -545,6 +553,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     var _messageType: String = String()
     var _testCategory: Conformance_TestCategory = .unspecifiedTest
     var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
+    var _printUnknownFields: Bool = false
 
     static let defaultInstance = _StorageClass()
 
@@ -556,6 +565,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       _messageType = source._messageType
       _testCategory = source._testCategory
       _jspbEncodingOptions = source._jspbEncodingOptions
+      _printUnknownFields = source._printUnknownFields
     }
   }
 
@@ -595,6 +605,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
           if let v = v {_storage._payload = .textPayload(v)}
+        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
         default: break
         }
       }
@@ -631,6 +642,9 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       case nil: break
       default: break
       }
+      if _storage._printUnknownFields != false {
+        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -645,6 +659,7 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
         if _storage._messageType != rhs_storage._messageType {return false}
         if _storage._testCategory != rhs_storage._testCategory {return false}
         if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
+        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
         return true
       }
       if !storagesAreEqual {return false}


### PR DESCRIPTION
Google's conformance test continues to add new checks for TextFormat.

A recent such addition demands that implementations have the ability to optionally emit unknown fields.  We've always emitted unknown fields by default, but we didn't have a way to suppress this behavior.  This PR adds the necessary option and uses it to update the conformance test.  With this, we once again fully pass Google's test suite.

I've broken this into four commits for simpler review:
* First adds the option to the existing API.
* Second adds tests of the new option.
* Third updates conformance test to honor the new flag from Google's driver.
* Last one updates reference files.
