### PR TITLE
Sync up the upstream protos (and regenerate)

### DIFF
--- a/Protos/google/protobuf/duration.proto
+++ b/Protos/google/protobuf/duration.proto
@@ -61,7 +61,7 @@ option objc_class_prefix = "GPB";
 //     if (duration.seconds < 0 && duration.nanos > 0) {
 //       duration.seconds += 1;
 //       duration.nanos -= 1000000000;
-//     } else if (durations.seconds > 0 && duration.nanos < 0) {
+//     } else if (duration.seconds > 0 && duration.nanos < 0) {
 //       duration.seconds -= 1;
 //       duration.nanos += 1000000000;
 //     }

--- a/Protos/google/protobuf/test_messages_proto2.proto
+++ b/Protos/google/protobuf/test_messages_proto2.proto
@@ -38,6 +38,7 @@
 syntax = "proto2";
 
 package protobuf_test_messages.proto2;
+
 option java_package = "com.google.protobuf_test_messages.proto2";
 
 // This is the default, but we specify it here explicitly.
@@ -66,79 +67,111 @@ message TestAllTypesProto2 {
   }
 
   // Singular
-  optional int32 optional_int32    =  1;
-  optional int64 optional_int64    =  2;
-  optional uint32 optional_uint32   =  3;
-  optional uint64 optional_uint64   =  4;
-  optional sint32 optional_sint32   =  5;
-  optional sint64 optional_sint64   =  6;
-  optional fixed32 optional_fixed32  =  7;
-  optional fixed64 optional_fixed64  =  8;
-  optional sfixed32 optional_sfixed32 =  9;
+  optional int32 optional_int32 = 1;
+  optional int64 optional_int64 = 2;
+  optional uint32 optional_uint32 = 3;
+  optional uint64 optional_uint64 = 4;
+  optional sint32 optional_sint32 = 5;
+  optional sint64 optional_sint64 = 6;
+  optional fixed32 optional_fixed32 = 7;
+  optional fixed64 optional_fixed64 = 8;
+  optional sfixed32 optional_sfixed32 = 9;
   optional sfixed64 optional_sfixed64 = 10;
-  optional float optional_float    = 11;
-  optional double optional_double   = 12;
-  optional bool optional_bool     = 13;
-  optional string optional_string   = 14;
-  optional bytes optional_bytes    = 15;
+  optional float optional_float = 11;
+  optional double optional_double = 12;
+  optional bool optional_bool = 13;
+  optional string optional_string = 14;
+  optional bytes optional_bytes = 15;
 
-  optional NestedMessage                        optional_nested_message  = 18;
-  optional ForeignMessageProto2                 optional_foreign_message = 19;
+  optional NestedMessage optional_nested_message = 18;
+  optional ForeignMessageProto2 optional_foreign_message = 19;
 
-  optional NestedEnum                           optional_nested_enum     = 21;
-  optional ForeignEnumProto2                    optional_foreign_enum    = 22;
+  optional NestedEnum optional_nested_enum = 21;
+  optional ForeignEnumProto2 optional_foreign_enum = 22;
 
-  optional string optional_string_piece = 24 [ctype=STRING_PIECE];
-  optional string optional_cord = 25 [ctype=CORD];
+  optional string optional_string_piece = 24 [ctype = STRING_PIECE];
+  optional string optional_cord = 25 [ctype = CORD];
 
   optional TestAllTypesProto2 recursive_message = 27;
 
   // Repeated
-  repeated    int32 repeated_int32    = 31;
-  repeated    int64 repeated_int64    = 32;
-  repeated   uint32 repeated_uint32   = 33;
-  repeated   uint64 repeated_uint64   = 34;
-  repeated   sint32 repeated_sint32   = 35;
-  repeated   sint64 repeated_sint64   = 36;
-  repeated  fixed32 repeated_fixed32  = 37;
-  repeated  fixed64 repeated_fixed64  = 38;
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
   repeated sfixed32 repeated_sfixed32 = 39;
   repeated sfixed64 repeated_sfixed64 = 40;
-  repeated    float repeated_float    = 41;
-  repeated   double repeated_double   = 42;
-  repeated     bool repeated_bool     = 43;
-  repeated   string repeated_string   = 44;
-  repeated    bytes repeated_bytes    = 45;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
 
-  repeated NestedMessage       repeated_nested_message  = 48;
-  repeated ForeignMessageProto2      repeated_foreign_message = 49;
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated ForeignMessageProto2 repeated_foreign_message = 49;
 
-  repeated NestedEnum          repeated_nested_enum     = 51;
-  repeated ForeignEnumProto2         repeated_foreign_enum    = 52;
+  repeated NestedEnum repeated_nested_enum = 51;
+  repeated ForeignEnumProto2 repeated_foreign_enum = 52;
 
-  repeated string repeated_string_piece = 54 [ctype=STRING_PIECE];
-  repeated string repeated_cord = 55 [ctype=CORD];
+  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype = CORD];
+
+  // Packed
+  repeated int32 packed_int32 = 75 [packed = true];
+  repeated int64 packed_int64 = 76 [packed = true];
+  repeated uint32 packed_uint32 = 77 [packed = true];
+  repeated uint64 packed_uint64 = 78 [packed = true];
+  repeated sint32 packed_sint32 = 79 [packed = true];
+  repeated sint64 packed_sint64 = 80 [packed = true];
+  repeated fixed32 packed_fixed32 = 81 [packed = true];
+  repeated fixed64 packed_fixed64 = 82 [packed = true];
+  repeated sfixed32 packed_sfixed32 = 83 [packed = true];
+  repeated sfixed64 packed_sfixed64 = 84 [packed = true];
+  repeated float packed_float = 85 [packed = true];
+  repeated double packed_double = 86 [packed = true];
+  repeated bool packed_bool = 87 [packed = true];
+  repeated NestedEnum packed_nested_enum = 88 [packed = true];
+
+  // Unpacked
+  repeated int32 unpacked_int32 = 89 [packed = false];
+  repeated int64 unpacked_int64 = 90 [packed = false];
+  repeated uint32 unpacked_uint32 = 91 [packed = false];
+  repeated uint64 unpacked_uint64 = 92 [packed = false];
+  repeated sint32 unpacked_sint32 = 93 [packed = false];
+  repeated sint64 unpacked_sint64 = 94 [packed = false];
+  repeated fixed32 unpacked_fixed32 = 95 [packed = false];
+  repeated fixed64 unpacked_fixed64 = 96 [packed = false];
+  repeated sfixed32 unpacked_sfixed32 = 97 [packed = false];
+  repeated sfixed64 unpacked_sfixed64 = 98 [packed = false];
+  repeated float unpacked_float = 99 [packed = false];
+  repeated double unpacked_double = 100 [packed = false];
+  repeated bool unpacked_bool = 101 [packed = false];
+  repeated NestedEnum unpacked_nested_enum = 102 [packed = false];
 
   // Map
