### PR TITLE
add new func in visitor protocol

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -22,5 +22,7 @@ public struct JSONEncodingOptions {
   /// By default they are converted to JSON(lowerCamelCase) names.
   public var preserveProtoFieldNames: Bool = false
 
+  /// Wether to include proto field with default value
+  public var includeDefaultValue: Bool = false
   public init() {}
 }

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -331,6 +331,10 @@ internal struct JSONEncodingVisitor: Visitor {
   mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
     // JSON does not store extensions
   }
+    
+  mutating func shouldIncludeDefault() -> Bool {
+    return options.includeDefaultValue
+  }
 
   /// Helper function that throws an error if the field number could not be
   /// resolved.

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -443,6 +443,8 @@ public protocol Visitor {
 
   /// Called with the raw bytes that represent any unknown fields.
   mutating func visitUnknown(bytes: Data) throws
+    
+ func shouldIncludeDefault() -> Bool
 }
 
 /// Forwarding default implementations of some visitor methods, for convenience.
@@ -690,4 +692,8 @@ extension Visitor {
   public mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
     try fields.traverse(visitor: &self, start: start, end: end)
   }
+    
+    func shouldIncludeDefault()->Bool {
+        return false
+    }
 }


### PR DESCRIPTION
Less change, add new func into protocol that's it. 

codegen will look like this 

```
  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
    if !self.text.isEmpty || visitor.shouldIncludeDefault() {
      try visitor.visitSingularStringField(value: self.text, fieldNumber: 1)
    }
    if self.action != .searchCancelEventActionInvalid ||  visitor.shouldIncludeDefault() {
      try visitor.visitSingularEnumField(value: self.action, fieldNumber: 2)
    }
    if self.resultCount != 0  || visitor.shouldIncludeDefault(){
      try visitor.visitSingularUInt32Field(value: self.resultCount, fieldNumber: 3)
    }
    try unknownFields.traverse(visitor: &visitor)
  }
```