### PR TITLE
Specify `swift_versions` in podspec and minimum CocoaPods 1.7.0 version.

### DIFF
--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -13,7 +13,9 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.cocoapods_version = '>= 1.1.0'
+  s.cocoapods_version = '>= 1.7.0'
 
   s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
+
+  s.swift_versions = ['4.0', '4.2', '5.0']
 end


### PR DESCRIPTION
Supersedes https://github.com/apple/swift-protobuf/pull/732

@thomasvl verified that the following commands pass:
```
pod lib lint SwiftProtobuf.podspec # uses Swift 5.0 as latest from podspec
pod lib lint SwiftProtobuf.podspec --swift-version=4.2
pod lib lint SwiftProtobuf.podspec --swift-version=4.0
```

Not sure if there is CI to test each version already so I can update this.

Also, not sure if you want me to bump from version 1.5.0 to 1.6.0  or something else does it later when a release happens.