-  map <   int32, int32>    map_int32_int32 = 56;
-  map <   int64, int64>    map_int64_int64 = 57;
-  map <  uint32, uint32>   map_uint32_uint32 = 58;
-  map <  uint64, uint64>   map_uint64_uint64 = 59;
-  map <  sint32, sint32>   map_sint32_sint32 = 60;
-  map <  sint64, sint64>   map_sint64_sint64 = 61;
-  map < fixed32, fixed32>  map_fixed32_fixed32 = 62;
-  map < fixed64, fixed64>  map_fixed64_fixed64 = 63;
-  map <sfixed32, sfixed32> map_sfixed32_sfixed32 = 64;
-  map <sfixed64, sfixed64> map_sfixed64_sfixed64 = 65;
-  map <   int32, float>    map_int32_float = 66;
-  map <   int32, double>   map_int32_double = 67;
-  map <    bool, bool>     map_bool_bool = 68;
-  map <  string, string>   map_string_string = 69;
-  map <  string, bytes>    map_string_bytes = 70;
-  map <  string, NestedMessage>  map_string_nested_message = 71;
-  map <  string, ForeignMessageProto2> map_string_foreign_message = 72;
-  map <  string, NestedEnum>     map_string_nested_enum = 73;
-  map <  string, ForeignEnumProto2>    map_string_foreign_enum = 74;
+  map<int32, int32> map_int32_int32 = 56;
+  map<int64, int64> map_int64_int64 = 57;
+  map<uint32, uint32> map_uint32_uint32 = 58;
+  map<uint64, uint64> map_uint64_uint64 = 59;
+  map<sint32, sint32> map_sint32_sint32 = 60;
+  map<sint64, sint64> map_sint64_sint64 = 61;
+  map<fixed32, fixed32> map_fixed32_fixed32 = 62;
+  map<fixed64, fixed64> map_fixed64_fixed64 = 63;
+  map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64;
+  map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65;
+  map<int32, float> map_int32_float = 66;
+  map<int32, double> map_int32_double = 67;
+  map<bool, bool> map_bool_bool = 68;
+  map<string, string> map_string_string = 69;
+  map<string, bytes> map_string_bytes = 70;
+  map<string, NestedMessage> map_string_nested_message = 71;
+  map<string, ForeignMessageProto2> map_string_foreign_message = 72;
+  map<string, NestedEnum> map_string_nested_enum = 73;
+  map<string, ForeignEnumProto2> map_string_foreign_enum = 74;
 
   oneof oneof_field {
     uint32 oneof_uint32 = 111;
@@ -159,7 +192,7 @@ message TestAllTypesProto2 {
   optional group Data = 201 {
     optional int32 group_int32 = 202;
     optional uint32 group_uint32 = 203;
-  };
+  }
 
   // Test field-name-to-JSON-name convention.
   // (protobuf says names can be any valid C/C++ identifier.)
@@ -188,6 +221,7 @@ message TestAllTypesProto2 {
   // message_set test case.
   message MessageSetCorrect {
     option message_set_wire_format = true;
+
     extensions 4 to max;
   }
 
@@ -221,7 +255,7 @@ extend TestAllTypesProto2 {
 }
 
 message UnknownToTestAllTypes {
-  optional int32  optional_int32 = 1001;
+  optional int32 optional_int32 = 1001;
   optional string optional_string = 1002;
   optional ForeignMessageProto2 nested_message = 1003;
   optional group OptionalGroup = 1004 {
@@ -230,4 +264,3 @@ message UnknownToTestAllTypes {
   optional bool optional_bool = 1006;
   repeated int32 repeated_int32 = 1011;
 }
-

--- a/Protos/google/protobuf/test_messages_proto3.proto
+++ b/Protos/google/protobuf/test_messages_proto3.proto
@@ -38,6 +38,7 @@
 syntax = "proto3";
 
 package protobuf_test_messages.proto3;
+
 option java_package = "com.google.protobuf_test_messages.proto3";
 option objc_class_prefix = "Proto3";
 
@@ -85,80 +86,112 @@ message TestAllTypesProto3 {
   }
 
   // Singular
-  int32 optional_int32    =  1;
-  int64 optional_int64    =  2;
-  uint32 optional_uint32   =  3;
-  uint64 optional_uint64   =  4;
-  sint32 optional_sint32   =  5;
-  sint64 optional_sint64   =  6;
-  fixed32 optional_fixed32  =  7;
-  fixed64 optional_fixed64  =  8;
-  sfixed32 optional_sfixed32 =  9;
+  int32 optional_int32 = 1;
+  int64 optional_int64 = 2;
+  uint32 optional_uint32 = 3;
+  uint64 optional_uint64 = 4;
+  sint32 optional_sint32 = 5;
+  sint64 optional_sint64 = 6;
+  fixed32 optional_fixed32 = 7;
+  fixed64 optional_fixed64 = 8;
+  sfixed32 optional_sfixed32 = 9;
   sfixed64 optional_sfixed64 = 10;
-  float optional_float    = 11;
-  double optional_double   = 12;
-  bool optional_bool     = 13;
-  string optional_string   = 14;
-  bytes optional_bytes    = 15;
+  float optional_float = 11;
+  double optional_double = 12;
+  bool optional_bool = 13;
+  string optional_string = 14;
+  bytes optional_bytes = 15;
 
-  NestedMessage                        optional_nested_message  = 18;
-  ForeignMessage                       optional_foreign_message = 19;
+  NestedMessage optional_nested_message = 18;
+  ForeignMessage optional_foreign_message = 19;
 
-  NestedEnum                           optional_nested_enum     = 21;
-  ForeignEnum                          optional_foreign_enum    = 22;
-  AliasedEnum                          optional_aliased_enum    = 23;
+  NestedEnum optional_nested_enum = 21;
+  ForeignEnum optional_foreign_enum = 22;
+  AliasedEnum optional_aliased_enum = 23;
 
-  string optional_string_piece = 24 [ctype=STRING_PIECE];
-  string optional_cord = 25 [ctype=CORD];
+  string optional_string_piece = 24 [ctype = STRING_PIECE];
+  string optional_cord = 25 [ctype = CORD];
 
   TestAllTypesProto3 recursive_message = 27;
 
   // Repeated
-  repeated    int32 repeated_int32    = 31;
-  repeated    int64 repeated_int64    = 32;
-  repeated   uint32 repeated_uint32   = 33;
-  repeated   uint64 repeated_uint64   = 34;
-  repeated   sint32 repeated_sint32   = 35;
-  repeated   sint64 repeated_sint64   = 36;
-  repeated  fixed32 repeated_fixed32  = 37;
-  repeated  fixed64 repeated_fixed64  = 38;
+  repeated int32 repeated_int32 = 31;
+  repeated int64 repeated_int64 = 32;
+  repeated uint32 repeated_uint32 = 33;
+  repeated uint64 repeated_uint64 = 34;
+  repeated sint32 repeated_sint32 = 35;
+  repeated sint64 repeated_sint64 = 36;
+  repeated fixed32 repeated_fixed32 = 37;
+  repeated fixed64 repeated_fixed64 = 38;
   repeated sfixed32 repeated_sfixed32 = 39;
   repeated sfixed64 repeated_sfixed64 = 40;
-  repeated    float repeated_float    = 41;
-  repeated   double repeated_double   = 42;
-  repeated     bool repeated_bool     = 43;
-  repeated   string repeated_string   = 44;
-  repeated    bytes repeated_bytes    = 45;
+  repeated float repeated_float = 41;
+  repeated double repeated_double = 42;
+  repeated bool repeated_bool = 43;
+  repeated string repeated_string = 44;
+  repeated bytes repeated_bytes = 45;
 
-  repeated NestedMessage                        repeated_nested_message  = 48;
-  repeated ForeignMessage                       repeated_foreign_message = 49;
+  repeated NestedMessage repeated_nested_message = 48;
+  repeated ForeignMessage repeated_foreign_message = 49;
 
-  repeated NestedEnum                           repeated_nested_enum     = 51;
-  repeated ForeignEnum                          repeated_foreign_enum    = 52;
+  repeated NestedEnum repeated_nested_enum = 51;
+  repeated ForeignEnum repeated_foreign_enum = 52;
 
-  repeated string repeated_string_piece = 54 [ctype=STRING_PIECE];
-  repeated string repeated_cord = 55 [ctype=CORD];
+  repeated string repeated_string_piece = 54 [ctype = STRING_PIECE];
+  repeated string repeated_cord = 55 [ctype = CORD];
+
+  // Packed
+  repeated int32 packed_int32 = 75 [packed = true];
+  repeated int64 packed_int64 = 76 [packed = true];
+  repeated uint32 packed_uint32 = 77 [packed = true];
+  repeated uint64 packed_uint64 = 78 [packed = true];
+  repeated sint32 packed_sint32 = 79 [packed = true];
+  repeated sint64 packed_sint64 = 80 [packed = true];
+  repeated fixed32 packed_fixed32 = 81 [packed = true];
+  repeated fixed64 packed_fixed64 = 82 [packed = true];
+  repeated sfixed32 packed_sfixed32 = 83 [packed = true];
+  repeated sfixed64 packed_sfixed64 = 84 [packed = true];
+  repeated float packed_float = 85 [packed = true];
+  repeated double packed_double = 86 [packed = true];
+  repeated bool packed_bool = 87 [packed = true];
+  repeated NestedEnum packed_nested_enum = 88 [packed = true];
+
+  // Unpacked
+  repeated int32 unpacked_int32 = 89 [packed = false];
+  repeated int64 unpacked_int64 = 90 [packed = false];
+  repeated uint32 unpacked_uint32 = 91 [packed = false];
+  repeated uint64 unpacked_uint64 = 92 [packed = false];
+  repeated sint32 unpacked_sint32 = 93 [packed = false];
+  repeated sint64 unpacked_sint64 = 94 [packed = false];
+  repeated fixed32 unpacked_fixed32 = 95 [packed = false];
+  repeated fixed64 unpacked_fixed64 = 96 [packed = false];
+  repeated sfixed32 unpacked_sfixed32 = 97 [packed = false];
+  repeated sfixed64 unpacked_sfixed64 = 98 [packed = false];
+  repeated float unpacked_float = 99 [packed = false];
+  repeated double unpacked_double = 100 [packed = false];
+  repeated bool unpacked_bool = 101 [packed = false];
+  repeated NestedEnum unpacked_nested_enum = 102 [packed = false];
 
   // Map
-  map <   int32, int32>    map_int32_int32 = 56;
-  map <   int64, int64>    map_int64_int64 = 57;
-  map <  uint32, uint32>   map_uint32_uint32 = 58;
-  map <  uint64, uint64>   map_uint64_uint64 = 59;
-  map <  sint32, sint32>   map_sint32_sint32 = 60;
-  map <  sint64, sint64>   map_sint64_sint64 = 61;
-  map < fixed32, fixed32>  map_fixed32_fixed32 = 62;
-  map < fixed64, fixed64>  map_fixed64_fixed64 = 63;
-  map <sfixed32, sfixed32> map_sfixed32_sfixed32 = 64;
-  map <sfixed64, sfixed64> map_sfixed64_sfixed64 = 65;
-  map <   int32, float>    map_int32_float = 66;
-  map <   int32, double>   map_int32_double = 67;
-  map <    bool, bool>     map_bool_bool = 68;
-  map <  string, string>   map_string_string = 69;
-  map <  string, bytes>    map_string_bytes = 70;
-  map <  string, NestedMessage>  map_string_nested_message = 71;
-  map <  string, ForeignMessage> map_string_foreign_message = 72;
-  map <  string, NestedEnum>     map_string_nested_enum = 73;
-  map <  string, ForeignEnum>    map_string_foreign_enum = 74;
+  map<int32, int32> map_int32_int32 = 56;
+  map<int64, int64> map_int64_int64 = 57;
+  map<uint32, uint32> map_uint32_uint32 = 58;
+  map<uint64, uint64> map_uint64_uint64 = 59;
+  map<sint32, sint32> map_sint32_sint32 = 60;
+  map<sint64, sint64> map_sint64_sint64 = 61;
+  map<fixed32, fixed32> map_fixed32_fixed32 = 62;
+  map<fixed64, fixed64> map_fixed64_fixed64 = 63;
+  map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64;
+  map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65;
+  map<int32, float> map_int32_float = 66;
+  map<int32, double> map_int32_double = 67;
+  map<bool, bool> map_bool_bool = 68;
+  map<string, string> map_string_string = 69;
+  map<string, bytes> map_string_bytes = 70;
+  map<string, NestedMessage> map_string_nested_message = 71;
+  map<string, ForeignMessage> map_string_foreign_message = 72;
+  map<string, NestedEnum> map_string_nested_enum = 73;
+  map<string, ForeignEnum> map_string_foreign_enum = 74;
 
   oneof oneof_field {
     uint32 oneof_uint32 = 111;

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -69,7 +69,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///     if (duration.seconds < 0 && duration.nanos > 0) {
 ///       duration.seconds += 1;
 ///       duration.nanos -= 1000000000;
-///     } else if (durations.seconds > 0 && duration.nanos < 0) {
+///     } else if (duration.seconds > 0 && duration.nanos < 0) {
 ///       duration.seconds -= 1;
 ///       duration.nanos += 1000000000;
 ///     }

--- a/Reference/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto2.pb.swift
@@ -409,6 +409,148 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
+  /// Packed
+  var packedInt32: [Int32] {
+    get {return _storage._packedInt32}
+    set {_uniqueStorage()._packedInt32 = newValue}
+  }
+
+  var packedInt64: [Int64] {
+    get {return _storage._packedInt64}
+    set {_uniqueStorage()._packedInt64 = newValue}
+  }
+
+  var packedUint32: [UInt32] {
+    get {return _storage._packedUint32}
+    set {_uniqueStorage()._packedUint32 = newValue}
+  }
+
+  var packedUint64: [UInt64] {
+    get {return _storage._packedUint64}
+    set {_uniqueStorage()._packedUint64 = newValue}
+  }
+
+  var packedSint32: [Int32] {
+    get {return _storage._packedSint32}
+    set {_uniqueStorage()._packedSint32 = newValue}
+  }
+
+  var packedSint64: [Int64] {
+    get {return _storage._packedSint64}
+    set {_uniqueStorage()._packedSint64 = newValue}
+  }
+
+  var packedFixed32: [UInt32] {
+    get {return _storage._packedFixed32}
+    set {_uniqueStorage()._packedFixed32 = newValue}
+  }
+
+  var packedFixed64: [UInt64] {
+    get {return _storage._packedFixed64}
+    set {_uniqueStorage()._packedFixed64 = newValue}
+  }
+
+  var packedSfixed32: [Int32] {
+    get {return _storage._packedSfixed32}
+    set {_uniqueStorage()._packedSfixed32 = newValue}
+  }
+
+  var packedSfixed64: [Int64] {
+    get {return _storage._packedSfixed64}
+    set {_uniqueStorage()._packedSfixed64 = newValue}
+  }
+
+  var packedFloat: [Float] {
+    get {return _storage._packedFloat}
+    set {_uniqueStorage()._packedFloat = newValue}
+  }
+
+  var packedDouble: [Double] {
+    get {return _storage._packedDouble}
+    set {_uniqueStorage()._packedDouble = newValue}
+  }
+
+  var packedBool: [Bool] {
+    get {return _storage._packedBool}
+    set {_uniqueStorage()._packedBool = newValue}
+  }
+
+  var packedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] {
+    get {return _storage._packedNestedEnum}
+    set {_uniqueStorage()._packedNestedEnum = newValue}
+  }
+
+  /// Unpacked
+  var unpackedInt32: [Int32] {
+    get {return _storage._unpackedInt32}
+    set {_uniqueStorage()._unpackedInt32 = newValue}
+  }
+
+  var unpackedInt64: [Int64] {
+    get {return _storage._unpackedInt64}
+    set {_uniqueStorage()._unpackedInt64 = newValue}
+  }
+
+  var unpackedUint32: [UInt32] {
+    get {return _storage._unpackedUint32}
+    set {_uniqueStorage()._unpackedUint32 = newValue}
+  }
+
+  var unpackedUint64: [UInt64] {
+    get {return _storage._unpackedUint64}
+    set {_uniqueStorage()._unpackedUint64 = newValue}
+  }
+
+  var unpackedSint32: [Int32] {
+    get {return _storage._unpackedSint32}
+    set {_uniqueStorage()._unpackedSint32 = newValue}
+  }
+
+  var unpackedSint64: [Int64] {
+    get {return _storage._unpackedSint64}
+    set {_uniqueStorage()._unpackedSint64 = newValue}
+  }
+
+  var unpackedFixed32: [UInt32] {
+    get {return _storage._unpackedFixed32}
+    set {_uniqueStorage()._unpackedFixed32 = newValue}
+  }
+
+  var unpackedFixed64: [UInt64] {
+    get {return _storage._unpackedFixed64}
+    set {_uniqueStorage()._unpackedFixed64 = newValue}
+  }
+
+  var unpackedSfixed32: [Int32] {
+    get {return _storage._unpackedSfixed32}
+    set {_uniqueStorage()._unpackedSfixed32 = newValue}
+  }
+
+  var unpackedSfixed64: [Int64] {
+    get {return _storage._unpackedSfixed64}
+    set {_uniqueStorage()._unpackedSfixed64 = newValue}
+  }
+
+  var unpackedFloat: [Float] {
+    get {return _storage._unpackedFloat}
+    set {_uniqueStorage()._unpackedFloat = newValue}
+  }
+
+  var unpackedDouble: [Double] {
+    get {return _storage._unpackedDouble}
+    set {_uniqueStorage()._unpackedDouble = newValue}
+  }
+
+  var unpackedBool: [Bool] {
+    get {return _storage._unpackedBool}
+    set {_uniqueStorage()._unpackedBool = newValue}
+  }
+
+  var unpackedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] {
+    get {return _storage._unpackedNestedEnum}
+    set {_uniqueStorage()._unpackedNestedEnum = newValue}
+  }
+
   /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
@@ -1200,6 +1342,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
     52: .standard(proto: "repeated_foreign_enum"),
     54: .standard(proto: "repeated_string_piece"),
     55: .standard(proto: "repeated_cord"),
+    75: .standard(proto: "packed_int32"),
+    76: .standard(proto: "packed_int64"),
+    77: .standard(proto: "packed_uint32"),
+    78: .standard(proto: "packed_uint64"),
+    79: .standard(proto: "packed_sint32"),
+    80: .standard(proto: "packed_sint64"),
+    81: .standard(proto: "packed_fixed32"),
+    82: .standard(proto: "packed_fixed64"),
+    83: .standard(proto: "packed_sfixed32"),
+    84: .standard(proto: "packed_sfixed64"),
+    85: .standard(proto: "packed_float"),
+    86: .standard(proto: "packed_double"),
+    87: .standard(proto: "packed_bool"),
+    88: .standard(proto: "packed_nested_enum"),
+    89: .standard(proto: "unpacked_int32"),
+    90: .standard(proto: "unpacked_int64"),
+    91: .standard(proto: "unpacked_uint32"),
+    92: .standard(proto: "unpacked_uint64"),
+    93: .standard(proto: "unpacked_sint32"),
+    94: .standard(proto: "unpacked_sint64"),
+    95: .standard(proto: "unpacked_fixed32"),
+    96: .standard(proto: "unpacked_fixed64"),
+    97: .standard(proto: "unpacked_sfixed32"),
+    98: .standard(proto: "unpacked_sfixed64"),
+    99: .standard(proto: "unpacked_float"),
+    100: .standard(proto: "unpacked_double"),
+    101: .standard(proto: "unpacked_bool"),
+    102: .standard(proto: "unpacked_nested_enum"),
     56: .standard(proto: "map_int32_int32"),
     57: .standard(proto: "map_int64_int64"),
     58: .standard(proto: "map_uint32_uint32"),
@@ -1293,6 +1463,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
     var _repeatedForeignEnum: [ProtobufTestMessages_Proto2_ForeignEnumProto2] = []
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
+    var _packedInt32: [Int32] = []
+    var _packedInt64: [Int64] = []
+    var _packedUint32: [UInt32] = []
+    var _packedUint64: [UInt64] = []
+    var _packedSint32: [Int32] = []
+    var _packedSint64: [Int64] = []
+    var _packedFixed32: [UInt32] = []
+    var _packedFixed64: [UInt64] = []
+    var _packedSfixed32: [Int32] = []
+    var _packedSfixed64: [Int64] = []
+    var _packedFloat: [Float] = []
+    var _packedDouble: [Double] = []
+    var _packedBool: [Bool] = []
+    var _packedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] = []
+    var _unpackedInt32: [Int32] = []
+    var _unpackedInt64: [Int64] = []
+    var _unpackedUint32: [UInt32] = []
+    var _unpackedUint64: [UInt64] = []
+    var _unpackedSint32: [Int32] = []
+    var _unpackedSint64: [Int64] = []
+    var _unpackedFixed32: [UInt32] = []
+    var _unpackedFixed64: [UInt64] = []
+    var _unpackedSfixed32: [Int32] = []
+    var _unpackedSfixed64: [Int64] = []
+    var _unpackedFloat: [Float] = []
+    var _unpackedDouble: [Double] = []
+    var _unpackedBool: [Bool] = []
+    var _unpackedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] = []
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -1381,6 +1579,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       _repeatedForeignEnum = source._repeatedForeignEnum
       _repeatedStringPiece = source._repeatedStringPiece
       _repeatedCord = source._repeatedCord
+      _packedInt32 = source._packedInt32
+      _packedInt64 = source._packedInt64
+      _packedUint32 = source._packedUint32
+      _packedUint64 = source._packedUint64
+      _packedSint32 = source._packedSint32
+      _packedSint64 = source._packedSint64
+      _packedFixed32 = source._packedFixed32
+      _packedFixed64 = source._packedFixed64
+      _packedSfixed32 = source._packedSfixed32
+      _packedSfixed64 = source._packedSfixed64
+      _packedFloat = source._packedFloat
+      _packedDouble = source._packedDouble
+      _packedBool = source._packedBool
+      _packedNestedEnum = source._packedNestedEnum
+      _unpackedInt32 = source._unpackedInt32
+      _unpackedInt64 = source._unpackedInt64
+      _unpackedUint32 = source._unpackedUint32
+      _unpackedUint64 = source._unpackedUint64
+      _unpackedSint32 = source._unpackedSint32
+      _unpackedSint64 = source._unpackedSint64
+      _unpackedFixed32 = source._unpackedFixed32
+      _unpackedFixed64 = source._unpackedFixed64
+      _unpackedSfixed32 = source._unpackedSfixed32
+      _unpackedSfixed64 = source._unpackedSfixed64
+      _unpackedFloat = source._unpackedFloat
+      _unpackedDouble = source._unpackedDouble
+      _unpackedBool = source._unpackedBool
+      _unpackedNestedEnum = source._unpackedNestedEnum
       _mapInt32Int32 = source._mapInt32Int32
       _mapInt64Int64 = source._mapInt64Int64
       _mapUint32Uint32 = source._mapUint32Uint32
@@ -1509,6 +1735,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignMessageProto2>.self, value: &_storage._mapStringForeignMessage)
         case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
         case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignEnumProto2>.self, value: &_storage._mapStringForeignEnum)
