### PR TITLE
Stop using old Swift 3 "build --clean" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,8 +280,7 @@ install: build
 	${INSTALL} ${PROTOC_GEN_SWIFT} ${BINDIR}
 
 clean:
-	-swift build --clean
-	-swift package clean
+	swift package clean
 	rm -rf .build _test ${PROTOC_GEN_SWIFT} DescriptorTestData.bin \
 	  Performance/_generated Performance/_results Protos/mined_words.txt \
 	  docs build


### PR DESCRIPTION
To ensure compatibility with Swift 3 and Swift 4, the
Makefile has had both of the following for a while:
  "swift build --clean" was used in Swift 3
  "swift package clean" replaced it in Swift 4

Of course, this also meant the Makefile had to ignore errors from
both commands, since either might fail.

Now that we're no longer supporting Swift 3, we can
remove the Swift 3 command and respect errors from
the Swift 4 (and later) command.