### PR TITLE
Change "var" to "let" in Test_Map

### DIFF
--- a/Tests/SwiftProtobufTests/Test_Map.swift
+++ b/Tests/SwiftProtobufTests/Test_Map.swift
@@ -32,7 +32,7 @@ class Test_Map: XCTestCase, PBTestHelpers {
             while matched && !availableBlocks.isEmpty {
                 matched = false
                 for n in 0..<availableBlocks.count {
-                    var e = availableBlocks[n]
+                    let e = availableBlocks[n]
                     if (e.count == t.count && t == e[0..<e.count]) {
                         t = []
                         availableBlocks.remove(at:n)


### PR DESCRIPTION
Fixes a warning from the Swift 5 compiler about
this "var" that is never mutated.  (The fix is correct
for Swift 4 as well, the only change in Swift 5 is the new
warning.)