+        case 75: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
+        case 76: try decoder.decodeRepeatedInt64Field(value: &_storage._packedInt64)
+        case 77: try decoder.decodeRepeatedUInt32Field(value: &_storage._packedUint32)
+        case 78: try decoder.decodeRepeatedUInt64Field(value: &_storage._packedUint64)
+        case 79: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedSint32)
+        case 80: try decoder.decodeRepeatedSInt64Field(value: &_storage._packedSint64)
+        case 81: try decoder.decodeRepeatedFixed32Field(value: &_storage._packedFixed32)
+        case 82: try decoder.decodeRepeatedFixed64Field(value: &_storage._packedFixed64)
+        case 83: try decoder.decodeRepeatedSFixed32Field(value: &_storage._packedSfixed32)
+        case 84: try decoder.decodeRepeatedSFixed64Field(value: &_storage._packedSfixed64)
+        case 85: try decoder.decodeRepeatedFloatField(value: &_storage._packedFloat)
+        case 86: try decoder.decodeRepeatedDoubleField(value: &_storage._packedDouble)
+        case 87: try decoder.decodeRepeatedBoolField(value: &_storage._packedBool)
+        case 88: try decoder.decodeRepeatedEnumField(value: &_storage._packedNestedEnum)
+        case 89: try decoder.decodeRepeatedInt32Field(value: &_storage._unpackedInt32)
+        case 90: try decoder.decodeRepeatedInt64Field(value: &_storage._unpackedInt64)
+        case 91: try decoder.decodeRepeatedUInt32Field(value: &_storage._unpackedUint32)
+        case 92: try decoder.decodeRepeatedUInt64Field(value: &_storage._unpackedUint64)
+        case 93: try decoder.decodeRepeatedSInt32Field(value: &_storage._unpackedSint32)
+        case 94: try decoder.decodeRepeatedSInt64Field(value: &_storage._unpackedSint64)
+        case 95: try decoder.decodeRepeatedFixed32Field(value: &_storage._unpackedFixed32)
+        case 96: try decoder.decodeRepeatedFixed64Field(value: &_storage._unpackedFixed64)
+        case 97: try decoder.decodeRepeatedSFixed32Field(value: &_storage._unpackedSfixed32)
+        case 98: try decoder.decodeRepeatedSFixed64Field(value: &_storage._unpackedSfixed64)
+        case 99: try decoder.decodeRepeatedFloatField(value: &_storage._unpackedFloat)
+        case 100: try decoder.decodeRepeatedDoubleField(value: &_storage._unpackedDouble)
+        case 101: try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool)
+        case 102: try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum)
         case 111:
           if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
@@ -1772,6 +2026,90 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignEnumProto2>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
+      if !_storage._packedInt32.isEmpty {
+        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 75)
+      }
+      if !_storage._packedInt64.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._packedInt64, fieldNumber: 76)
+      }
+      if !_storage._packedUint32.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._packedUint32, fieldNumber: 77)
+      }
+      if !_storage._packedUint64.isEmpty {
+        try visitor.visitPackedUInt64Field(value: _storage._packedUint64, fieldNumber: 78)
+      }
+      if !_storage._packedSint32.isEmpty {
+        try visitor.visitPackedSInt32Field(value: _storage._packedSint32, fieldNumber: 79)
+      }
+      if !_storage._packedSint64.isEmpty {
+        try visitor.visitPackedSInt64Field(value: _storage._packedSint64, fieldNumber: 80)
+      }
+      if !_storage._packedFixed32.isEmpty {
+        try visitor.visitPackedFixed32Field(value: _storage._packedFixed32, fieldNumber: 81)
+      }
+      if !_storage._packedFixed64.isEmpty {
+        try visitor.visitPackedFixed64Field(value: _storage._packedFixed64, fieldNumber: 82)
+      }
+      if !_storage._packedSfixed32.isEmpty {
+        try visitor.visitPackedSFixed32Field(value: _storage._packedSfixed32, fieldNumber: 83)
+      }
+      if !_storage._packedSfixed64.isEmpty {
+        try visitor.visitPackedSFixed64Field(value: _storage._packedSfixed64, fieldNumber: 84)
+      }
+      if !_storage._packedFloat.isEmpty {
+        try visitor.visitPackedFloatField(value: _storage._packedFloat, fieldNumber: 85)
+      }
+      if !_storage._packedDouble.isEmpty {
+        try visitor.visitPackedDoubleField(value: _storage._packedDouble, fieldNumber: 86)
+      }
+      if !_storage._packedBool.isEmpty {
+        try visitor.visitPackedBoolField(value: _storage._packedBool, fieldNumber: 87)
+      }
+      if !_storage._packedNestedEnum.isEmpty {
+        try visitor.visitPackedEnumField(value: _storage._packedNestedEnum, fieldNumber: 88)
+      }
+      if !_storage._unpackedInt32.isEmpty {
+        try visitor.visitRepeatedInt32Field(value: _storage._unpackedInt32, fieldNumber: 89)
+      }
+      if !_storage._unpackedInt64.isEmpty {
+        try visitor.visitRepeatedInt64Field(value: _storage._unpackedInt64, fieldNumber: 90)
+      }
+      if !_storage._unpackedUint32.isEmpty {
+        try visitor.visitRepeatedUInt32Field(value: _storage._unpackedUint32, fieldNumber: 91)
+      }
+      if !_storage._unpackedUint64.isEmpty {
+        try visitor.visitRepeatedUInt64Field(value: _storage._unpackedUint64, fieldNumber: 92)
+      }
+      if !_storage._unpackedSint32.isEmpty {
+        try visitor.visitRepeatedSInt32Field(value: _storage._unpackedSint32, fieldNumber: 93)
+      }
+      if !_storage._unpackedSint64.isEmpty {
+        try visitor.visitRepeatedSInt64Field(value: _storage._unpackedSint64, fieldNumber: 94)
+      }
+      if !_storage._unpackedFixed32.isEmpty {
+        try visitor.visitRepeatedFixed32Field(value: _storage._unpackedFixed32, fieldNumber: 95)
+      }
+      if !_storage._unpackedFixed64.isEmpty {
+        try visitor.visitRepeatedFixed64Field(value: _storage._unpackedFixed64, fieldNumber: 96)
+      }
+      if !_storage._unpackedSfixed32.isEmpty {
+        try visitor.visitRepeatedSFixed32Field(value: _storage._unpackedSfixed32, fieldNumber: 97)
+      }
+      if !_storage._unpackedSfixed64.isEmpty {
+        try visitor.visitRepeatedSFixed64Field(value: _storage._unpackedSfixed64, fieldNumber: 98)
+      }
+      if !_storage._unpackedFloat.isEmpty {
+        try visitor.visitRepeatedFloatField(value: _storage._unpackedFloat, fieldNumber: 99)
+      }
+      if !_storage._unpackedDouble.isEmpty {
+        try visitor.visitRepeatedDoubleField(value: _storage._unpackedDouble, fieldNumber: 100)
+      }
+      if !_storage._unpackedBool.isEmpty {
+        try visitor.visitRepeatedBoolField(value: _storage._unpackedBool, fieldNumber: 101)
+      }
+      if !_storage._unpackedNestedEnum.isEmpty {
+        try visitor.visitRepeatedEnumField(value: _storage._unpackedNestedEnum, fieldNumber: 102)
+      }
       switch _storage._oneofField {
       case .oneofUint32(let v)?:
         try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
@@ -1903,6 +2241,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         if _storage._repeatedForeignEnum != rhs_storage._repeatedForeignEnum {return false}
         if _storage._repeatedStringPiece != rhs_storage._repeatedStringPiece {return false}
         if _storage._repeatedCord != rhs_storage._repeatedCord {return false}
+        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
+        if _storage._packedInt64 != rhs_storage._packedInt64 {return false}
+        if _storage._packedUint32 != rhs_storage._packedUint32 {return false}
+        if _storage._packedUint64 != rhs_storage._packedUint64 {return false}
+        if _storage._packedSint32 != rhs_storage._packedSint32 {return false}
+        if _storage._packedSint64 != rhs_storage._packedSint64 {return false}
+        if _storage._packedFixed32 != rhs_storage._packedFixed32 {return false}
+        if _storage._packedFixed64 != rhs_storage._packedFixed64 {return false}
+        if _storage._packedSfixed32 != rhs_storage._packedSfixed32 {return false}
+        if _storage._packedSfixed64 != rhs_storage._packedSfixed64 {return false}
+        if _storage._packedFloat != rhs_storage._packedFloat {return false}
+        if _storage._packedDouble != rhs_storage._packedDouble {return false}
+        if _storage._packedBool != rhs_storage._packedBool {return false}
+        if _storage._packedNestedEnum != rhs_storage._packedNestedEnum {return false}
+        if _storage._unpackedInt32 != rhs_storage._unpackedInt32 {return false}
+        if _storage._unpackedInt64 != rhs_storage._unpackedInt64 {return false}
+        if _storage._unpackedUint32 != rhs_storage._unpackedUint32 {return false}
+        if _storage._unpackedUint64 != rhs_storage._unpackedUint64 {return false}
+        if _storage._unpackedSint32 != rhs_storage._unpackedSint32 {return false}
+        if _storage._unpackedSint64 != rhs_storage._unpackedSint64 {return false}
+        if _storage._unpackedFixed32 != rhs_storage._unpackedFixed32 {return false}
+        if _storage._unpackedFixed64 != rhs_storage._unpackedFixed64 {return false}
+        if _storage._unpackedSfixed32 != rhs_storage._unpackedSfixed32 {return false}
+        if _storage._unpackedSfixed64 != rhs_storage._unpackedSfixed64 {return false}
+        if _storage._unpackedFloat != rhs_storage._unpackedFloat {return false}
+        if _storage._unpackedDouble != rhs_storage._unpackedDouble {return false}
+        if _storage._unpackedBool != rhs_storage._unpackedBool {return false}
+        if _storage._unpackedNestedEnum != rhs_storage._unpackedNestedEnum {return false}
         if _storage._mapInt32Int32 != rhs_storage._mapInt32Int32 {return false}
         if _storage._mapInt64Int64 != rhs_storage._mapInt64Int64 {return false}
         if _storage._mapUint32Uint32 != rhs_storage._mapUint32Uint32 {return false}

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -345,6 +345,148 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
+  /// Packed
+  var packedInt32: [Int32] {
+    get {return _storage._packedInt32}
+    set {_uniqueStorage()._packedInt32 = newValue}
+  }
+
+  var packedInt64: [Int64] {
+    get {return _storage._packedInt64}
+    set {_uniqueStorage()._packedInt64 = newValue}
+  }
+
+  var packedUint32: [UInt32] {
+    get {return _storage._packedUint32}
+    set {_uniqueStorage()._packedUint32 = newValue}
+  }
+
+  var packedUint64: [UInt64] {
+    get {return _storage._packedUint64}
+    set {_uniqueStorage()._packedUint64 = newValue}
+  }
+
+  var packedSint32: [Int32] {
+    get {return _storage._packedSint32}
+    set {_uniqueStorage()._packedSint32 = newValue}
+  }
+
+  var packedSint64: [Int64] {
+    get {return _storage._packedSint64}
+    set {_uniqueStorage()._packedSint64 = newValue}
+  }
+
+  var packedFixed32: [UInt32] {
+    get {return _storage._packedFixed32}
+    set {_uniqueStorage()._packedFixed32 = newValue}
+  }
+
+  var packedFixed64: [UInt64] {
+    get {return _storage._packedFixed64}
+    set {_uniqueStorage()._packedFixed64 = newValue}
+  }
+
+  var packedSfixed32: [Int32] {
+    get {return _storage._packedSfixed32}
+    set {_uniqueStorage()._packedSfixed32 = newValue}
+  }
+
+  var packedSfixed64: [Int64] {
+    get {return _storage._packedSfixed64}
+    set {_uniqueStorage()._packedSfixed64 = newValue}
+  }
+
+  var packedFloat: [Float] {
+    get {return _storage._packedFloat}
+    set {_uniqueStorage()._packedFloat = newValue}
+  }
+
+  var packedDouble: [Double] {
+    get {return _storage._packedDouble}
+    set {_uniqueStorage()._packedDouble = newValue}
+  }
+
+  var packedBool: [Bool] {
+    get {return _storage._packedBool}
+    set {_uniqueStorage()._packedBool = newValue}
+  }
+
+  var packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._packedNestedEnum}
+    set {_uniqueStorage()._packedNestedEnum = newValue}
+  }
+
+  /// Unpacked
+  var unpackedInt32: [Int32] {
+    get {return _storage._unpackedInt32}
+    set {_uniqueStorage()._unpackedInt32 = newValue}
+  }
+
+  var unpackedInt64: [Int64] {
+    get {return _storage._unpackedInt64}
+    set {_uniqueStorage()._unpackedInt64 = newValue}
+  }
+
+  var unpackedUint32: [UInt32] {
+    get {return _storage._unpackedUint32}
+    set {_uniqueStorage()._unpackedUint32 = newValue}
+  }
+
+  var unpackedUint64: [UInt64] {
+    get {return _storage._unpackedUint64}
+    set {_uniqueStorage()._unpackedUint64 = newValue}
+  }
+
+  var unpackedSint32: [Int32] {
+    get {return _storage._unpackedSint32}
+    set {_uniqueStorage()._unpackedSint32 = newValue}
+  }
+
+  var unpackedSint64: [Int64] {
+    get {return _storage._unpackedSint64}
+    set {_uniqueStorage()._unpackedSint64 = newValue}
+  }
+
+  var unpackedFixed32: [UInt32] {
+    get {return _storage._unpackedFixed32}
+    set {_uniqueStorage()._unpackedFixed32 = newValue}
+  }
+
+  var unpackedFixed64: [UInt64] {
+    get {return _storage._unpackedFixed64}
+    set {_uniqueStorage()._unpackedFixed64 = newValue}
+  }
+
+  var unpackedSfixed32: [Int32] {
+    get {return _storage._unpackedSfixed32}
+    set {_uniqueStorage()._unpackedSfixed32 = newValue}
+  }
+
+  var unpackedSfixed64: [Int64] {
+    get {return _storage._unpackedSfixed64}
+    set {_uniqueStorage()._unpackedSfixed64 = newValue}
+  }
+
+  var unpackedFloat: [Float] {
+    get {return _storage._unpackedFloat}
+    set {_uniqueStorage()._unpackedFloat = newValue}
+  }
+
+  var unpackedDouble: [Double] {
+    get {return _storage._unpackedDouble}
+    set {_uniqueStorage()._unpackedDouble = newValue}
+  }
+
+  var unpackedBool: [Bool] {
+    get {return _storage._unpackedBool}
+    set {_uniqueStorage()._unpackedBool = newValue}
+  }
+
+  var unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._unpackedNestedEnum}
+    set {_uniqueStorage()._unpackedNestedEnum = newValue}
+  }
+
   /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
@@ -1051,6 +1193,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     52: .standard(proto: "repeated_foreign_enum"),
     54: .standard(proto: "repeated_string_piece"),
     55: .standard(proto: "repeated_cord"),
