### PR TITLE
Allow messages to be (de/)serialized from Unsafe[Mutable]RawBufferPointer

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -246,7 +246,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
                                              fieldNumber: Int) throws {
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .lengthDelimited).encodedSize
-    let messageSize = try value.serializedDataSize()
+    let messageSize = try value.serializedBinarySize()
     serializedSize +=
       tagSize + Varint.encodedSize(of: UInt64(messageSize)) + messageSize
   }
@@ -257,7 +257,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
                            wireFormat: .lengthDelimited).encodedSize
     serializedSize += value.count * tagSize
     for v in value {
-      let messageSize = try v.serializedDataSize()
+      let messageSize = try v.serializedBinarySize()
       serializedSize +=
         Varint.encodedSize(of: UInt64(messageSize)) + messageSize
     }
@@ -357,7 +357,7 @@ extension BinaryEncodingSizeVisitor {
 
       groupSize += Varint.encodedSize(of: Int32(fieldNumber))
 
-      let messageSize = try value.serializedDataSize()
+      let messageSize = try value.serializedBinarySize()
       groupSize += Varint.encodedSize(of: UInt64(messageSize)) + messageSize
 
       serializedSize += groupSize

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -106,7 +106,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   mutating func visitSingularMessageField<M: Message>(value: M,
                                              fieldNumber: Int) throws {
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
-    let length = try value.serializedDataSize()
+    let length = try value.serializedBinarySize()
     encoder.putVarInt(value: length)
     try value.traverse(visitor: &self)
   }
@@ -344,7 +344,7 @@ extension BinaryEncodingVisitor {
 
       // Use a normal BinaryEncodingVisitor so any message fields end up in the
       // normal wire format (instead of MessageSet format).
-      let length = try value.serializedDataSize()
+      let length = try value.serializedBinarySize()
       encoder.putVarInt(value: length)
       // Create the sub encoder after writing the length.
       var subVisitor = BinaryEncodingVisitor(encoder: encoder)

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -31,32 +31,58 @@ extension Message {
     if !partial && !isInitialized {
       throw BinaryEncodingError.missingRequiredFields
     }
-    let requiredSize = try serializedDataSize()
+    let requiredSize = try serializedBinarySize()
     var data = Data(count: requiredSize)
     try data.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
-      if let baseAddress = body.baseAddress, body.count > 0 {
-        let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+      let bytesWritten = try self.serializeBinary(into: body, partial: partial)
 
-        var visitor = BinaryEncodingVisitor(forWritingInto: pointer)
-        try traverse(visitor: &visitor)
-        // Currently not exposing this from the api because it really would be
-        // an internal error in the library and should never happen.
-        assert(requiredSize == visitor.encoder.distance(pointer: pointer))
-      }
+      // Currently not exposing this from the api because it really would be
+      // an internal error in the library and should never happen.
+      assert(requiredSize == bytesWritten)
     }
     return data
   }
 
   /// Returns the size in bytes required to encode the message in binary format.
-  /// This is used by `serializedData()` to precalculate the size of the buffer
-  /// so that encoding can proceed without bounds checks or reallocation.
-  internal func serializedDataSize() throws -> Int {
+  ///
+  /// This should be used with `serializeBytes(into:partial:)` so that enough space may
+  /// be allocated for the buffer so that encoding can proceed without bounds checks
+  /// or reallocation.
+  public func serializedBinarySize() throws -> Int {
     // Note: since this api is internal, it doesn't currently worry about
     // needing a partial argument to handle proto2 syntax required fields.
     // If this become public, it will need that added.
     var visitor = BinaryEncodingSizeVisitor()
     try traverse(visitor: &visitor)
     return visitor.serializedSize
+  }
+
+  /// Writes the message in the Protocol Buffer binary format into the given buffer.
+  ///
+  /// - Parameters:
+  ///   - buffer: An `UnsafeMutableRawBufferPointer` into which the serialized message
+  ///     will be written. The buffer should be at least `serializedDataSize()` bytes
+  ///     in size.
+  ///   - partial: If `false` (the default), this method will check
+  ///     `Message.isInitialized` before encoding to verify that all required
+  ///     fields are present. If any are missing, this method throws
+  ///     `BinaryEncodingError.missingRequiredFields`.
+  /// - Returns: The number of bytes written into the buffer.
+  /// - Throws: `BinaryEncodingError` if encoding fails.
+  @discardableResult
+  public func serializeBinary(into buffer: UnsafeMutableRawBufferPointer, partial: Bool = false) throws -> Int {
+    if !partial && !isInitialized {
+      throw BinaryEncodingError.missingRequiredFields
+    }
+    guard let baseAddress = buffer.baseAddress, buffer.count > 0 else {
+      return 0
+    }
+
+    let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+    var visitor = BinaryEncodingVisitor(forWritingInto: pointer)
+    try traverse(visitor: &visitor)
+
+    return visitor.encoder.distance(pointer: pointer)
   }
 
   /// Creates a new message by decoding the given `Data` value containing a
@@ -96,9 +122,9 @@ extension Message {
   ///     extensions in this message or messages nested within this message's
   ///     fields.
   ///   - partial: If `false` (the default), this method will check
-  ///     `Message.isInitialized` before encoding to verify that all required
+  ///     `Message.isInitialized` after decoding to verify that all required
   ///     fields are present. If any are missing, this method throws
-  ///     `BinaryEncodingError.missingRequiredFields`.
+  ///     `BinaryDecodingError.missingRequiredFields`.
   ///   - options: The BinaryDecodingOptions to use.
   /// - Throws: `BinaryDecodingError` if decoding fails.
   public mutating func merge(
@@ -109,18 +135,82 @@ extension Message {
   ) throws {
     if !data.isEmpty {
       try data.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
-        if let baseAddress = body.baseAddress, body.count > 0 {
-          let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
-          var decoder = BinaryDecoder(forReadingFrom: pointer,
-                                      count: body.count,
-                                      options: options,
-                                      extensions: extensions)
-          try decoder.decodeFullMessage(message: &self)
-        }
+        try self.merge(body: body, extensions: extensions, options: options)
       }
     }
     if !partial && !isInitialized {
       throw BinaryDecodingError.missingRequiredFields
+    }
+  }
+
+  /// Creates a new message by decoding the given bytes containing a
+  /// serialized message in Protocol Buffer binary format.
+  ///
+  /// - Parameters:
+  ///   - body: The binary-encoded message buffer to decode.
+  ///   - extensions: An `ExtensionMap` used to look up and decode any
+  ///     extensions in this message or messages nested within this message's
+  ///     fields.
+  ///   - partial: If `false` (the default), this method will check
+  ///     `Message.isInitialized` after decoding to verify that all required
+  ///     fields are present. If any are missing, this method throws
+  ///     `BinaryDecodingError.missingRequiredFields`.
+  ///   - options: The BinaryDecodingOptions to use.
+  /// - Throws: `BinaryDecodingError` if decoding fails.
+  public init(
+    body: UnsafeRawBufferPointer,
+    extensions: ExtensionMap? = nil,
+    partial: Bool = false,
+    options: BinaryDecodingOptions = BinaryDecodingOptions()
+  ) throws {
+    self.init()
+    try merge(body: body, extensions: extensions, partial: partial, options: options)
+  }
+
+  /// Updates the message by decoding the given `buffer` value containing a
+  /// serialized message in Protocol Buffer binary format into the receiver.
+  ///
+  /// - Note: If this method throws an error, the message may still have been
+  ///   partially mutated by the binary data that was decoded before the error
+  ///   occurred.
+  ///
+  /// - Parameters:
+  ///   - buffer: The binary-encoded message data to decode.
+  ///   - extensions: An `ExtensionMap` used to look up and decode any
+  ///     extensions in this message or messages nested within this message's
+  ///     fields.
+  ///   - partial: If `false` (the default), this method will check
+  ///     `Message.isInitialized` after decoding to verify that all required
+  ///     fields are present. If any are missing, this method throws
+  ///     `BinaryDecodingError.missingRequiredFields`.
+  ///   - options: The BinaryDecodingOptions to use.
+  /// - Throws: `BinaryDecodingError` if decoding fails.
+  public mutating func merge(
+    body: UnsafeRawBufferPointer,
+    extensions: ExtensionMap? = nil,
+    partial: Bool = false,
+    options: BinaryDecodingOptions = BinaryDecodingOptions()
+  ) throws {
+    try self.merge(body: body, extensions: extensions, options: options)
+    if !partial && !isInitialized {
+      throw BinaryDecodingError.missingRequiredFields
+    }
+  }
+
+  /// Updates the message by decoding the given `buffer` value containing a
+  /// serialized message in Protocol Buffer binary format into the receiver.
+  private mutating func merge(
+    body: UnsafeRawBufferPointer,
+    extensions: ExtensionMap?,
+    options: BinaryDecodingOptions
+  ) throws {
+    if let baseAddress = body.baseAddress, body.count > 0 {
+      let pointer = baseAddress.assumingMemoryBound(to: UInt8.self)
+      var decoder = BinaryDecoder(forReadingFrom: pointer,
+                                  count: body.count,
+                                  options: options,
+                                  extensions: extensions)
+      try decoder.decodeFullMessage(message: &self)
     }
   }
 }


### PR DESCRIPTION
This change allows users who already have a buffer allocated to
serialize a message straight into that buffer, avoiding an additional
copy via Data.

The motivation behind this is that in Swift gRPC the currency for
storing bytes is NIOs `ByteBuffer`, and we'd like to avoid having
an additional copy from going via `Data`. As such this change
- makes `serializedDataSize` public and renames it `serializedBinarySize`
- adds a `serializeBinary(into:partial:)` method, and
- adds an `init` to `Message` to read from an `UnsafeRawBufferPointer`.

A couple of errors in the documentation were also fixed.

I also saw issue #816 after implementing this so more than happy to
hear what everyone has to think about this! 