### PR TITLE
Add an option to ignore unknown enum cases when decoding from JSON (instead of failing)

### DIFF
--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -466,7 +466,7 @@ internal struct JSONDecoder: Decoder {
       value = nil
       return
     }
-    value = try scanner.nextEnumValue() as E
+    value = try scanner.nextEnumValue()
   }
 
   mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws
@@ -475,7 +475,7 @@ internal struct JSONDecoder: Decoder {
       value = E()
       return
     }
-    value = try scanner.nextEnumValue()
+    value = try scanner.nextEnumValue() ?? E()
   }
 
   mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws
@@ -488,8 +488,9 @@ internal struct JSONDecoder: Decoder {
       return
     }
     while true {
-      let e: E = try scanner.nextEnumValue()
-      value.append(e)
+      if let e: E = try scanner.nextEnumValue() {
+        value.append(e)
+      }
       if scanner.skipOptionalArrayEnd() {
         return
       }

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1285,7 +1285,14 @@ internal struct JSONScanner {
   /// Parse the next token as a string or numeric enum value.  Throws
   /// unrecognizedEnumValue if the string/number can't initialize the
   /// enum.  Will throw other errors if the JSON is malformed.
-  internal mutating func nextEnumValue<E: Enum>() throws -> E {
+  internal mutating func nextEnumValue<E: Enum>() throws -> E? {
+    func throwOrIgnore() throws -> E? {
+      if ignoreUnknownFields {
+        return nil
+      } else {
+        throw JSONDecodingError.unrecognizedEnumValue
+      }
+    }
     skipWhitespace()
     guard hasMoreContent else {
         throw JSONDecodingError.truncated
@@ -1295,14 +1302,14 @@ internal struct JSONScanner {
         if let e = E(rawUTF8: name) {
           return e
         } else {
-          throw JSONDecodingError.unrecognizedEnumValue
+          return try throwOrIgnore()
         }
       }
       let name = try nextQuotedString()
       if let e = E(name: name) {
         return e
       } else {
-        throw JSONDecodingError.unrecognizedEnumValue
+        return try throwOrIgnore()
       }
     } else {
       let n = try nextSInt()
@@ -1310,7 +1317,7 @@ internal struct JSONScanner {
         if let e = E(rawValue: i) {
           return e
         } else {
-          throw JSONDecodingError.unrecognizedEnumValue
+          return try throwOrIgnore()
         }
       } else {
         throw JSONDecodingError.numberRange

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -208,9 +208,9 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         }
     }
 
-    func assertJSONDecodeSucceeds(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) -> Bool) {
+    func assertJSONDecodeSucceeds(_ json: String, options: JSONDecodingOptions = JSONDecodingOptions(), file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) -> Bool) {
         do {
-            let decoded: MessageTestType = try MessageTestType(jsonString: json)
+            let decoded: MessageTestType = try MessageTestType(jsonString: json, options: options)
             XCTAssert(check(decoded), "Condition failed for \(decoded)", file: file, line: line)
 
             do {
@@ -232,7 +232,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
 
         do {
             let jsonData = json.data(using: String.Encoding.utf8)!
-            let decoded: MessageTestType = try MessageTestType(jsonUTF8Data: jsonData)
+            let decoded: MessageTestType = try MessageTestType(jsonUTF8Data: jsonData, options: options)
             XCTAssert(check(decoded), "Condition failed for \(decoded) from binary \(json)", file: file, line: line)
 
             do {

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import XCTest
+import SwiftProtobuf
 
 class Test_Enum: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Proto3Unittest_TestAllTypes
@@ -37,6 +38,23 @@ class Test_Enum: XCTestCase, PBTestHelpers {
     func testJSONrepeated() {
         assertJSONEncode("{\"repeatedNestedEnum\":[\"FOO\",\"BAR\"]}") { (m: inout MessageTestType) in
             m.repeatedNestedEnum = [.foo, .bar]
+        }
+    }
+
+    func testJSONdecodingOptions() {
+
+        var options = JSONDecodingOptions()
+        options.ignoreUnknownFields = true
+
+        assertJSONDecodeSucceeds("{\"optionalNestedEnum\":\"NEW_VALUE\"}", options: options) { (m: MessageTestType) -> Bool in
+            switch m.optionalNestedEnum {
+            case .zero: return true
+            default: return false
+            }
+        }
+
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\":[\"FOO\",\"NEW_VALUE\"]}", options: options) { (m: MessageTestType) -> Bool in
+            m.repeatedNestedEnum == [.foo]
         }
     }
 


### PR DESCRIPTION
The issue was already described in the past but looks like no PR was uploaded: [https://github.com/apple/swift-protobuf/issues/481#issuecomment-295800326](url)

I know it is unwanted behaviour but in real life scenarios backend teams sometimes coming to the necessity of extending existing enums by adding new cases. This leads to backward incompatibility in the mobile clients using swift-protobuf generated models and when backend encodes enum cases with case names. 

To avoid the issue, an option added to pass unknown enum cases and use first enum case as default case following the best practice in proto programming. Backend teams usually define first enum case as "unknown" or "initial" or any other with the intention that it will be used as a default case, or to indicate the problem.