+    75: .standard(proto: "packed_int32"),
+    76: .standard(proto: "packed_int64"),
+    77: .standard(proto: "packed_uint32"),
+    78: .standard(proto: "packed_uint64"),
+    79: .standard(proto: "packed_sint32"),
+    80: .standard(proto: "packed_sint64"),
+    81: .standard(proto: "packed_fixed32"),
+    82: .standard(proto: "packed_fixed64"),
+    83: .standard(proto: "packed_sfixed32"),
+    84: .standard(proto: "packed_sfixed64"),
+    85: .standard(proto: "packed_float"),
+    86: .standard(proto: "packed_double"),
+    87: .standard(proto: "packed_bool"),
+    88: .standard(proto: "packed_nested_enum"),
+    89: .standard(proto: "unpacked_int32"),
+    90: .standard(proto: "unpacked_int64"),
+    91: .standard(proto: "unpacked_uint32"),
+    92: .standard(proto: "unpacked_uint64"),
+    93: .standard(proto: "unpacked_sint32"),
+    94: .standard(proto: "unpacked_sint64"),
+    95: .standard(proto: "unpacked_fixed32"),
+    96: .standard(proto: "unpacked_fixed64"),
+    97: .standard(proto: "unpacked_sfixed32"),
+    98: .standard(proto: "unpacked_sfixed64"),
+    99: .standard(proto: "unpacked_float"),
+    100: .standard(proto: "unpacked_double"),
+    101: .standard(proto: "unpacked_bool"),
+    102: .standard(proto: "unpacked_nested_enum"),
     56: .standard(proto: "map_int32_int32"),
     57: .standard(proto: "map_int64_int64"),
     58: .standard(proto: "map_uint32_uint32"),
@@ -1175,6 +1345,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     var _repeatedForeignEnum: [ProtobufTestMessages_Proto3_ForeignEnum] = []
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
+    var _packedInt32: [Int32] = []
+    var _packedInt64: [Int64] = []
+    var _packedUint32: [UInt32] = []
+    var _packedUint64: [UInt64] = []
+    var _packedSint32: [Int32] = []
+    var _packedSint64: [Int64] = []
+    var _packedFixed32: [UInt32] = []
+    var _packedFixed64: [UInt64] = []
+    var _packedSfixed32: [Int32] = []
+    var _packedSfixed64: [Int64] = []
+    var _packedFloat: [Float] = []
+    var _packedDouble: [Double] = []
+    var _packedBool: [Bool] = []
+    var _packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
+    var _unpackedInt32: [Int32] = []
+    var _unpackedInt64: [Int64] = []
+    var _unpackedUint32: [UInt32] = []
+    var _unpackedUint64: [UInt64] = []
+    var _unpackedSint32: [Int32] = []
+    var _unpackedSint64: [Int64] = []
+    var _unpackedFixed32: [UInt32] = []
+    var _unpackedFixed64: [UInt64] = []
+    var _unpackedSfixed32: [Int32] = []
+    var _unpackedSfixed64: [Int64] = []
+    var _unpackedFloat: [Float] = []
+    var _unpackedDouble: [Double] = []
+    var _unpackedBool: [Bool] = []
+    var _unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -1294,6 +1492,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       _repeatedForeignEnum = source._repeatedForeignEnum
       _repeatedStringPiece = source._repeatedStringPiece
       _repeatedCord = source._repeatedCord
+      _packedInt32 = source._packedInt32
+      _packedInt64 = source._packedInt64
+      _packedUint32 = source._packedUint32
+      _packedUint64 = source._packedUint64
+      _packedSint32 = source._packedSint32
+      _packedSint64 = source._packedSint64
+      _packedFixed32 = source._packedFixed32
+      _packedFixed64 = source._packedFixed64
+      _packedSfixed32 = source._packedSfixed32
+      _packedSfixed64 = source._packedSfixed64
+      _packedFloat = source._packedFloat
+      _packedDouble = source._packedDouble
+      _packedBool = source._packedBool
+      _packedNestedEnum = source._packedNestedEnum
+      _unpackedInt32 = source._unpackedInt32
+      _unpackedInt64 = source._unpackedInt64
+      _unpackedUint32 = source._unpackedUint32
+      _unpackedUint64 = source._unpackedUint64
+      _unpackedSint32 = source._unpackedSint32
+      _unpackedSint64 = source._unpackedSint64
+      _unpackedFixed32 = source._unpackedFixed32
+      _unpackedFixed64 = source._unpackedFixed64
+      _unpackedSfixed32 = source._unpackedSfixed32
+      _unpackedSfixed64 = source._unpackedSfixed64
+      _unpackedFloat = source._unpackedFloat
+      _unpackedDouble = source._unpackedDouble
+      _unpackedBool = source._unpackedBool
+      _unpackedNestedEnum = source._unpackedNestedEnum
       _mapInt32Int32 = source._mapInt32Int32
       _mapInt64Int64 = source._mapInt64Int64
       _mapUint32Uint32 = source._mapUint32Uint32
@@ -1441,6 +1667,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
         case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
         case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
+        case 75: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
+        case 76: try decoder.decodeRepeatedInt64Field(value: &_storage._packedInt64)
+        case 77: try decoder.decodeRepeatedUInt32Field(value: &_storage._packedUint32)
+        case 78: try decoder.decodeRepeatedUInt64Field(value: &_storage._packedUint64)
+        case 79: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedSint32)
+        case 80: try decoder.decodeRepeatedSInt64Field(value: &_storage._packedSint64)
+        case 81: try decoder.decodeRepeatedFixed32Field(value: &_storage._packedFixed32)
+        case 82: try decoder.decodeRepeatedFixed64Field(value: &_storage._packedFixed64)
+        case 83: try decoder.decodeRepeatedSFixed32Field(value: &_storage._packedSfixed32)
+        case 84: try decoder.decodeRepeatedSFixed64Field(value: &_storage._packedSfixed64)
+        case 85: try decoder.decodeRepeatedFloatField(value: &_storage._packedFloat)
+        case 86: try decoder.decodeRepeatedDoubleField(value: &_storage._packedDouble)
+        case 87: try decoder.decodeRepeatedBoolField(value: &_storage._packedBool)
+        case 88: try decoder.decodeRepeatedEnumField(value: &_storage._packedNestedEnum)
+        case 89: try decoder.decodeRepeatedInt32Field(value: &_storage._unpackedInt32)
+        case 90: try decoder.decodeRepeatedInt64Field(value: &_storage._unpackedInt64)
+        case 91: try decoder.decodeRepeatedUInt32Field(value: &_storage._unpackedUint32)
+        case 92: try decoder.decodeRepeatedUInt64Field(value: &_storage._unpackedUint64)
+        case 93: try decoder.decodeRepeatedSInt32Field(value: &_storage._unpackedSint32)
+        case 94: try decoder.decodeRepeatedSInt64Field(value: &_storage._unpackedSint64)
+        case 95: try decoder.decodeRepeatedFixed32Field(value: &_storage._unpackedFixed32)
+        case 96: try decoder.decodeRepeatedFixed64Field(value: &_storage._unpackedFixed64)
+        case 97: try decoder.decodeRepeatedSFixed32Field(value: &_storage._unpackedSfixed32)
+        case 98: try decoder.decodeRepeatedSFixed64Field(value: &_storage._unpackedSfixed64)
+        case 99: try decoder.decodeRepeatedFloatField(value: &_storage._unpackedFloat)
+        case 100: try decoder.decodeRepeatedDoubleField(value: &_storage._unpackedDouble)
+        case 101: try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool)
+        case 102: try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum)
         case 111:
           if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
@@ -1735,6 +1989,90 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
+      if !_storage._packedInt32.isEmpty {
+        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 75)
+      }
+      if !_storage._packedInt64.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._packedInt64, fieldNumber: 76)
+      }
+      if !_storage._packedUint32.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._packedUint32, fieldNumber: 77)
+      }
+      if !_storage._packedUint64.isEmpty {
+        try visitor.visitPackedUInt64Field(value: _storage._packedUint64, fieldNumber: 78)
+      }
+      if !_storage._packedSint32.isEmpty {
+        try visitor.visitPackedSInt32Field(value: _storage._packedSint32, fieldNumber: 79)
+      }
+      if !_storage._packedSint64.isEmpty {
+        try visitor.visitPackedSInt64Field(value: _storage._packedSint64, fieldNumber: 80)
+      }
+      if !_storage._packedFixed32.isEmpty {
+        try visitor.visitPackedFixed32Field(value: _storage._packedFixed32, fieldNumber: 81)
+      }
+      if !_storage._packedFixed64.isEmpty {
+        try visitor.visitPackedFixed64Field(value: _storage._packedFixed64, fieldNumber: 82)
+      }
+      if !_storage._packedSfixed32.isEmpty {
+        try visitor.visitPackedSFixed32Field(value: _storage._packedSfixed32, fieldNumber: 83)
+      }
+      if !_storage._packedSfixed64.isEmpty {
+        try visitor.visitPackedSFixed64Field(value: _storage._packedSfixed64, fieldNumber: 84)
+      }
+      if !_storage._packedFloat.isEmpty {
+        try visitor.visitPackedFloatField(value: _storage._packedFloat, fieldNumber: 85)
+      }
+      if !_storage._packedDouble.isEmpty {
+        try visitor.visitPackedDoubleField(value: _storage._packedDouble, fieldNumber: 86)
+      }
+      if !_storage._packedBool.isEmpty {
+        try visitor.visitPackedBoolField(value: _storage._packedBool, fieldNumber: 87)
+      }
+      if !_storage._packedNestedEnum.isEmpty {
+        try visitor.visitPackedEnumField(value: _storage._packedNestedEnum, fieldNumber: 88)
+      }
+      if !_storage._unpackedInt32.isEmpty {
+        try visitor.visitRepeatedInt32Field(value: _storage._unpackedInt32, fieldNumber: 89)
+      }
+      if !_storage._unpackedInt64.isEmpty {
+        try visitor.visitRepeatedInt64Field(value: _storage._unpackedInt64, fieldNumber: 90)
+      }
+      if !_storage._unpackedUint32.isEmpty {
+        try visitor.visitRepeatedUInt32Field(value: _storage._unpackedUint32, fieldNumber: 91)
+      }
+      if !_storage._unpackedUint64.isEmpty {
+        try visitor.visitRepeatedUInt64Field(value: _storage._unpackedUint64, fieldNumber: 92)
+      }
+      if !_storage._unpackedSint32.isEmpty {
+        try visitor.visitRepeatedSInt32Field(value: _storage._unpackedSint32, fieldNumber: 93)
+      }
+      if !_storage._unpackedSint64.isEmpty {
+        try visitor.visitRepeatedSInt64Field(value: _storage._unpackedSint64, fieldNumber: 94)
+      }
+      if !_storage._unpackedFixed32.isEmpty {
+        try visitor.visitRepeatedFixed32Field(value: _storage._unpackedFixed32, fieldNumber: 95)
+      }
+      if !_storage._unpackedFixed64.isEmpty {
+        try visitor.visitRepeatedFixed64Field(value: _storage._unpackedFixed64, fieldNumber: 96)
+      }
+      if !_storage._unpackedSfixed32.isEmpty {
+        try visitor.visitRepeatedSFixed32Field(value: _storage._unpackedSfixed32, fieldNumber: 97)
+      }
+      if !_storage._unpackedSfixed64.isEmpty {
+        try visitor.visitRepeatedSFixed64Field(value: _storage._unpackedSfixed64, fieldNumber: 98)
+      }
+      if !_storage._unpackedFloat.isEmpty {
+        try visitor.visitRepeatedFloatField(value: _storage._unpackedFloat, fieldNumber: 99)
+      }
+      if !_storage._unpackedDouble.isEmpty {
+        try visitor.visitRepeatedDoubleField(value: _storage._unpackedDouble, fieldNumber: 100)
+      }
+      if !_storage._unpackedBool.isEmpty {
+        try visitor.visitRepeatedBoolField(value: _storage._unpackedBool, fieldNumber: 101)
+      }
+      if !_storage._unpackedNestedEnum.isEmpty {
+        try visitor.visitRepeatedEnumField(value: _storage._unpackedNestedEnum, fieldNumber: 102)
+      }
       switch _storage._oneofField {
       case .oneofUint32(let v)?:
         try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
@@ -1956,6 +2294,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         if _storage._repeatedForeignEnum != rhs_storage._repeatedForeignEnum {return false}
         if _storage._repeatedStringPiece != rhs_storage._repeatedStringPiece {return false}
         if _storage._repeatedCord != rhs_storage._repeatedCord {return false}
+        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
+        if _storage._packedInt64 != rhs_storage._packedInt64 {return false}
+        if _storage._packedUint32 != rhs_storage._packedUint32 {return false}
+        if _storage._packedUint64 != rhs_storage._packedUint64 {return false}
+        if _storage._packedSint32 != rhs_storage._packedSint32 {return false}
+        if _storage._packedSint64 != rhs_storage._packedSint64 {return false}
+        if _storage._packedFixed32 != rhs_storage._packedFixed32 {return false}
+        if _storage._packedFixed64 != rhs_storage._packedFixed64 {return false}
+        if _storage._packedSfixed32 != rhs_storage._packedSfixed32 {return false}
+        if _storage._packedSfixed64 != rhs_storage._packedSfixed64 {return false}
+        if _storage._packedFloat != rhs_storage._packedFloat {return false}
+        if _storage._packedDouble != rhs_storage._packedDouble {return false}
+        if _storage._packedBool != rhs_storage._packedBool {return false}
+        if _storage._packedNestedEnum != rhs_storage._packedNestedEnum {return false}
+        if _storage._unpackedInt32 != rhs_storage._unpackedInt32 {return false}
+        if _storage._unpackedInt64 != rhs_storage._unpackedInt64 {return false}
+        if _storage._unpackedUint32 != rhs_storage._unpackedUint32 {return false}
+        if _storage._unpackedUint64 != rhs_storage._unpackedUint64 {return false}
+        if _storage._unpackedSint32 != rhs_storage._unpackedSint32 {return false}
+        if _storage._unpackedSint64 != rhs_storage._unpackedSint64 {return false}
+        if _storage._unpackedFixed32 != rhs_storage._unpackedFixed32 {return false}
+        if _storage._unpackedFixed64 != rhs_storage._unpackedFixed64 {return false}
+        if _storage._unpackedSfixed32 != rhs_storage._unpackedSfixed32 {return false}
+        if _storage._unpackedSfixed64 != rhs_storage._unpackedSfixed64 {return false}
+        if _storage._unpackedFloat != rhs_storage._unpackedFloat {return false}
+        if _storage._unpackedDouble != rhs_storage._unpackedDouble {return false}
+        if _storage._unpackedBool != rhs_storage._unpackedBool {return false}
+        if _storage._unpackedNestedEnum != rhs_storage._unpackedNestedEnum {return false}
         if _storage._mapInt32Int32 != rhs_storage._mapInt32Int32 {return false}
         if _storage._mapInt64Int64 != rhs_storage._mapInt64Int64 {return false}
         if _storage._mapUint32Uint32 != rhs_storage._mapUint32Uint32 {return false}

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -409,6 +409,148 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
+  /// Packed
+  var packedInt32: [Int32] {
+    get {return _storage._packedInt32}
+    set {_uniqueStorage()._packedInt32 = newValue}
+  }
+
+  var packedInt64: [Int64] {
+    get {return _storage._packedInt64}
+    set {_uniqueStorage()._packedInt64 = newValue}
+  }
+
+  var packedUint32: [UInt32] {
+    get {return _storage._packedUint32}
+    set {_uniqueStorage()._packedUint32 = newValue}
+  }
+
+  var packedUint64: [UInt64] {
+    get {return _storage._packedUint64}
+    set {_uniqueStorage()._packedUint64 = newValue}
+  }
+
+  var packedSint32: [Int32] {
+    get {return _storage._packedSint32}
+    set {_uniqueStorage()._packedSint32 = newValue}
+  }
+
+  var packedSint64: [Int64] {
+    get {return _storage._packedSint64}
+    set {_uniqueStorage()._packedSint64 = newValue}
+  }
+
+  var packedFixed32: [UInt32] {
+    get {return _storage._packedFixed32}
+    set {_uniqueStorage()._packedFixed32 = newValue}
+  }
+
+  var packedFixed64: [UInt64] {
+    get {return _storage._packedFixed64}
+    set {_uniqueStorage()._packedFixed64 = newValue}
+  }
+
+  var packedSfixed32: [Int32] {
+    get {return _storage._packedSfixed32}
+    set {_uniqueStorage()._packedSfixed32 = newValue}
+  }
+
+  var packedSfixed64: [Int64] {
+    get {return _storage._packedSfixed64}
+    set {_uniqueStorage()._packedSfixed64 = newValue}
+  }
+
+  var packedFloat: [Float] {
+    get {return _storage._packedFloat}
+    set {_uniqueStorage()._packedFloat = newValue}
+  }
+
+  var packedDouble: [Double] {
+    get {return _storage._packedDouble}
+    set {_uniqueStorage()._packedDouble = newValue}
+  }
+
+  var packedBool: [Bool] {
+    get {return _storage._packedBool}
+    set {_uniqueStorage()._packedBool = newValue}
+  }
+
+  var packedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] {
+    get {return _storage._packedNestedEnum}
+    set {_uniqueStorage()._packedNestedEnum = newValue}
+  }
+
+  /// Unpacked
+  var unpackedInt32: [Int32] {
+    get {return _storage._unpackedInt32}
+    set {_uniqueStorage()._unpackedInt32 = newValue}
+  }
+
+  var unpackedInt64: [Int64] {
+    get {return _storage._unpackedInt64}
+    set {_uniqueStorage()._unpackedInt64 = newValue}
+  }
+
+  var unpackedUint32: [UInt32] {
+    get {return _storage._unpackedUint32}
+    set {_uniqueStorage()._unpackedUint32 = newValue}
+  }
+
+  var unpackedUint64: [UInt64] {
+    get {return _storage._unpackedUint64}
+    set {_uniqueStorage()._unpackedUint64 = newValue}
+  }
+
+  var unpackedSint32: [Int32] {
+    get {return _storage._unpackedSint32}
+    set {_uniqueStorage()._unpackedSint32 = newValue}
+  }
+
+  var unpackedSint64: [Int64] {
+    get {return _storage._unpackedSint64}
+    set {_uniqueStorage()._unpackedSint64 = newValue}
+  }
+
+  var unpackedFixed32: [UInt32] {
+    get {return _storage._unpackedFixed32}
+    set {_uniqueStorage()._unpackedFixed32 = newValue}
+  }
+
+  var unpackedFixed64: [UInt64] {
+    get {return _storage._unpackedFixed64}
+    set {_uniqueStorage()._unpackedFixed64 = newValue}
+  }
+
+  var unpackedSfixed32: [Int32] {
+    get {return _storage._unpackedSfixed32}
+    set {_uniqueStorage()._unpackedSfixed32 = newValue}
+  }
+
+  var unpackedSfixed64: [Int64] {
+    get {return _storage._unpackedSfixed64}
+    set {_uniqueStorage()._unpackedSfixed64 = newValue}
+  }
+
+  var unpackedFloat: [Float] {
+    get {return _storage._unpackedFloat}
+    set {_uniqueStorage()._unpackedFloat = newValue}
+  }
+
+  var unpackedDouble: [Double] {
+    get {return _storage._unpackedDouble}
+    set {_uniqueStorage()._unpackedDouble = newValue}
+  }
+
+  var unpackedBool: [Bool] {
+    get {return _storage._unpackedBool}
+    set {_uniqueStorage()._unpackedBool = newValue}
+  }
+
+  var unpackedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] {
+    get {return _storage._unpackedNestedEnum}
+    set {_uniqueStorage()._unpackedNestedEnum = newValue}
+  }
+
   /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
