### PR TITLE
Raise a .illegalNull is the top level JSON is null.

### DIFF
--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -104,6 +104,8 @@ extension Message {
           } else {
             throw JSONDecodingError.illegalNull
           }
+        } else {
+          throw JSONDecodingError.illegalNull
         }
         if !decoder.scanner.complete {
           throw JSONDecodingError.trailingGarbage


### PR DESCRIPTION
This still allows it for the things that can custom support decoding from
null, but the test isn't completely clear on what should happen for those.

Fixes #869