### PR TITLE
#851 Fix build command to work also with Swift 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ build the protoc plugin:
 
 ```
 $ git checkout tags/[tag_name]
-$ swift build -c release -Xswiftc -static-stdlib
+$ swift build --static-swift-stdlib -c release
 ```
 
 This will create a binary called `protoc-gen-swift` in the `.build/release`


### PR DESCRIPTION
Command proposed to build swift-protobuf in Readme file
```swift build -c release -Xswiftc -static-swift-stdlib```
doesn't work with Swift 5, it crashed on linking phase, full crash log available in issue https://github.com/apple/swift-protobuf/issues/851

Replacing `-Xswiftc --static-swift-stdlib` with `--static-swift-stdlib` seems to fix the issue.

So successful command should looks like:
```swift build --static-swift-stdlib -c release```

I've tested it with swift 5 and 4.2.