@@ -1200,6 +1342,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
     52: .standard(proto: "repeated_foreign_enum"),
     54: .standard(proto: "repeated_string_piece"),
     55: .standard(proto: "repeated_cord"),
+    75: .standard(proto: "packed_int32"),
+    76: .standard(proto: "packed_int64"),
+    77: .standard(proto: "packed_uint32"),
+    78: .standard(proto: "packed_uint64"),
+    79: .standard(proto: "packed_sint32"),
+    80: .standard(proto: "packed_sint64"),
+    81: .standard(proto: "packed_fixed32"),
+    82: .standard(proto: "packed_fixed64"),
+    83: .standard(proto: "packed_sfixed32"),
+    84: .standard(proto: "packed_sfixed64"),
+    85: .standard(proto: "packed_float"),
+    86: .standard(proto: "packed_double"),
+    87: .standard(proto: "packed_bool"),
+    88: .standard(proto: "packed_nested_enum"),
+    89: .standard(proto: "unpacked_int32"),
+    90: .standard(proto: "unpacked_int64"),
+    91: .standard(proto: "unpacked_uint32"),
+    92: .standard(proto: "unpacked_uint64"),
+    93: .standard(proto: "unpacked_sint32"),
+    94: .standard(proto: "unpacked_sint64"),
+    95: .standard(proto: "unpacked_fixed32"),
+    96: .standard(proto: "unpacked_fixed64"),
+    97: .standard(proto: "unpacked_sfixed32"),
+    98: .standard(proto: "unpacked_sfixed64"),
+    99: .standard(proto: "unpacked_float"),
+    100: .standard(proto: "unpacked_double"),
+    101: .standard(proto: "unpacked_bool"),
+    102: .standard(proto: "unpacked_nested_enum"),
     56: .standard(proto: "map_int32_int32"),
     57: .standard(proto: "map_int64_int64"),
     58: .standard(proto: "map_uint32_uint32"),
@@ -1293,6 +1463,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
     var _repeatedForeignEnum: [ProtobufTestMessages_Proto2_ForeignEnumProto2] = []
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
+    var _packedInt32: [Int32] = []
+    var _packedInt64: [Int64] = []
+    var _packedUint32: [UInt32] = []
+    var _packedUint64: [UInt64] = []
+    var _packedSint32: [Int32] = []
+    var _packedSint64: [Int64] = []
+    var _packedFixed32: [UInt32] = []
+    var _packedFixed64: [UInt64] = []
+    var _packedSfixed32: [Int32] = []
+    var _packedSfixed64: [Int64] = []
+    var _packedFloat: [Float] = []
+    var _packedDouble: [Double] = []
+    var _packedBool: [Bool] = []
+    var _packedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] = []
+    var _unpackedInt32: [Int32] = []
+    var _unpackedInt64: [Int64] = []
+    var _unpackedUint32: [UInt32] = []
+    var _unpackedUint64: [UInt64] = []
+    var _unpackedSint32: [Int32] = []
+    var _unpackedSint64: [Int64] = []
+    var _unpackedFixed32: [UInt32] = []
+    var _unpackedFixed64: [UInt64] = []
+    var _unpackedSfixed32: [Int32] = []
+    var _unpackedSfixed64: [Int64] = []
+    var _unpackedFloat: [Float] = []
+    var _unpackedDouble: [Double] = []
+    var _unpackedBool: [Bool] = []
+    var _unpackedNestedEnum: [ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum] = []
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -1381,6 +1579,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       _repeatedForeignEnum = source._repeatedForeignEnum
       _repeatedStringPiece = source._repeatedStringPiece
       _repeatedCord = source._repeatedCord
+      _packedInt32 = source._packedInt32
+      _packedInt64 = source._packedInt64
+      _packedUint32 = source._packedUint32
+      _packedUint64 = source._packedUint64
+      _packedSint32 = source._packedSint32
+      _packedSint64 = source._packedSint64
+      _packedFixed32 = source._packedFixed32
+      _packedFixed64 = source._packedFixed64
+      _packedSfixed32 = source._packedSfixed32
+      _packedSfixed64 = source._packedSfixed64
+      _packedFloat = source._packedFloat
+      _packedDouble = source._packedDouble
+      _packedBool = source._packedBool
+      _packedNestedEnum = source._packedNestedEnum
+      _unpackedInt32 = source._unpackedInt32
+      _unpackedInt64 = source._unpackedInt64
+      _unpackedUint32 = source._unpackedUint32
+      _unpackedUint64 = source._unpackedUint64
+      _unpackedSint32 = source._unpackedSint32
+      _unpackedSint64 = source._unpackedSint64
+      _unpackedFixed32 = source._unpackedFixed32
+      _unpackedFixed64 = source._unpackedFixed64
+      _unpackedSfixed32 = source._unpackedSfixed32
+      _unpackedSfixed64 = source._unpackedSfixed64
+      _unpackedFloat = source._unpackedFloat
+      _unpackedDouble = source._unpackedDouble
+      _unpackedBool = source._unpackedBool
+      _unpackedNestedEnum = source._unpackedNestedEnum
       _mapInt32Int32 = source._mapInt32Int32
       _mapInt64Int64 = source._mapInt64Int64
       _mapUint32Uint32 = source._mapUint32Uint32
@@ -1509,6 +1735,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignMessageProto2>.self, value: &_storage._mapStringForeignMessage)
         case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
         case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignEnumProto2>.self, value: &_storage._mapStringForeignEnum)
+        case 75: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
+        case 76: try decoder.decodeRepeatedInt64Field(value: &_storage._packedInt64)
+        case 77: try decoder.decodeRepeatedUInt32Field(value: &_storage._packedUint32)
+        case 78: try decoder.decodeRepeatedUInt64Field(value: &_storage._packedUint64)
+        case 79: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedSint32)
+        case 80: try decoder.decodeRepeatedSInt64Field(value: &_storage._packedSint64)
+        case 81: try decoder.decodeRepeatedFixed32Field(value: &_storage._packedFixed32)
+        case 82: try decoder.decodeRepeatedFixed64Field(value: &_storage._packedFixed64)
+        case 83: try decoder.decodeRepeatedSFixed32Field(value: &_storage._packedSfixed32)
+        case 84: try decoder.decodeRepeatedSFixed64Field(value: &_storage._packedSfixed64)
+        case 85: try decoder.decodeRepeatedFloatField(value: &_storage._packedFloat)
+        case 86: try decoder.decodeRepeatedDoubleField(value: &_storage._packedDouble)
+        case 87: try decoder.decodeRepeatedBoolField(value: &_storage._packedBool)
+        case 88: try decoder.decodeRepeatedEnumField(value: &_storage._packedNestedEnum)
+        case 89: try decoder.decodeRepeatedInt32Field(value: &_storage._unpackedInt32)
+        case 90: try decoder.decodeRepeatedInt64Field(value: &_storage._unpackedInt64)
+        case 91: try decoder.decodeRepeatedUInt32Field(value: &_storage._unpackedUint32)
+        case 92: try decoder.decodeRepeatedUInt64Field(value: &_storage._unpackedUint64)
+        case 93: try decoder.decodeRepeatedSInt32Field(value: &_storage._unpackedSint32)
+        case 94: try decoder.decodeRepeatedSInt64Field(value: &_storage._unpackedSint64)
+        case 95: try decoder.decodeRepeatedFixed32Field(value: &_storage._unpackedFixed32)
+        case 96: try decoder.decodeRepeatedFixed64Field(value: &_storage._unpackedFixed64)
+        case 97: try decoder.decodeRepeatedSFixed32Field(value: &_storage._unpackedSfixed32)
+        case 98: try decoder.decodeRepeatedSFixed64Field(value: &_storage._unpackedSfixed64)
+        case 99: try decoder.decodeRepeatedFloatField(value: &_storage._unpackedFloat)
+        case 100: try decoder.decodeRepeatedDoubleField(value: &_storage._unpackedDouble)
+        case 101: try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool)
+        case 102: try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum)
         case 111:
           if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
@@ -1772,6 +2026,90 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto2_ForeignEnumProto2>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
+      if !_storage._packedInt32.isEmpty {
+        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 75)
+      }
+      if !_storage._packedInt64.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._packedInt64, fieldNumber: 76)
+      }
+      if !_storage._packedUint32.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._packedUint32, fieldNumber: 77)
+      }
+      if !_storage._packedUint64.isEmpty {
+        try visitor.visitPackedUInt64Field(value: _storage._packedUint64, fieldNumber: 78)
+      }
+      if !_storage._packedSint32.isEmpty {
+        try visitor.visitPackedSInt32Field(value: _storage._packedSint32, fieldNumber: 79)
+      }
+      if !_storage._packedSint64.isEmpty {
+        try visitor.visitPackedSInt64Field(value: _storage._packedSint64, fieldNumber: 80)
+      }
+      if !_storage._packedFixed32.isEmpty {
+        try visitor.visitPackedFixed32Field(value: _storage._packedFixed32, fieldNumber: 81)
+      }
+      if !_storage._packedFixed64.isEmpty {
+        try visitor.visitPackedFixed64Field(value: _storage._packedFixed64, fieldNumber: 82)
+      }
+      if !_storage._packedSfixed32.isEmpty {
+        try visitor.visitPackedSFixed32Field(value: _storage._packedSfixed32, fieldNumber: 83)
+      }
+      if !_storage._packedSfixed64.isEmpty {
+        try visitor.visitPackedSFixed64Field(value: _storage._packedSfixed64, fieldNumber: 84)
+      }
+      if !_storage._packedFloat.isEmpty {
+        try visitor.visitPackedFloatField(value: _storage._packedFloat, fieldNumber: 85)
+      }
+      if !_storage._packedDouble.isEmpty {
+        try visitor.visitPackedDoubleField(value: _storage._packedDouble, fieldNumber: 86)
+      }
+      if !_storage._packedBool.isEmpty {
+        try visitor.visitPackedBoolField(value: _storage._packedBool, fieldNumber: 87)
+      }
+      if !_storage._packedNestedEnum.isEmpty {
+        try visitor.visitPackedEnumField(value: _storage._packedNestedEnum, fieldNumber: 88)
+      }
+      if !_storage._unpackedInt32.isEmpty {
+        try visitor.visitRepeatedInt32Field(value: _storage._unpackedInt32, fieldNumber: 89)
+      }
+      if !_storage._unpackedInt64.isEmpty {
+        try visitor.visitRepeatedInt64Field(value: _storage._unpackedInt64, fieldNumber: 90)
+      }
+      if !_storage._unpackedUint32.isEmpty {
+        try visitor.visitRepeatedUInt32Field(value: _storage._unpackedUint32, fieldNumber: 91)
+      }
+      if !_storage._unpackedUint64.isEmpty {
+        try visitor.visitRepeatedUInt64Field(value: _storage._unpackedUint64, fieldNumber: 92)
+      }
+      if !_storage._unpackedSint32.isEmpty {
+        try visitor.visitRepeatedSInt32Field(value: _storage._unpackedSint32, fieldNumber: 93)
+      }
+      if !_storage._unpackedSint64.isEmpty {
+        try visitor.visitRepeatedSInt64Field(value: _storage._unpackedSint64, fieldNumber: 94)
+      }
+      if !_storage._unpackedFixed32.isEmpty {
+        try visitor.visitRepeatedFixed32Field(value: _storage._unpackedFixed32, fieldNumber: 95)
+      }
+      if !_storage._unpackedFixed64.isEmpty {
+        try visitor.visitRepeatedFixed64Field(value: _storage._unpackedFixed64, fieldNumber: 96)
+      }
+      if !_storage._unpackedSfixed32.isEmpty {
+        try visitor.visitRepeatedSFixed32Field(value: _storage._unpackedSfixed32, fieldNumber: 97)
+      }
+      if !_storage._unpackedSfixed64.isEmpty {
+        try visitor.visitRepeatedSFixed64Field(value: _storage._unpackedSfixed64, fieldNumber: 98)
+      }
+      if !_storage._unpackedFloat.isEmpty {
+        try visitor.visitRepeatedFloatField(value: _storage._unpackedFloat, fieldNumber: 99)
+      }
+      if !_storage._unpackedDouble.isEmpty {
+        try visitor.visitRepeatedDoubleField(value: _storage._unpackedDouble, fieldNumber: 100)
+      }
+      if !_storage._unpackedBool.isEmpty {
+        try visitor.visitRepeatedBoolField(value: _storage._unpackedBool, fieldNumber: 101)
+      }
+      if !_storage._unpackedNestedEnum.isEmpty {
+        try visitor.visitRepeatedEnumField(value: _storage._unpackedNestedEnum, fieldNumber: 102)
+      }
       switch _storage._oneofField {
       case .oneofUint32(let v)?:
         try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
@@ -1903,6 +2241,34 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         if _storage._repeatedForeignEnum != rhs_storage._repeatedForeignEnum {return false}
         if _storage._repeatedStringPiece != rhs_storage._repeatedStringPiece {return false}
         if _storage._repeatedCord != rhs_storage._repeatedCord {return false}
+        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
+        if _storage._packedInt64 != rhs_storage._packedInt64 {return false}
+        if _storage._packedUint32 != rhs_storage._packedUint32 {return false}
+        if _storage._packedUint64 != rhs_storage._packedUint64 {return false}
+        if _storage._packedSint32 != rhs_storage._packedSint32 {return false}
+        if _storage._packedSint64 != rhs_storage._packedSint64 {return false}
+        if _storage._packedFixed32 != rhs_storage._packedFixed32 {return false}
+        if _storage._packedFixed64 != rhs_storage._packedFixed64 {return false}
+        if _storage._packedSfixed32 != rhs_storage._packedSfixed32 {return false}
+        if _storage._packedSfixed64 != rhs_storage._packedSfixed64 {return false}
+        if _storage._packedFloat != rhs_storage._packedFloat {return false}
+        if _storage._packedDouble != rhs_storage._packedDouble {return false}
+        if _storage._packedBool != rhs_storage._packedBool {return false}
+        if _storage._packedNestedEnum != rhs_storage._packedNestedEnum {return false}
+        if _storage._unpackedInt32 != rhs_storage._unpackedInt32 {return false}
+        if _storage._unpackedInt64 != rhs_storage._unpackedInt64 {return false}
+        if _storage._unpackedUint32 != rhs_storage._unpackedUint32 {return false}
+        if _storage._unpackedUint64 != rhs_storage._unpackedUint64 {return false}
+        if _storage._unpackedSint32 != rhs_storage._unpackedSint32 {return false}
+        if _storage._unpackedSint64 != rhs_storage._unpackedSint64 {return false}
+        if _storage._unpackedFixed32 != rhs_storage._unpackedFixed32 {return false}
+        if _storage._unpackedFixed64 != rhs_storage._unpackedFixed64 {return false}
+        if _storage._unpackedSfixed32 != rhs_storage._unpackedSfixed32 {return false}
+        if _storage._unpackedSfixed64 != rhs_storage._unpackedSfixed64 {return false}
+        if _storage._unpackedFloat != rhs_storage._unpackedFloat {return false}
+        if _storage._unpackedDouble != rhs_storage._unpackedDouble {return false}
+        if _storage._unpackedBool != rhs_storage._unpackedBool {return false}
+        if _storage._unpackedNestedEnum != rhs_storage._unpackedNestedEnum {return false}
         if _storage._mapInt32Int32 != rhs_storage._mapInt32Int32 {return false}
         if _storage._mapInt64Int64 != rhs_storage._mapInt64Int64 {return false}
         if _storage._mapUint32Uint32 != rhs_storage._mapUint32Uint32 {return false}

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -345,6 +345,148 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
+  /// Packed
+  var packedInt32: [Int32] {
+    get {return _storage._packedInt32}
+    set {_uniqueStorage()._packedInt32 = newValue}
+  }
+
+  var packedInt64: [Int64] {
+    get {return _storage._packedInt64}
+    set {_uniqueStorage()._packedInt64 = newValue}
+  }
+
+  var packedUint32: [UInt32] {
+    get {return _storage._packedUint32}
+    set {_uniqueStorage()._packedUint32 = newValue}
+  }
+
+  var packedUint64: [UInt64] {
+    get {return _storage._packedUint64}
+    set {_uniqueStorage()._packedUint64 = newValue}
+  }
+
+  var packedSint32: [Int32] {
+    get {return _storage._packedSint32}
+    set {_uniqueStorage()._packedSint32 = newValue}
+  }
+
+  var packedSint64: [Int64] {
+    get {return _storage._packedSint64}
+    set {_uniqueStorage()._packedSint64 = newValue}
+  }
+
+  var packedFixed32: [UInt32] {
+    get {return _storage._packedFixed32}
+    set {_uniqueStorage()._packedFixed32 = newValue}
+  }
+
+  var packedFixed64: [UInt64] {
+    get {return _storage._packedFixed64}
+    set {_uniqueStorage()._packedFixed64 = newValue}
+  }
+
+  var packedSfixed32: [Int32] {
+    get {return _storage._packedSfixed32}
+    set {_uniqueStorage()._packedSfixed32 = newValue}
+  }
+
+  var packedSfixed64: [Int64] {
+    get {return _storage._packedSfixed64}
+    set {_uniqueStorage()._packedSfixed64 = newValue}
+  }
+
+  var packedFloat: [Float] {
+    get {return _storage._packedFloat}
+    set {_uniqueStorage()._packedFloat = newValue}
+  }
+
+  var packedDouble: [Double] {
+    get {return _storage._packedDouble}
+    set {_uniqueStorage()._packedDouble = newValue}
+  }
+
+  var packedBool: [Bool] {
+    get {return _storage._packedBool}
+    set {_uniqueStorage()._packedBool = newValue}
+  }
+
+  var packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._packedNestedEnum}
+    set {_uniqueStorage()._packedNestedEnum = newValue}
+  }
+
+  /// Unpacked
+  var unpackedInt32: [Int32] {
+    get {return _storage._unpackedInt32}
+    set {_uniqueStorage()._unpackedInt32 = newValue}
+  }
+
+  var unpackedInt64: [Int64] {
+    get {return _storage._unpackedInt64}
+    set {_uniqueStorage()._unpackedInt64 = newValue}
+  }
+
+  var unpackedUint32: [UInt32] {
+    get {return _storage._unpackedUint32}
+    set {_uniqueStorage()._unpackedUint32 = newValue}
+  }
+
+  var unpackedUint64: [UInt64] {
+    get {return _storage._unpackedUint64}
+    set {_uniqueStorage()._unpackedUint64 = newValue}
+  }
+
+  var unpackedSint32: [Int32] {
+    get {return _storage._unpackedSint32}
+    set {_uniqueStorage()._unpackedSint32 = newValue}
+  }
+
+  var unpackedSint64: [Int64] {
+    get {return _storage._unpackedSint64}
+    set {_uniqueStorage()._unpackedSint64 = newValue}
+  }
+
+  var unpackedFixed32: [UInt32] {
+    get {return _storage._unpackedFixed32}
+    set {_uniqueStorage()._unpackedFixed32 = newValue}
+  }
+
+  var unpackedFixed64: [UInt64] {
+    get {return _storage._unpackedFixed64}
+    set {_uniqueStorage()._unpackedFixed64 = newValue}
+  }
+
+  var unpackedSfixed32: [Int32] {
+    get {return _storage._unpackedSfixed32}
+    set {_uniqueStorage()._unpackedSfixed32 = newValue}
+  }
+
+  var unpackedSfixed64: [Int64] {
+    get {return _storage._unpackedSfixed64}
+    set {_uniqueStorage()._unpackedSfixed64 = newValue}
+  }
+
+  var unpackedFloat: [Float] {
+    get {return _storage._unpackedFloat}
+    set {_uniqueStorage()._unpackedFloat = newValue}
+  }
+
+  var unpackedDouble: [Double] {
+    get {return _storage._unpackedDouble}
+    set {_uniqueStorage()._unpackedDouble = newValue}
+  }
+
+  var unpackedBool: [Bool] {
+    get {return _storage._unpackedBool}
+    set {_uniqueStorage()._unpackedBool = newValue}
+  }
+
+  var unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._unpackedNestedEnum}
+    set {_uniqueStorage()._unpackedNestedEnum = newValue}
+  }
+
   /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
@@ -1051,6 +1193,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     52: .standard(proto: "repeated_foreign_enum"),
     54: .standard(proto: "repeated_string_piece"),
     55: .standard(proto: "repeated_cord"),
+    75: .standard(proto: "packed_int32"),
+    76: .standard(proto: "packed_int64"),
+    77: .standard(proto: "packed_uint32"),
+    78: .standard(proto: "packed_uint64"),
+    79: .standard(proto: "packed_sint32"),
+    80: .standard(proto: "packed_sint64"),
+    81: .standard(proto: "packed_fixed32"),
+    82: .standard(proto: "packed_fixed64"),
+    83: .standard(proto: "packed_sfixed32"),
+    84: .standard(proto: "packed_sfixed64"),
+    85: .standard(proto: "packed_float"),
+    86: .standard(proto: "packed_double"),
+    87: .standard(proto: "packed_bool"),
+    88: .standard(proto: "packed_nested_enum"),
+    89: .standard(proto: "unpacked_int32"),
+    90: .standard(proto: "unpacked_int64"),
+    91: .standard(proto: "unpacked_uint32"),
+    92: .standard(proto: "unpacked_uint64"),
+    93: .standard(proto: "unpacked_sint32"),
+    94: .standard(proto: "unpacked_sint64"),
+    95: .standard(proto: "unpacked_fixed32"),
+    96: .standard(proto: "unpacked_fixed64"),
+    97: .standard(proto: "unpacked_sfixed32"),
+    98: .standard(proto: "unpacked_sfixed64"),
+    99: .standard(proto: "unpacked_float"),
+    100: .standard(proto: "unpacked_double"),
+    101: .standard(proto: "unpacked_bool"),
+    102: .standard(proto: "unpacked_nested_enum"),
     56: .standard(proto: "map_int32_int32"),
     57: .standard(proto: "map_int64_int64"),
     58: .standard(proto: "map_uint32_uint32"),
@@ -1175,6 +1345,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     var _repeatedForeignEnum: [ProtobufTestMessages_Proto3_ForeignEnum] = []
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
+    var _packedInt32: [Int32] = []
+    var _packedInt64: [Int64] = []
+    var _packedUint32: [UInt32] = []
+    var _packedUint64: [UInt64] = []
+    var _packedSint32: [Int32] = []
+    var _packedSint64: [Int64] = []
+    var _packedFixed32: [UInt32] = []
+    var _packedFixed64: [UInt64] = []
+    var _packedSfixed32: [Int32] = []
+    var _packedSfixed64: [Int64] = []
+    var _packedFloat: [Float] = []
+    var _packedDouble: [Double] = []
+    var _packedBool: [Bool] = []
+    var _packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
+    var _unpackedInt32: [Int32] = []
+    var _unpackedInt64: [Int64] = []
+    var _unpackedUint32: [UInt32] = []
+    var _unpackedUint64: [UInt64] = []
+    var _unpackedSint32: [Int32] = []
+    var _unpackedSint64: [Int64] = []
+    var _unpackedFixed32: [UInt32] = []
+    var _unpackedFixed64: [UInt64] = []
+    var _unpackedSfixed32: [Int32] = []
+    var _unpackedSfixed64: [Int64] = []
+    var _unpackedFloat: [Float] = []
+    var _unpackedDouble: [Double] = []
+    var _unpackedBool: [Bool] = []
+    var _unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -1294,6 +1492,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       _repeatedForeignEnum = source._repeatedForeignEnum
       _repeatedStringPiece = source._repeatedStringPiece
       _repeatedCord = source._repeatedCord
+      _packedInt32 = source._packedInt32
+      _packedInt64 = source._packedInt64
+      _packedUint32 = source._packedUint32
+      _packedUint64 = source._packedUint64
+      _packedSint32 = source._packedSint32
+      _packedSint64 = source._packedSint64
+      _packedFixed32 = source._packedFixed32
+      _packedFixed64 = source._packedFixed64
+      _packedSfixed32 = source._packedSfixed32
+      _packedSfixed64 = source._packedSfixed64
+      _packedFloat = source._packedFloat
+      _packedDouble = source._packedDouble
+      _packedBool = source._packedBool
+      _packedNestedEnum = source._packedNestedEnum
+      _unpackedInt32 = source._unpackedInt32
+      _unpackedInt64 = source._unpackedInt64
+      _unpackedUint32 = source._unpackedUint32
+      _unpackedUint64 = source._unpackedUint64
+      _unpackedSint32 = source._unpackedSint32
+      _unpackedSint64 = source._unpackedSint64
+      _unpackedFixed32 = source._unpackedFixed32
+      _unpackedFixed64 = source._unpackedFixed64
+      _unpackedSfixed32 = source._unpackedSfixed32
+      _unpackedSfixed64 = source._unpackedSfixed64
+      _unpackedFloat = source._unpackedFloat
+      _unpackedDouble = source._unpackedDouble
+      _unpackedBool = source._unpackedBool
+      _unpackedNestedEnum = source._unpackedNestedEnum
       _mapInt32Int32 = source._mapInt32Int32
       _mapInt64Int64 = source._mapInt64Int64
       _mapUint32Uint32 = source._mapUint32Uint32
@@ -1441,6 +1667,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
         case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
         case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
+        case 75: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
+        case 76: try decoder.decodeRepeatedInt64Field(value: &_storage._packedInt64)
+        case 77: try decoder.decodeRepeatedUInt32Field(value: &_storage._packedUint32)
+        case 78: try decoder.decodeRepeatedUInt64Field(value: &_storage._packedUint64)
+        case 79: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedSint32)
+        case 80: try decoder.decodeRepeatedSInt64Field(value: &_storage._packedSint64)
+        case 81: try decoder.decodeRepeatedFixed32Field(value: &_storage._packedFixed32)
+        case 82: try decoder.decodeRepeatedFixed64Field(value: &_storage._packedFixed64)
+        case 83: try decoder.decodeRepeatedSFixed32Field(value: &_storage._packedSfixed32)
+        case 84: try decoder.decodeRepeatedSFixed64Field(value: &_storage._packedSfixed64)
+        case 85: try decoder.decodeRepeatedFloatField(value: &_storage._packedFloat)
+        case 86: try decoder.decodeRepeatedDoubleField(value: &_storage._packedDouble)
+        case 87: try decoder.decodeRepeatedBoolField(value: &_storage._packedBool)
+        case 88: try decoder.decodeRepeatedEnumField(value: &_storage._packedNestedEnum)
+        case 89: try decoder.decodeRepeatedInt32Field(value: &_storage._unpackedInt32)
+        case 90: try decoder.decodeRepeatedInt64Field(value: &_storage._unpackedInt64)
+        case 91: try decoder.decodeRepeatedUInt32Field(value: &_storage._unpackedUint32)
+        case 92: try decoder.decodeRepeatedUInt64Field(value: &_storage._unpackedUint64)
+        case 93: try decoder.decodeRepeatedSInt32Field(value: &_storage._unpackedSint32)
+        case 94: try decoder.decodeRepeatedSInt64Field(value: &_storage._unpackedSint64)
+        case 95: try decoder.decodeRepeatedFixed32Field(value: &_storage._unpackedFixed32)
+        case 96: try decoder.decodeRepeatedFixed64Field(value: &_storage._unpackedFixed64)
+        case 97: try decoder.decodeRepeatedSFixed32Field(value: &_storage._unpackedSfixed32)
+        case 98: try decoder.decodeRepeatedSFixed64Field(value: &_storage._unpackedSfixed64)
+        case 99: try decoder.decodeRepeatedFloatField(value: &_storage._unpackedFloat)
+        case 100: try decoder.decodeRepeatedDoubleField(value: &_storage._unpackedDouble)
+        case 101: try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool)
+        case 102: try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum)
         case 111:
           if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
@@ -1735,6 +1989,90 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
+      if !_storage._packedInt32.isEmpty {
+        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 75)
+      }
+      if !_storage._packedInt64.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._packedInt64, fieldNumber: 76)
+      }
+      if !_storage._packedUint32.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._packedUint32, fieldNumber: 77)
+      }
+      if !_storage._packedUint64.isEmpty {
+        try visitor.visitPackedUInt64Field(value: _storage._packedUint64, fieldNumber: 78)
+      }
+      if !_storage._packedSint32.isEmpty {
+        try visitor.visitPackedSInt32Field(value: _storage._packedSint32, fieldNumber: 79)
+      }
+      if !_storage._packedSint64.isEmpty {
+        try visitor.visitPackedSInt64Field(value: _storage._packedSint64, fieldNumber: 80)
+      }
+      if !_storage._packedFixed32.isEmpty {
+        try visitor.visitPackedFixed32Field(value: _storage._packedFixed32, fieldNumber: 81)
+      }
+      if !_storage._packedFixed64.isEmpty {
+        try visitor.visitPackedFixed64Field(value: _storage._packedFixed64, fieldNumber: 82)
+      }
+      if !_storage._packedSfixed32.isEmpty {
+        try visitor.visitPackedSFixed32Field(value: _storage._packedSfixed32, fieldNumber: 83)
+      }
+      if !_storage._packedSfixed64.isEmpty {
+        try visitor.visitPackedSFixed64Field(value: _storage._packedSfixed64, fieldNumber: 84)
+      }
+      if !_storage._packedFloat.isEmpty {
+        try visitor.visitPackedFloatField(value: _storage._packedFloat, fieldNumber: 85)
+      }
+      if !_storage._packedDouble.isEmpty {
+        try visitor.visitPackedDoubleField(value: _storage._packedDouble, fieldNumber: 86)
+      }
+      if !_storage._packedBool.isEmpty {
+        try visitor.visitPackedBoolField(value: _storage._packedBool, fieldNumber: 87)
+      }
+      if !_storage._packedNestedEnum.isEmpty {
+        try visitor.visitPackedEnumField(value: _storage._packedNestedEnum, fieldNumber: 88)
+      }
+      if !_storage._unpackedInt32.isEmpty {
+        try visitor.visitRepeatedInt32Field(value: _storage._unpackedInt32, fieldNumber: 89)
+      }
+      if !_storage._unpackedInt64.isEmpty {
+        try visitor.visitRepeatedInt64Field(value: _storage._unpackedInt64, fieldNumber: 90)
+      }
+      if !_storage._unpackedUint32.isEmpty {
+        try visitor.visitRepeatedUInt32Field(value: _storage._unpackedUint32, fieldNumber: 91)
+      }
+      if !_storage._unpackedUint64.isEmpty {
+        try visitor.visitRepeatedUInt64Field(value: _storage._unpackedUint64, fieldNumber: 92)
+      }
+      if !_storage._unpackedSint32.isEmpty {
+        try visitor.visitRepeatedSInt32Field(value: _storage._unpackedSint32, fieldNumber: 93)
+      }
+      if !_storage._unpackedSint64.isEmpty {
+        try visitor.visitRepeatedSInt64Field(value: _storage._unpackedSint64, fieldNumber: 94)
+      }
+      if !_storage._unpackedFixed32.isEmpty {
+        try visitor.visitRepeatedFixed32Field(value: _storage._unpackedFixed32, fieldNumber: 95)
+      }
+      if !_storage._unpackedFixed64.isEmpty {
+        try visitor.visitRepeatedFixed64Field(value: _storage._unpackedFixed64, fieldNumber: 96)
+      }
+      if !_storage._unpackedSfixed32.isEmpty {
+        try visitor.visitRepeatedSFixed32Field(value: _storage._unpackedSfixed32, fieldNumber: 97)
+      }
+      if !_storage._unpackedSfixed64.isEmpty {
+        try visitor.visitRepeatedSFixed64Field(value: _storage._unpackedSfixed64, fieldNumber: 98)
+      }
+      if !_storage._unpackedFloat.isEmpty {
+        try visitor.visitRepeatedFloatField(value: _storage._unpackedFloat, fieldNumber: 99)
+      }
+      if !_storage._unpackedDouble.isEmpty {
+        try visitor.visitRepeatedDoubleField(value: _storage._unpackedDouble, fieldNumber: 100)
+      }
+      if !_storage._unpackedBool.isEmpty {
+        try visitor.visitRepeatedBoolField(value: _storage._unpackedBool, fieldNumber: 101)
+      }
+      if !_storage._unpackedNestedEnum.isEmpty {
+        try visitor.visitRepeatedEnumField(value: _storage._unpackedNestedEnum, fieldNumber: 102)
+      }
       switch _storage._oneofField {
       case .oneofUint32(let v)?:
         try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
@@ -1956,6 +2294,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         if _storage._repeatedForeignEnum != rhs_storage._repeatedForeignEnum {return false}
         if _storage._repeatedStringPiece != rhs_storage._repeatedStringPiece {return false}
         if _storage._repeatedCord != rhs_storage._repeatedCord {return false}
+        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
+        if _storage._packedInt64 != rhs_storage._packedInt64 {return false}
+        if _storage._packedUint32 != rhs_storage._packedUint32 {return false}
+        if _storage._packedUint64 != rhs_storage._packedUint64 {return false}
+        if _storage._packedSint32 != rhs_storage._packedSint32 {return false}
+        if _storage._packedSint64 != rhs_storage._packedSint64 {return false}
+        if _storage._packedFixed32 != rhs_storage._packedFixed32 {return false}
+        if _storage._packedFixed64 != rhs_storage._packedFixed64 {return false}
+        if _storage._packedSfixed32 != rhs_storage._packedSfixed32 {return false}
+        if _storage._packedSfixed64 != rhs_storage._packedSfixed64 {return false}
+        if _storage._packedFloat != rhs_storage._packedFloat {return false}
+        if _storage._packedDouble != rhs_storage._packedDouble {return false}
+        if _storage._packedBool != rhs_storage._packedBool {return false}
+        if _storage._packedNestedEnum != rhs_storage._packedNestedEnum {return false}
+        if _storage._unpackedInt32 != rhs_storage._unpackedInt32 {return false}
+        if _storage._unpackedInt64 != rhs_storage._unpackedInt64 {return false}
+        if _storage._unpackedUint32 != rhs_storage._unpackedUint32 {return false}
+        if _storage._unpackedUint64 != rhs_storage._unpackedUint64 {return false}
+        if _storage._unpackedSint32 != rhs_storage._unpackedSint32 {return false}
+        if _storage._unpackedSint64 != rhs_storage._unpackedSint64 {return false}
+        if _storage._unpackedFixed32 != rhs_storage._unpackedFixed32 {return false}
+        if _storage._unpackedFixed64 != rhs_storage._unpackedFixed64 {return false}
+        if _storage._unpackedSfixed32 != rhs_storage._unpackedSfixed32 {return false}
+        if _storage._unpackedSfixed64 != rhs_storage._unpackedSfixed64 {return false}
+        if _storage._unpackedFloat != rhs_storage._unpackedFloat {return false}
+        if _storage._unpackedDouble != rhs_storage._unpackedDouble {return false}
+        if _storage._unpackedBool != rhs_storage._unpackedBool {return false}
+        if _storage._unpackedNestedEnum != rhs_storage._unpackedNestedEnum {return false}
         if _storage._mapInt32Int32 != rhs_storage._mapInt32Int32 {return false}
         if _storage._mapInt64Int64 != rhs_storage._mapInt64Int64 {return false}
         if _storage._mapUint32Uint32 != rhs_storage._mapUint32Uint32 {return false}

--- a/Sources/SwiftProtobuf/duration.pb.swift
+++ b/Sources/SwiftProtobuf/duration.pb.swift
@@ -69,7 +69,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///     if (duration.seconds < 0 && duration.nanos > 0) {
 ///       duration.seconds += 1;
 ///       duration.nanos -= 1000000000;
-///     } else if (durations.seconds > 0 && duration.nanos < 0) {
+///     } else if (duration.seconds > 0 && duration.nanos < 0) {
 ///       duration.seconds -= 1;
 ///       duration.nanos += 1000000000;
 ///     }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -345,6 +345,148 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
+  /// Packed
+  var packedInt32: [Int32] {
+    get {return _storage._packedInt32}
+    set {_uniqueStorage()._packedInt32 = newValue}
+  }
+
+  var packedInt64: [Int64] {
+    get {return _storage._packedInt64}
+    set {_uniqueStorage()._packedInt64 = newValue}
+  }
+
+  var packedUint32: [UInt32] {
+    get {return _storage._packedUint32}
+    set {_uniqueStorage()._packedUint32 = newValue}
+  }
+
+  var packedUint64: [UInt64] {
+    get {return _storage._packedUint64}
+    set {_uniqueStorage()._packedUint64 = newValue}
+  }
+
+  var packedSint32: [Int32] {
+    get {return _storage._packedSint32}
+    set {_uniqueStorage()._packedSint32 = newValue}
+  }
+
+  var packedSint64: [Int64] {
+    get {return _storage._packedSint64}
+    set {_uniqueStorage()._packedSint64 = newValue}
+  }
+
+  var packedFixed32: [UInt32] {
+    get {return _storage._packedFixed32}
+    set {_uniqueStorage()._packedFixed32 = newValue}
+  }
+
+  var packedFixed64: [UInt64] {
+    get {return _storage._packedFixed64}
+    set {_uniqueStorage()._packedFixed64 = newValue}
+  }
+
+  var packedSfixed32: [Int32] {
+    get {return _storage._packedSfixed32}
+    set {_uniqueStorage()._packedSfixed32 = newValue}
+  }
+
+  var packedSfixed64: [Int64] {
+    get {return _storage._packedSfixed64}
+    set {_uniqueStorage()._packedSfixed64 = newValue}
+  }
+
+  var packedFloat: [Float] {
+    get {return _storage._packedFloat}
+    set {_uniqueStorage()._packedFloat = newValue}
+  }
+
+  var packedDouble: [Double] {
+    get {return _storage._packedDouble}
+    set {_uniqueStorage()._packedDouble = newValue}
+  }
+
+  var packedBool: [Bool] {
+    get {return _storage._packedBool}
+    set {_uniqueStorage()._packedBool = newValue}
+  }
+
+  var packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._packedNestedEnum}
+    set {_uniqueStorage()._packedNestedEnum = newValue}
+  }
+
+  /// Unpacked
+  var unpackedInt32: [Int32] {
+    get {return _storage._unpackedInt32}
+    set {_uniqueStorage()._unpackedInt32 = newValue}
+  }
+
+  var unpackedInt64: [Int64] {
+    get {return _storage._unpackedInt64}
+    set {_uniqueStorage()._unpackedInt64 = newValue}
+  }
+
+  var unpackedUint32: [UInt32] {
+    get {return _storage._unpackedUint32}
+    set {_uniqueStorage()._unpackedUint32 = newValue}
+  }
+
+  var unpackedUint64: [UInt64] {
+    get {return _storage._unpackedUint64}
+    set {_uniqueStorage()._unpackedUint64 = newValue}
+  }
+
+  var unpackedSint32: [Int32] {
+    get {return _storage._unpackedSint32}
+    set {_uniqueStorage()._unpackedSint32 = newValue}
+  }
+
+  var unpackedSint64: [Int64] {
+    get {return _storage._unpackedSint64}
+    set {_uniqueStorage()._unpackedSint64 = newValue}
+  }
+
+  var unpackedFixed32: [UInt32] {
+    get {return _storage._unpackedFixed32}
+    set {_uniqueStorage()._unpackedFixed32 = newValue}
+  }
+
+  var unpackedFixed64: [UInt64] {
+    get {return _storage._unpackedFixed64}
+    set {_uniqueStorage()._unpackedFixed64 = newValue}
+  }
+
+  var unpackedSfixed32: [Int32] {
+    get {return _storage._unpackedSfixed32}
+    set {_uniqueStorage()._unpackedSfixed32 = newValue}
+  }
+
+  var unpackedSfixed64: [Int64] {
+    get {return _storage._unpackedSfixed64}
+    set {_uniqueStorage()._unpackedSfixed64 = newValue}
+  }
+
+  var unpackedFloat: [Float] {
+    get {return _storage._unpackedFloat}
+    set {_uniqueStorage()._unpackedFloat = newValue}
+  }
+
+  var unpackedDouble: [Double] {
+    get {return _storage._unpackedDouble}
+    set {_uniqueStorage()._unpackedDouble = newValue}
+  }
+
+  var unpackedBool: [Bool] {
+    get {return _storage._unpackedBool}
+    set {_uniqueStorage()._unpackedBool = newValue}
+  }
+
+  var unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] {
+    get {return _storage._unpackedNestedEnum}
+    set {_uniqueStorage()._unpackedNestedEnum = newValue}
+  }
+
   /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
@@ -1051,6 +1193,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     52: .standard(proto: "repeated_foreign_enum"),
     54: .standard(proto: "repeated_string_piece"),
     55: .standard(proto: "repeated_cord"),
+    75: .standard(proto: "packed_int32"),
+    76: .standard(proto: "packed_int64"),
+    77: .standard(proto: "packed_uint32"),
+    78: .standard(proto: "packed_uint64"),
+    79: .standard(proto: "packed_sint32"),
+    80: .standard(proto: "packed_sint64"),
+    81: .standard(proto: "packed_fixed32"),
+    82: .standard(proto: "packed_fixed64"),
+    83: .standard(proto: "packed_sfixed32"),
+    84: .standard(proto: "packed_sfixed64"),
+    85: .standard(proto: "packed_float"),
+    86: .standard(proto: "packed_double"),
+    87: .standard(proto: "packed_bool"),
+    88: .standard(proto: "packed_nested_enum"),
+    89: .standard(proto: "unpacked_int32"),
+    90: .standard(proto: "unpacked_int64"),
+    91: .standard(proto: "unpacked_uint32"),
+    92: .standard(proto: "unpacked_uint64"),
+    93: .standard(proto: "unpacked_sint32"),
+    94: .standard(proto: "unpacked_sint64"),
+    95: .standard(proto: "unpacked_fixed32"),
+    96: .standard(proto: "unpacked_fixed64"),
+    97: .standard(proto: "unpacked_sfixed32"),
+    98: .standard(proto: "unpacked_sfixed64"),
+    99: .standard(proto: "unpacked_float"),
+    100: .standard(proto: "unpacked_double"),
+    101: .standard(proto: "unpacked_bool"),
+    102: .standard(proto: "unpacked_nested_enum"),
     56: .standard(proto: "map_int32_int32"),
     57: .standard(proto: "map_int64_int64"),
     58: .standard(proto: "map_uint32_uint32"),
@@ -1175,6 +1345,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
     var _repeatedForeignEnum: [ProtobufTestMessages_Proto3_ForeignEnum] = []
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
+    var _packedInt32: [Int32] = []
+    var _packedInt64: [Int64] = []
+    var _packedUint32: [UInt32] = []
+    var _packedUint64: [UInt64] = []
+    var _packedSint32: [Int32] = []
+    var _packedSint64: [Int64] = []
+    var _packedFixed32: [UInt32] = []
+    var _packedFixed64: [UInt64] = []
+    var _packedSfixed32: [Int32] = []
+    var _packedSfixed64: [Int64] = []
+    var _packedFloat: [Float] = []
+    var _packedDouble: [Double] = []
+    var _packedBool: [Bool] = []
+    var _packedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
+    var _unpackedInt32: [Int32] = []
+    var _unpackedInt64: [Int64] = []
+    var _unpackedUint32: [UInt32] = []
+    var _unpackedUint64: [UInt64] = []
+    var _unpackedSint32: [Int32] = []
+    var _unpackedSint64: [Int64] = []
+    var _unpackedFixed32: [UInt32] = []
+    var _unpackedFixed64: [UInt64] = []
+    var _unpackedSfixed32: [Int32] = []
+    var _unpackedSfixed64: [Int64] = []
+    var _unpackedFloat: [Float] = []
+    var _unpackedDouble: [Double] = []
+    var _unpackedBool: [Bool] = []
+    var _unpackedNestedEnum: [ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum] = []
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -1294,6 +1492,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       _repeatedForeignEnum = source._repeatedForeignEnum
       _repeatedStringPiece = source._repeatedStringPiece
       _repeatedCord = source._repeatedCord
+      _packedInt32 = source._packedInt32
+      _packedInt64 = source._packedInt64
+      _packedUint32 = source._packedUint32
+      _packedUint64 = source._packedUint64
+      _packedSint32 = source._packedSint32
+      _packedSint64 = source._packedSint64
+      _packedFixed32 = source._packedFixed32
+      _packedFixed64 = source._packedFixed64
+      _packedSfixed32 = source._packedSfixed32
+      _packedSfixed64 = source._packedSfixed64
+      _packedFloat = source._packedFloat
+      _packedDouble = source._packedDouble
+      _packedBool = source._packedBool
+      _packedNestedEnum = source._packedNestedEnum
+      _unpackedInt32 = source._unpackedInt32
+      _unpackedInt64 = source._unpackedInt64
+      _unpackedUint32 = source._unpackedUint32
+      _unpackedUint64 = source._unpackedUint64
+      _unpackedSint32 = source._unpackedSint32
+      _unpackedSint64 = source._unpackedSint64
+      _unpackedFixed32 = source._unpackedFixed32
+      _unpackedFixed64 = source._unpackedFixed64
+      _unpackedSfixed32 = source._unpackedSfixed32
+      _unpackedSfixed64 = source._unpackedSfixed64
+      _unpackedFloat = source._unpackedFloat
+      _unpackedDouble = source._unpackedDouble
+      _unpackedBool = source._unpackedBool
+      _unpackedNestedEnum = source._unpackedNestedEnum
       _mapInt32Int32 = source._mapInt32Int32
       _mapInt64Int64 = source._mapInt64Int64
       _mapUint32Uint32 = source._mapUint32Uint32
@@ -1441,6 +1667,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
         case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
         case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
+        case 75: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
+        case 76: try decoder.decodeRepeatedInt64Field(value: &_storage._packedInt64)
+        case 77: try decoder.decodeRepeatedUInt32Field(value: &_storage._packedUint32)
+        case 78: try decoder.decodeRepeatedUInt64Field(value: &_storage._packedUint64)
+        case 79: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedSint32)
+        case 80: try decoder.decodeRepeatedSInt64Field(value: &_storage._packedSint64)
+        case 81: try decoder.decodeRepeatedFixed32Field(value: &_storage._packedFixed32)
+        case 82: try decoder.decodeRepeatedFixed64Field(value: &_storage._packedFixed64)
+        case 83: try decoder.decodeRepeatedSFixed32Field(value: &_storage._packedSfixed32)
+        case 84: try decoder.decodeRepeatedSFixed64Field(value: &_storage._packedSfixed64)
+        case 85: try decoder.decodeRepeatedFloatField(value: &_storage._packedFloat)
+        case 86: try decoder.decodeRepeatedDoubleField(value: &_storage._packedDouble)
+        case 87: try decoder.decodeRepeatedBoolField(value: &_storage._packedBool)
+        case 88: try decoder.decodeRepeatedEnumField(value: &_storage._packedNestedEnum)
+        case 89: try decoder.decodeRepeatedInt32Field(value: &_storage._unpackedInt32)
+        case 90: try decoder.decodeRepeatedInt64Field(value: &_storage._unpackedInt64)
+        case 91: try decoder.decodeRepeatedUInt32Field(value: &_storage._unpackedUint32)
+        case 92: try decoder.decodeRepeatedUInt64Field(value: &_storage._unpackedUint64)
+        case 93: try decoder.decodeRepeatedSInt32Field(value: &_storage._unpackedSint32)
+        case 94: try decoder.decodeRepeatedSInt64Field(value: &_storage._unpackedSint64)
+        case 95: try decoder.decodeRepeatedFixed32Field(value: &_storage._unpackedFixed32)
+        case 96: try decoder.decodeRepeatedFixed64Field(value: &_storage._unpackedFixed64)
+        case 97: try decoder.decodeRepeatedSFixed32Field(value: &_storage._unpackedSfixed32)
+        case 98: try decoder.decodeRepeatedSFixed64Field(value: &_storage._unpackedSfixed64)
+        case 99: try decoder.decodeRepeatedFloatField(value: &_storage._unpackedFloat)
+        case 100: try decoder.decodeRepeatedDoubleField(value: &_storage._unpackedDouble)
+        case 101: try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool)
+        case 102: try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum)
         case 111:
           if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
@@ -1735,6 +1989,90 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
+      if !_storage._packedInt32.isEmpty {
+        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 75)
+      }
+      if !_storage._packedInt64.isEmpty {
+        try visitor.visitPackedInt64Field(value: _storage._packedInt64, fieldNumber: 76)
+      }
+      if !_storage._packedUint32.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._packedUint32, fieldNumber: 77)
+      }
+      if !_storage._packedUint64.isEmpty {
+        try visitor.visitPackedUInt64Field(value: _storage._packedUint64, fieldNumber: 78)
+      }
+      if !_storage._packedSint32.isEmpty {
+        try visitor.visitPackedSInt32Field(value: _storage._packedSint32, fieldNumber: 79)
+      }
+      if !_storage._packedSint64.isEmpty {
+        try visitor.visitPackedSInt64Field(value: _storage._packedSint64, fieldNumber: 80)
+      }
+      if !_storage._packedFixed32.isEmpty {
+        try visitor.visitPackedFixed32Field(value: _storage._packedFixed32, fieldNumber: 81)
+      }
+      if !_storage._packedFixed64.isEmpty {
+        try visitor.visitPackedFixed64Field(value: _storage._packedFixed64, fieldNumber: 82)
+      }
+      if !_storage._packedSfixed32.isEmpty {
+        try visitor.visitPackedSFixed32Field(value: _storage._packedSfixed32, fieldNumber: 83)
+      }
+      if !_storage._packedSfixed64.isEmpty {
+        try visitor.visitPackedSFixed64Field(value: _storage._packedSfixed64, fieldNumber: 84)
+      }
+      if !_storage._packedFloat.isEmpty {
+        try visitor.visitPackedFloatField(value: _storage._packedFloat, fieldNumber: 85)
+      }
+      if !_storage._packedDouble.isEmpty {
+        try visitor.visitPackedDoubleField(value: _storage._packedDouble, fieldNumber: 86)
+      }
+      if !_storage._packedBool.isEmpty {
+        try visitor.visitPackedBoolField(value: _storage._packedBool, fieldNumber: 87)
+      }
+      if !_storage._packedNestedEnum.isEmpty {
+        try visitor.visitPackedEnumField(value: _storage._packedNestedEnum, fieldNumber: 88)
+      }
+      if !_storage._unpackedInt32.isEmpty {
+        try visitor.visitRepeatedInt32Field(value: _storage._unpackedInt32, fieldNumber: 89)
+      }
+      if !_storage._unpackedInt64.isEmpty {
+        try visitor.visitRepeatedInt64Field(value: _storage._unpackedInt64, fieldNumber: 90)
+      }
+      if !_storage._unpackedUint32.isEmpty {
+        try visitor.visitRepeatedUInt32Field(value: _storage._unpackedUint32, fieldNumber: 91)
+      }
+      if !_storage._unpackedUint64.isEmpty {
+        try visitor.visitRepeatedUInt64Field(value: _storage._unpackedUint64, fieldNumber: 92)
+      }
+      if !_storage._unpackedSint32.isEmpty {
+        try visitor.visitRepeatedSInt32Field(value: _storage._unpackedSint32, fieldNumber: 93)
+      }
+      if !_storage._unpackedSint64.isEmpty {
+        try visitor.visitRepeatedSInt64Field(value: _storage._unpackedSint64, fieldNumber: 94)
+      }
+      if !_storage._unpackedFixed32.isEmpty {
+        try visitor.visitRepeatedFixed32Field(value: _storage._unpackedFixed32, fieldNumber: 95)
+      }
+      if !_storage._unpackedFixed64.isEmpty {
+        try visitor.visitRepeatedFixed64Field(value: _storage._unpackedFixed64, fieldNumber: 96)
+      }
+      if !_storage._unpackedSfixed32.isEmpty {
+        try visitor.visitRepeatedSFixed32Field(value: _storage._unpackedSfixed32, fieldNumber: 97)
+      }
+      if !_storage._unpackedSfixed64.isEmpty {
+        try visitor.visitRepeatedSFixed64Field(value: _storage._unpackedSfixed64, fieldNumber: 98)
+      }
+      if !_storage._unpackedFloat.isEmpty {
+        try visitor.visitRepeatedFloatField(value: _storage._unpackedFloat, fieldNumber: 99)
+      }
+      if !_storage._unpackedDouble.isEmpty {
+        try visitor.visitRepeatedDoubleField(value: _storage._unpackedDouble, fieldNumber: 100)
+      }
+      if !_storage._unpackedBool.isEmpty {
+        try visitor.visitRepeatedBoolField(value: _storage._unpackedBool, fieldNumber: 101)
+      }
+      if !_storage._unpackedNestedEnum.isEmpty {
+        try visitor.visitRepeatedEnumField(value: _storage._unpackedNestedEnum, fieldNumber: 102)
+      }
       switch _storage._oneofField {
       case .oneofUint32(let v)?:
         try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
@@ -1956,6 +2294,34 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         if _storage._repeatedForeignEnum != rhs_storage._repeatedForeignEnum {return false}
         if _storage._repeatedStringPiece != rhs_storage._repeatedStringPiece {return false}
         if _storage._repeatedCord != rhs_storage._repeatedCord {return false}
+        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
+        if _storage._packedInt64 != rhs_storage._packedInt64 {return false}
+        if _storage._packedUint32 != rhs_storage._packedUint32 {return false}
+        if _storage._packedUint64 != rhs_storage._packedUint64 {return false}
+        if _storage._packedSint32 != rhs_storage._packedSint32 {return false}
+        if _storage._packedSint64 != rhs_storage._packedSint64 {return false}
+        if _storage._packedFixed32 != rhs_storage._packedFixed32 {return false}
+        if _storage._packedFixed64 != rhs_storage._packedFixed64 {return false}
+        if _storage._packedSfixed32 != rhs_storage._packedSfixed32 {return false}
+        if _storage._packedSfixed64 != rhs_storage._packedSfixed64 {return false}
+        if _storage._packedFloat != rhs_storage._packedFloat {return false}
+        if _storage._packedDouble != rhs_storage._packedDouble {return false}
+        if _storage._packedBool != rhs_storage._packedBool {return false}
+        if _storage._packedNestedEnum != rhs_storage._packedNestedEnum {return false}
+        if _storage._unpackedInt32 != rhs_storage._unpackedInt32 {return false}
+        if _storage._unpackedInt64 != rhs_storage._unpackedInt64 {return false}
+        if _storage._unpackedUint32 != rhs_storage._unpackedUint32 {return false}
+        if _storage._unpackedUint64 != rhs_storage._unpackedUint64 {return false}
+        if _storage._unpackedSint32 != rhs_storage._unpackedSint32 {return false}
+        if _storage._unpackedSint64 != rhs_storage._unpackedSint64 {return false}
+        if _storage._unpackedFixed32 != rhs_storage._unpackedFixed32 {return false}
+        if _storage._unpackedFixed64 != rhs_storage._unpackedFixed64 {return false}
+        if _storage._unpackedSfixed32 != rhs_storage._unpackedSfixed32 {return false}
+        if _storage._unpackedSfixed64 != rhs_storage._unpackedSfixed64 {return false}
+        if _storage._unpackedFloat != rhs_storage._unpackedFloat {return false}
+        if _storage._unpackedDouble != rhs_storage._unpackedDouble {return false}
+        if _storage._unpackedBool != rhs_storage._unpackedBool {return false}
+        if _storage._unpackedNestedEnum != rhs_storage._unpackedNestedEnum {return false}
         if _storage._mapInt32Int32 != rhs_storage._mapInt32Int32 {return false}
         if _storage._mapInt64Int64 != rhs_storage._mapInt64Int64 {return false}
         if _storage._mapUint32Uint32 != rhs_storage._mapUint32Uint32 {return false}


### PR DESCRIPTION
Using 1be79eefd5d94db7bada646a293b3fa42546763e.

The conformance tests use the new fields, so things appear to fail with the
update.