### PR TITLE
Use heap-based storage only when a Protobuf has a singular transitive recursion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "swiftformat.enable": false,
-  "files.trimTrailingWhitespace": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "swiftformat.enable": false,
+  "files.trimTrailingWhitespace": true
+}

--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -206,82 +206,67 @@ struct Conformance_ConformanceRequest {
   /// TODO(haberman): if/when we expand the conformance tests to support proto2,
   /// we will want to include a field that lets the payload/response be a
   /// protobuf_test_messages.proto2.TestAllTypes message instead.
-  var payload: OneOf_Payload? {
-    get {return _storage._payload}
-    set {_uniqueStorage()._payload = newValue}
-  }
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = _storage._payload {return v}
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._payload = .protobufPayload(newValue)}
+    set {payload = .protobufPayload(newValue)}
   }
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = _storage._payload {return v}
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jsonPayload(newValue)}
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Google internal only.  Opensource testees just skip it.
   var jspbPayload: String {
     get {
-      if case .jspbPayload(let v)? = _storage._payload {return v}
+      if case .jspbPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jspbPayload(newValue)}
+    set {payload = .jspbPayload(newValue)}
   }
 
   var textPayload: String {
     get {
-      if case .textPayload(let v)? = _storage._payload {return v}
+      if case .textPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .textPayload(newValue)}
+    set {payload = .textPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
-  var requestedOutputFormat: Conformance_WireFormat {
-    get {return _storage._requestedOutputFormat}
-    set {_uniqueStorage()._requestedOutputFormat = newValue}
-  }
+  var requestedOutputFormat: Conformance_WireFormat = .unspecified
 
   /// The full name for the test message to use; for the moment, either:
   /// protobuf_test_messages.proto3.TestAllTypesProto3 or
   /// protobuf_test_messages.proto2.TestAllTypesProto2.
-  var messageType: String {
-    get {return _storage._messageType}
-    set {_uniqueStorage()._messageType = newValue}
-  }
+  var messageType: String = String()
 
   /// Each test is given a specific test category. Some category may need
   /// spedific support in testee programs. Refer to the defintion of TestCategory
   /// for more information.
-  var testCategory: Conformance_TestCategory {
-    get {return _storage._testCategory}
-    set {_uniqueStorage()._testCategory = newValue}
-  }
+  var testCategory: Conformance_TestCategory = .unspecifiedTest
 
   /// Specify details for how to encode jspb.
   var jspbEncodingOptions: Conformance_JspbEncodingConfig {
-    get {return _storage._jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
-    set {_uniqueStorage()._jspbEncodingOptions = newValue}
+    get {return _jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
+    set {_jspbEncodingOptions = newValue}
   }
   /// Returns true if `jspbEncodingOptions` has been explicitly set.
-  var hasJspbEncodingOptions: Bool {return _storage._jspbEncodingOptions != nil}
+  var hasJspbEncodingOptions: Bool {return self._jspbEncodingOptions != nil}
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
-  mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
+  mutating func clearJspbEncodingOptions() {self._jspbEncodingOptions = nil}
 
   /// This can be used in json and text format. If true, testee should print
   /// unknown fields instead of ignore. This feature is optional.
-  var printUnknownFields: Bool {
-    get {return _storage._printUnknownFields}
-    set {_uniqueStorage()._printUnknownFields = newValue}
-  }
+  var printUnknownFields: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -302,7 +287,7 @@ struct Conformance_ConformanceRequest {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
 }
 
 /// Represents a single test case's output.
@@ -519,123 +504,81 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     9: .standard(proto: "print_unknown_fields"),
   ]
 
-  fileprivate class _StorageClass {
-    var _payload: Conformance_ConformanceRequest.OneOf_Payload?
-    var _requestedOutputFormat: Conformance_WireFormat = .unspecified
-    var _messageType: String = String()
-    var _testCategory: Conformance_TestCategory = .unspecifiedTest
-    var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
-    var _printUnknownFields: Bool = false
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _payload = source._payload
-      _requestedOutputFormat = source._requestedOutputFormat
-      _messageType = source._messageType
-      _testCategory = source._testCategory
-      _jspbEncodingOptions = source._jspbEncodingOptions
-      _printUnknownFields = source._printUnknownFields
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._payload = .protobufPayload(v)}
-        case 2:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jsonPayload(v)}
-        case 3: try decoder.decodeSingularEnumField(value: &_storage._requestedOutputFormat)
-        case 4: try decoder.decodeSingularStringField(value: &_storage._messageType)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._testCategory)
-        case 6: try decoder.decodeSingularMessageField(value: &_storage._jspbEncodingOptions)
-        case 7:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jspbPayload(v)}
-        case 8:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .textPayload(v)}
-        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.payload = .protobufPayload(v)}
+      case 2:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jsonPayload(v)}
+      case 3: try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat)
+      case 4: try decoder.decodeSingularStringField(value: &self.messageType)
+      case 5: try decoder.decodeSingularEnumField(value: &self.testCategory)
+      case 6: try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions)
+      case 7:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jspbPayload(v)}
+      case 8:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .textPayload(v)}
+      case 9: try decoder.decodeSingularBoolField(value: &self.printUnknownFields)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._payload {
-      case .protobufPayload(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-      case .jsonPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case nil: break
-      default: break
-      }
-      if _storage._requestedOutputFormat != .unspecified {
-        try visitor.visitSingularEnumField(value: _storage._requestedOutputFormat, fieldNumber: 3)
-      }
-      if !_storage._messageType.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._messageType, fieldNumber: 4)
-      }
-      if _storage._testCategory != .unspecifiedTest {
-        try visitor.visitSingularEnumField(value: _storage._testCategory, fieldNumber: 5)
-      }
-      if let v = _storage._jspbEncodingOptions {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }
-      switch _storage._payload {
-      case .jspbPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      case .textPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 8)
-      case nil: break
-      default: break
-      }
-      if _storage._printUnknownFields != false {
-        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
-      }
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case nil: break
+    default: break
+    }
+    if self.requestedOutputFormat != .unspecified {
+      try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
+    }
+    if !self.messageType.isEmpty {
+      try visitor.visitSingularStringField(value: self.messageType, fieldNumber: 4)
+    }
+    if self.testCategory != .unspecifiedTest {
+      try visitor.visitSingularEnumField(value: self.testCategory, fieldNumber: 5)
+    }
+    if let v = self._jspbEncodingOptions {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }
+    switch self.payload {
+    case .jspbPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    case .textPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 8)
+    case nil: break
+    default: break
+    }
+    if self.printUnknownFields != false {
+      try visitor.visitSingularBoolField(value: self.printUnknownFields, fieldNumber: 9)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._payload != rhs_storage._payload {return false}
-        if _storage._requestedOutputFormat != rhs_storage._requestedOutputFormat {return false}
-        if _storage._messageType != rhs_storage._messageType {return false}
-        if _storage._testCategory != rhs_storage._testCategory {return false}
-        if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
-        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.payload != rhs.payload {return false}
+    if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
+    if lhs.messageType != rhs.messageType {return false}
+    if lhs.testCategory != rhs.testCategory {return false}
+    if lhs._jspbEncodingOptions != rhs._jspbEncodingOptions {return false}
+    if lhs.printUnknownFields != rhs.printUnknownFields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/any_test.pb.swift
+++ b/Reference/google/protobuf/any_test.pb.swift
@@ -54,30 +54,24 @@ struct ProtobufUnittest_TestAny {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var int32Value: Int32 {
-    get {return _storage._int32Value}
-    set {_uniqueStorage()._int32Value = newValue}
-  }
+  var int32Value: Int32 = 0
 
   var anyValue: SwiftProtobuf.Google_Protobuf_Any {
-    get {return _storage._anyValue ?? SwiftProtobuf.Google_Protobuf_Any()}
-    set {_uniqueStorage()._anyValue = newValue}
+    get {return _anyValue ?? SwiftProtobuf.Google_Protobuf_Any()}
+    set {_anyValue = newValue}
   }
   /// Returns true if `anyValue` has been explicitly set.
-  var hasAnyValue: Bool {return _storage._anyValue != nil}
+  var hasAnyValue: Bool {return self._anyValue != nil}
   /// Clears the value of `anyValue`. Subsequent reads from it will return its default value.
-  mutating func clearAnyValue() {_uniqueStorage()._anyValue = nil}
+  mutating func clearAnyValue() {self._anyValue = nil}
 
-  var repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] {
-    get {return _storage._repeatedAnyValue}
-    set {_uniqueStorage()._repeatedAnyValue = newValue}
-  }
+  var repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _anyValue: SwiftProtobuf.Google_Protobuf_Any? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -92,70 +86,34 @@ extension ProtobufUnittest_TestAny: SwiftProtobuf.Message, SwiftProtobuf._Messag
     3: .standard(proto: "repeated_any_value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _int32Value: Int32 = 0
-    var _anyValue: SwiftProtobuf.Google_Protobuf_Any? = nil
-    var _repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _int32Value = source._int32Value
-      _anyValue = source._anyValue
-      _repeatedAnyValue = source._repeatedAnyValue
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._int32Value)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._anyValue)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAnyValue)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self.int32Value)
+      case 2: try decoder.decodeSingularMessageField(value: &self._anyValue)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAnyValue)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._int32Value != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._int32Value, fieldNumber: 1)
-      }
-      if let v = _storage._anyValue {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAnyValue.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAnyValue, fieldNumber: 3)
-      }
+    if self.int32Value != 0 {
+      try visitor.visitSingularInt32Field(value: self.int32Value, fieldNumber: 1)
+    }
+    if let v = self._anyValue {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAnyValue.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAnyValue, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestAny, rhs: ProtobufUnittest_TestAny) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._int32Value != rhs_storage._int32Value {return false}
-        if _storage._anyValue != rhs_storage._anyValue {return false}
-        if _storage._repeatedAnyValue != rhs_storage._repeatedAnyValue {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.int32Value != rhs.int32Value {return false}
+    if lhs._anyValue != rhs._anyValue {return false}
+    if lhs.repeatedAnyValue != rhs.repeatedAnyValue {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -64,22 +64,13 @@ struct Google_Protobuf_Api {
 
   /// The fully qualified name of this interface, including package name
   /// followed by the interface's simple name.
-  var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  var name: String = String()
 
   /// The methods of this interface, in unspecified order.
-  var methods: [Google_Protobuf_Method] {
-    get {return _storage._methods}
-    set {_uniqueStorage()._methods = newValue}
-  }
+  var methods: [Google_Protobuf_Method] = []
 
   /// Any metadata attached to the interface.
-  var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  var options: [Google_Protobuf_Option] = []
 
   /// A version string for this interface. If specified, must have the form
   /// `major-version.minor-version`, as in `1.10`. If the minor version is
@@ -100,39 +91,30 @@ struct Google_Protobuf_Api {
   /// `google.feature.v1`. For major versions 0 and 1, the suffix can
   /// be omitted. Zero major versions must only be used for
   /// experimental, non-GA interfaces.
-  var version: String {
-    get {return _storage._version}
-    set {_uniqueStorage()._version = newValue}
-  }
+  var version: String = String()
 
   /// Source context for the protocol buffer service represented by this
   /// message.
   var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// Included interfaces. See [Mixin][].
-  var mixins: [Google_Protobuf_Mixin] {
-    get {return _storage._mixins}
-    set {_uniqueStorage()._mixins = newValue}
-  }
+  var mixins: [Google_Protobuf_Mixin] = []
 
   /// The source syntax of the service.
-  var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  var syntax: Google_Protobuf_Syntax = .proto2
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// Method represents a method of an API interface.
@@ -278,98 +260,54 @@ extension Google_Protobuf_Api: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     7: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _methods: [Google_Protobuf_Method] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _version: String = String()
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _mixins: [Google_Protobuf_Mixin] = []
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _methods = source._methods
-      _options = source._options
-      _version = source._version
-      _sourceContext = source._sourceContext
-      _mixins = source._mixins
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._methods)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 4: try decoder.decodeSingularStringField(value: &_storage._version)
-        case 5: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._mixins)
-        case 7: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.methods)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 4: try decoder.decodeSingularStringField(value: &self.version)
+      case 5: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.mixins)
+      case 7: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._methods.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._methods, fieldNumber: 2)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 3)
-      }
-      if !_storage._version.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._version, fieldNumber: 4)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if !_storage._mixins.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._mixins, fieldNumber: 6)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 7)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.methods.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.methods, fieldNumber: 2)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 3)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 4)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }
+    if !self.mixins.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.mixins, fieldNumber: 6)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 7)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Api, rhs: Google_Protobuf_Api) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._methods != rhs_storage._methods {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._version != rhs_storage._version {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._mixins != rhs_storage._mixins {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.methods != rhs.methods {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.mixins != rhs.mixins {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -128,20 +128,17 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest {
   /// The .proto files that were explicitly listed on the command-line.  The
   /// code generator should generate code only for these files.  Each file's
   /// descriptor will be included in proto_file, below.
-  var fileToGenerate: [String] {
-    get {return _storage._fileToGenerate}
-    set {_uniqueStorage()._fileToGenerate = newValue}
-  }
+  var fileToGenerate: [String] = []
 
   /// The generator parameter passed on the command-line.
   var parameter: String {
-    get {return _storage._parameter ?? String()}
-    set {_uniqueStorage()._parameter = newValue}
+    get {return _parameter ?? String()}
+    set {_parameter = newValue}
   }
   /// Returns true if `parameter` has been explicitly set.
-  var hasParameter: Bool {return _storage._parameter != nil}
+  var hasParameter: Bool {return self._parameter != nil}
   /// Clears the value of `parameter`. Subsequent reads from it will return its default value.
-  mutating func clearParameter() {_uniqueStorage()._parameter = nil}
+  mutating func clearParameter() {self._parameter = nil}
 
   /// FileDescriptorProtos for all files in files_to_generate and everything
   /// they import.  The files will appear in topological order, so each file
@@ -157,26 +154,24 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest {
   ///
   /// Type names of fields and extensions in the FileDescriptorProto are always
   /// fully qualified.
-  var protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] {
-    get {return _storage._protoFile}
-    set {_uniqueStorage()._protoFile = newValue}
-  }
+  var protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] = []
 
   /// The version number of protocol compiler.
   var compilerVersion: Google_Protobuf_Compiler_Version {
-    get {return _storage._compilerVersion ?? Google_Protobuf_Compiler_Version()}
-    set {_uniqueStorage()._compilerVersion = newValue}
+    get {return _compilerVersion ?? Google_Protobuf_Compiler_Version()}
+    set {_compilerVersion = newValue}
   }
   /// Returns true if `compilerVersion` has been explicitly set.
-  var hasCompilerVersion: Bool {return _storage._compilerVersion != nil}
+  var hasCompilerVersion: Bool {return self._compilerVersion != nil}
   /// Clears the value of `compilerVersion`. Subsequent reads from it will return its default value.
-  mutating func clearCompilerVersion() {_uniqueStorage()._compilerVersion = nil}
+  mutating func clearCompilerVersion() {self._compilerVersion = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _parameter: String? = nil
+  fileprivate var _compilerVersion: Google_Protobuf_Compiler_Version? = nil
 }
 
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
@@ -362,84 +357,44 @@ extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, 
     3: .standard(proto: "compiler_version"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fileToGenerate: [String] = []
-    var _parameter: String? = nil
-    var _protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] = []
-    var _compilerVersion: Google_Protobuf_Compiler_Version? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fileToGenerate = source._fileToGenerate
-      _parameter = source._parameter
-      _protoFile = source._protoFile
-      _compilerVersion = source._compilerVersion
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._protoFile) {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.protoFile) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedStringField(value: &_storage._fileToGenerate)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._parameter)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._compilerVersion)
-        case 15: try decoder.decodeRepeatedMessageField(value: &_storage._protoFile)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedStringField(value: &self.fileToGenerate)
+      case 2: try decoder.decodeSingularStringField(value: &self._parameter)
+      case 3: try decoder.decodeSingularMessageField(value: &self._compilerVersion)
+      case 15: try decoder.decodeRepeatedMessageField(value: &self.protoFile)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._fileToGenerate.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._fileToGenerate, fieldNumber: 1)
-      }
-      if let v = _storage._parameter {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._compilerVersion {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._protoFile.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._protoFile, fieldNumber: 15)
-      }
+    if !self.fileToGenerate.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.fileToGenerate, fieldNumber: 1)
+    }
+    if let v = self._parameter {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._compilerVersion {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.protoFile.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.protoFile, fieldNumber: 15)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Compiler_CodeGeneratorRequest, rhs: Google_Protobuf_Compiler_CodeGeneratorRequest) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fileToGenerate != rhs_storage._fileToGenerate {return false}
-        if _storage._parameter != rhs_storage._parameter {return false}
-        if _storage._protoFile != rhs_storage._protoFile {return false}
-        if _storage._compilerVersion != rhs_storage._compilerVersion {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.fileToGenerate != rhs.fileToGenerate {return false}
+    if lhs._parameter != rhs._parameter {return false}
+    if lhs.protoFile != rhs.protoFile {return false}
+    if lhs._compilerVersion != rhs._compilerVersion {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -63,11 +63,16 @@ struct Google_Protobuf_FileDescriptorSet {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var file: [Google_Protobuf_FileDescriptorProto] = []
+  var file: [Google_Protobuf_FileDescriptorProto] {
+    get {return _storage._file}
+    set {_uniqueStorage()._file = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// Describes a complete .proto file.
@@ -251,38 +256,40 @@ struct Google_Protobuf_DescriptorProto {
 
     /// Inclusive.
     var start: Int32 {
-      get {return _storage._start ?? 0}
-      set {_uniqueStorage()._start = newValue}
+      get {return _start ?? 0}
+      set {_start = newValue}
     }
     /// Returns true if `start` has been explicitly set.
-    var hasStart: Bool {return _storage._start != nil}
+    var hasStart: Bool {return self._start != nil}
     /// Clears the value of `start`. Subsequent reads from it will return its default value.
-    mutating func clearStart() {_uniqueStorage()._start = nil}
+    mutating func clearStart() {self._start = nil}
 
     /// Exclusive.
     var end: Int32 {
-      get {return _storage._end ?? 0}
-      set {_uniqueStorage()._end = newValue}
+      get {return _end ?? 0}
+      set {_end = newValue}
     }
     /// Returns true if `end` has been explicitly set.
-    var hasEnd: Bool {return _storage._end != nil}
+    var hasEnd: Bool {return self._end != nil}
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
-    mutating func clearEnd() {_uniqueStorage()._end = nil}
+    mutating func clearEnd() {self._end = nil}
 
     var options: Google_Protobuf_ExtensionRangeOptions {
-      get {return _storage._options ?? Google_Protobuf_ExtensionRangeOptions()}
-      set {_uniqueStorage()._options = newValue}
+      get {return _options ?? Google_Protobuf_ExtensionRangeOptions()}
+      set {_options = newValue}
     }
     /// Returns true if `options` has been explicitly set.
-    var hasOptions: Bool {return _storage._options != nil}
+    var hasOptions: Bool {return self._options != nil}
     /// Clears the value of `options`. Subsequent reads from it will return its default value.
-    mutating func clearOptions() {_uniqueStorage()._options = nil}
+    mutating func clearOptions() {self._options = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _start: Int32? = nil
+    fileprivate var _end: Int32? = nil
+    fileprivate var _options: Google_Protobuf_ExtensionRangeOptions? = nil
   }
 
   /// Range of reserved tag numbers. Reserved tag numbers may not be used by
@@ -348,42 +355,42 @@ struct Google_Protobuf_FieldDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
   var number: Int32 {
-    get {return _storage._number ?? 0}
-    set {_uniqueStorage()._number = newValue}
+    get {return _number ?? 0}
+    set {_number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  var hasNumber: Bool {return _storage._number != nil}
+  var hasNumber: Bool {return self._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  mutating func clearNumber() {_uniqueStorage()._number = nil}
+  mutating func clearNumber() {self._number = nil}
 
   var label: Google_Protobuf_FieldDescriptorProto.Label {
-    get {return _storage._label ?? .optional}
-    set {_uniqueStorage()._label = newValue}
+    get {return _label ?? .optional}
+    set {_label = newValue}
   }
   /// Returns true if `label` has been explicitly set.
-  var hasLabel: Bool {return _storage._label != nil}
+  var hasLabel: Bool {return self._label != nil}
   /// Clears the value of `label`. Subsequent reads from it will return its default value.
-  mutating func clearLabel() {_uniqueStorage()._label = nil}
+  mutating func clearLabel() {self._label = nil}
 
   /// If type_name is set, this need not be set.  If both this and type_name
   /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
-    get {return _storage._type ?? .double}
-    set {_uniqueStorage()._type = newValue}
+    get {return _type ?? .double}
+    set {_type = newValue}
   }
   /// Returns true if `type` has been explicitly set.
-  var hasType: Bool {return _storage._type != nil}
+  var hasType: Bool {return self._type != nil}
   /// Clears the value of `type`. Subsequent reads from it will return its default value.
-  mutating func clearType() {_uniqueStorage()._type = nil}
+  mutating func clearType() {self._type = nil}
 
   /// For message and enum types, this is the name of the type.  If the name
   /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
@@ -391,24 +398,24 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   var typeName: String {
-    get {return _storage._typeName ?? String()}
-    set {_uniqueStorage()._typeName = newValue}
+    get {return _typeName ?? String()}
+    set {_typeName = newValue}
   }
   /// Returns true if `typeName` has been explicitly set.
-  var hasTypeName: Bool {return _storage._typeName != nil}
+  var hasTypeName: Bool {return self._typeName != nil}
   /// Clears the value of `typeName`. Subsequent reads from it will return its default value.
-  mutating func clearTypeName() {_uniqueStorage()._typeName = nil}
+  mutating func clearTypeName() {self._typeName = nil}
 
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   var extendee: String {
-    get {return _storage._extendee ?? String()}
-    set {_uniqueStorage()._extendee = newValue}
+    get {return _extendee ?? String()}
+    set {_extendee = newValue}
   }
   /// Returns true if `extendee` has been explicitly set.
-  var hasExtendee: Bool {return _storage._extendee != nil}
+  var hasExtendee: Bool {return self._extendee != nil}
   /// Clears the value of `extendee`. Subsequent reads from it will return its default value.
-  mutating func clearExtendee() {_uniqueStorage()._extendee = nil}
+  mutating func clearExtendee() {self._extendee = nil}
 
   /// For numeric types, contains the original text representation of the value.
   /// For booleans, "true" or "false".
@@ -416,46 +423,46 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
-    get {return _storage._defaultValue ?? String()}
-    set {_uniqueStorage()._defaultValue = newValue}
+    get {return _defaultValue ?? String()}
+    set {_defaultValue = newValue}
   }
   /// Returns true if `defaultValue` has been explicitly set.
-  var hasDefaultValue: Bool {return _storage._defaultValue != nil}
+  var hasDefaultValue: Bool {return self._defaultValue != nil}
   /// Clears the value of `defaultValue`. Subsequent reads from it will return its default value.
-  mutating func clearDefaultValue() {_uniqueStorage()._defaultValue = nil}
+  mutating func clearDefaultValue() {self._defaultValue = nil}
 
   /// If set, gives the index of a oneof in the containing type's oneof_decl
   /// list.  This field is a member of that oneof.
   var oneofIndex: Int32 {
-    get {return _storage._oneofIndex ?? 0}
-    set {_uniqueStorage()._oneofIndex = newValue}
+    get {return _oneofIndex ?? 0}
+    set {_oneofIndex = newValue}
   }
   /// Returns true if `oneofIndex` has been explicitly set.
-  var hasOneofIndex: Bool {return _storage._oneofIndex != nil}
+  var hasOneofIndex: Bool {return self._oneofIndex != nil}
   /// Clears the value of `oneofIndex`. Subsequent reads from it will return its default value.
-  mutating func clearOneofIndex() {_uniqueStorage()._oneofIndex = nil}
+  mutating func clearOneofIndex() {self._oneofIndex = nil}
 
   /// JSON name of this field. The value is set by protocol compiler. If the
   /// user has set a "json_name" option on this field, that option's value
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   var jsonName: String {
-    get {return _storage._jsonName ?? String()}
-    set {_uniqueStorage()._jsonName = newValue}
+    get {return _jsonName ?? String()}
+    set {_jsonName = newValue}
   }
   /// Returns true if `jsonName` has been explicitly set.
-  var hasJsonName: Bool {return _storage._jsonName != nil}
+  var hasJsonName: Bool {return self._jsonName != nil}
   /// Clears the value of `jsonName`. Subsequent reads from it will return its default value.
-  mutating func clearJsonName() {_uniqueStorage()._jsonName = nil}
+  mutating func clearJsonName() {self._jsonName = nil}
 
   var options: Google_Protobuf_FieldOptions {
-    get {return _storage._options ?? Google_Protobuf_FieldOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_FieldOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -588,7 +595,16 @@ struct Google_Protobuf_FieldDescriptorProto {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _number: Int32? = nil
+  fileprivate var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
+  fileprivate var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
+  fileprivate var _typeName: String? = nil
+  fileprivate var _extendee: String? = nil
+  fileprivate var _defaultValue: String? = nil
+  fileprivate var _oneofIndex: Int32? = nil
+  fileprivate var _jsonName: String? = nil
+  fileprivate var _options: Google_Protobuf_FieldOptions? = nil
 }
 
 #if swift(>=4.2)
@@ -610,28 +626,29 @@ struct Google_Protobuf_OneofDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
   var options: Google_Protobuf_OneofOptions {
-    get {return _storage._options ?? Google_Protobuf_OneofOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_OneofOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_OneofOptions? = nil
 }
 
 /// Describes an enum type.
@@ -641,42 +658,33 @@ struct Google_Protobuf_EnumDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
-  var value: [Google_Protobuf_EnumValueDescriptorProto] {
-    get {return _storage._value}
-    set {_uniqueStorage()._value = newValue}
-  }
+  var value: [Google_Protobuf_EnumValueDescriptorProto] = []
 
   var options: Google_Protobuf_EnumOptions {
-    get {return _storage._options ?? Google_Protobuf_EnumOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_EnumOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   /// Range of reserved numeric values. Reserved numeric values may not be used
   /// by enum values in the same enum declaration. Reserved ranges may not
   /// overlap.
-  var reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] {
-    get {return _storage._reservedRange}
-    set {_uniqueStorage()._reservedRange = newValue}
-  }
+  var reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] = []
 
   /// Reserved enum value names, which may not be reused. A given name may only
   /// be reserved once.
-  var reservedName: [String] {
-    get {return _storage._reservedName}
-    set {_uniqueStorage()._reservedName = newValue}
-  }
+  var reservedName: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -721,7 +729,8 @@ struct Google_Protobuf_EnumDescriptorProto {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_EnumOptions? = nil
 }
 
 /// Describes a value within an enum.
@@ -731,37 +740,39 @@ struct Google_Protobuf_EnumValueDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
   var number: Int32 {
-    get {return _storage._number ?? 0}
-    set {_uniqueStorage()._number = newValue}
+    get {return _number ?? 0}
+    set {_number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  var hasNumber: Bool {return _storage._number != nil}
+  var hasNumber: Bool {return self._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  mutating func clearNumber() {_uniqueStorage()._number = nil}
+  mutating func clearNumber() {self._number = nil}
 
   var options: Google_Protobuf_EnumValueOptions {
-    get {return _storage._options ?? Google_Protobuf_EnumValueOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_EnumValueOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _number: Int32? = nil
+  fileprivate var _options: Google_Protobuf_EnumValueOptions? = nil
 }
 
 /// Describes a service.
@@ -771,33 +782,31 @@ struct Google_Protobuf_ServiceDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
-  var method: [Google_Protobuf_MethodDescriptorProto] {
-    get {return _storage._method}
-    set {_uniqueStorage()._method = newValue}
-  }
+  var method: [Google_Protobuf_MethodDescriptorProto] = []
 
   var options: Google_Protobuf_ServiceOptions {
-    get {return _storage._options ?? Google_Protobuf_ServiceOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_ServiceOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_ServiceOptions? = nil
 }
 
 /// Describes a method of a service.
@@ -807,68 +816,73 @@ struct Google_Protobuf_MethodDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
   var inputType: String {
-    get {return _storage._inputType ?? String()}
-    set {_uniqueStorage()._inputType = newValue}
+    get {return _inputType ?? String()}
+    set {_inputType = newValue}
   }
   /// Returns true if `inputType` has been explicitly set.
-  var hasInputType: Bool {return _storage._inputType != nil}
+  var hasInputType: Bool {return self._inputType != nil}
   /// Clears the value of `inputType`. Subsequent reads from it will return its default value.
-  mutating func clearInputType() {_uniqueStorage()._inputType = nil}
+  mutating func clearInputType() {self._inputType = nil}
 
   var outputType: String {
-    get {return _storage._outputType ?? String()}
-    set {_uniqueStorage()._outputType = newValue}
+    get {return _outputType ?? String()}
+    set {_outputType = newValue}
   }
   /// Returns true if `outputType` has been explicitly set.
-  var hasOutputType: Bool {return _storage._outputType != nil}
+  var hasOutputType: Bool {return self._outputType != nil}
   /// Clears the value of `outputType`. Subsequent reads from it will return its default value.
-  mutating func clearOutputType() {_uniqueStorage()._outputType = nil}
+  mutating func clearOutputType() {self._outputType = nil}
 
   var options: Google_Protobuf_MethodOptions {
-    get {return _storage._options ?? Google_Protobuf_MethodOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_MethodOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   /// Identifies if client streams multiple client messages
   var clientStreaming: Bool {
-    get {return _storage._clientStreaming ?? false}
-    set {_uniqueStorage()._clientStreaming = newValue}
+    get {return _clientStreaming ?? false}
+    set {_clientStreaming = newValue}
   }
   /// Returns true if `clientStreaming` has been explicitly set.
-  var hasClientStreaming: Bool {return _storage._clientStreaming != nil}
+  var hasClientStreaming: Bool {return self._clientStreaming != nil}
   /// Clears the value of `clientStreaming`. Subsequent reads from it will return its default value.
-  mutating func clearClientStreaming() {_uniqueStorage()._clientStreaming = nil}
+  mutating func clearClientStreaming() {self._clientStreaming = nil}
 
   /// Identifies if server streams multiple server messages
   var serverStreaming: Bool {
-    get {return _storage._serverStreaming ?? false}
-    set {_uniqueStorage()._serverStreaming = newValue}
+    get {return _serverStreaming ?? false}
+    set {_serverStreaming = newValue}
   }
   /// Returns true if `serverStreaming` has been explicitly set.
-  var hasServerStreaming: Bool {return _storage._serverStreaming != nil}
+  var hasServerStreaming: Bool {return self._serverStreaming != nil}
   /// Clears the value of `serverStreaming`. Subsequent reads from it will return its default value.
-  mutating func clearServerStreaming() {_uniqueStorage()._serverStreaming = nil}
+  mutating func clearServerStreaming() {self._serverStreaming = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _inputType: String? = nil
+  fileprivate var _outputType: String? = nil
+  fileprivate var _options: Google_Protobuf_MethodOptions? = nil
+  fileprivate var _clientStreaming: Bool? = nil
+  fileprivate var _serverStreaming: Bool? = nil
 }
 
 struct Google_Protobuf_FileOptions: SwiftProtobuf.ExtensibleMessage {
@@ -2044,29 +2058,63 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message, SwiftProtobu
     1: .same(proto: "file"),
   ]
 
+  fileprivate class _StorageClass {
+    var _file: [Google_Protobuf_FileDescriptorProto] = []
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _file = source._file
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public var isInitialized: Bool {
-    if !SwiftProtobuf.Internal.areAllInitialized(self.file) {return false}
-    return true
+    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !SwiftProtobuf.Internal.areAllInitialized(_storage._file) {return false}
+      return true
+    }
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeRepeatedMessageField(value: &self.file)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._file)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.file.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._file.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._file, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_FileDescriptorSet, rhs: Google_Protobuf_FileDescriptorSet) -> Bool {
-    if lhs.file != rhs.file {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._file != rhs_storage._file {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2386,77 +2434,39 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobuf.Message,
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _start: Int32? = nil
-    var _end: Int32? = nil
-    var _options: Google_Protobuf_ExtensionRangeOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _start = source._start
-      _end = source._end
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._start)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._end)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._start)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._end)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._start {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._end {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._start {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._end {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_DescriptorProto.ExtensionRange, rhs: Google_Protobuf_DescriptorProto.ExtensionRange) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._start != rhs_storage._start {return false}
-        if _storage._end != rhs_storage._end {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._start != rhs._start {return false}
+    if lhs._end != rhs._end {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2551,126 +2561,74 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProt
     8: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _number: Int32? = nil
-    var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
-    var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
-    var _typeName: String? = nil
-    var _extendee: String? = nil
-    var _defaultValue: String? = nil
-    var _oneofIndex: Int32? = nil
-    var _jsonName: String? = nil
-    var _options: Google_Protobuf_FieldOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _number = source._number
-      _label = source._label
-      _type = source._type
-      _typeName = source._typeName
-      _extendee = source._extendee
-      _defaultValue = source._defaultValue
-      _oneofIndex = source._oneofIndex
-      _jsonName = source._jsonName
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._extendee)
-        case 3: try decoder.decodeSingularInt32Field(value: &_storage._number)
-        case 4: try decoder.decodeSingularEnumField(value: &_storage._label)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._type)
-        case 6: try decoder.decodeSingularStringField(value: &_storage._typeName)
-        case 7: try decoder.decodeSingularStringField(value: &_storage._defaultValue)
-        case 8: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 9: try decoder.decodeSingularInt32Field(value: &_storage._oneofIndex)
-        case 10: try decoder.decodeSingularStringField(value: &_storage._jsonName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._extendee)
+      case 3: try decoder.decodeSingularInt32Field(value: &self._number)
+      case 4: try decoder.decodeSingularEnumField(value: &self._label)
+      case 5: try decoder.decodeSingularEnumField(value: &self._type)
+      case 6: try decoder.decodeSingularStringField(value: &self._typeName)
+      case 7: try decoder.decodeSingularStringField(value: &self._defaultValue)
+      case 8: try decoder.decodeSingularMessageField(value: &self._options)
+      case 9: try decoder.decodeSingularInt32Field(value: &self._oneofIndex)
+      case 10: try decoder.decodeSingularStringField(value: &self._jsonName)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._extendee {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._number {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._label {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._type {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._typeName {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-      }
-      if let v = _storage._defaultValue {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._oneofIndex {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
-      }
-      if let v = _storage._jsonName {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 10)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._extendee {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._number {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+    }
+    if let v = self._label {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
+    }
+    if let v = self._type {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    }
+    if let v = self._typeName {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    }
+    if let v = self._defaultValue {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }
+    if let v = self._oneofIndex {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
+    }
+    if let v = self._jsonName {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_FieldDescriptorProto, rhs: Google_Protobuf_FieldDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._number != rhs_storage._number {return false}
-        if _storage._label != rhs_storage._label {return false}
-        if _storage._type != rhs_storage._type {return false}
-        if _storage._typeName != rhs_storage._typeName {return false}
-        if _storage._extendee != rhs_storage._extendee {return false}
-        if _storage._defaultValue != rhs_storage._defaultValue {return false}
-        if _storage._oneofIndex != rhs_storage._oneofIndex {return false}
-        if _storage._jsonName != rhs_storage._jsonName {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._number != rhs._number {return false}
+    if lhs._label != rhs._label {return false}
+    if lhs._type != rhs._type {return false}
+    if lhs._typeName != rhs._typeName {return false}
+    if lhs._extendee != rhs._extendee {return false}
+    if lhs._defaultValue != rhs._defaultValue {return false}
+    if lhs._oneofIndex != rhs._oneofIndex {return false}
+    if lhs._jsonName != rhs._jsonName {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2714,70 +2672,34 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message, SwiftProt
     2: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _options: Google_Protobuf_OneofOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_OneofDescriptorProto, rhs: Google_Protobuf_OneofDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2793,92 +2715,50 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message, SwiftProto
     5: .standard(proto: "reserved_name"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _value: [Google_Protobuf_EnumValueDescriptorProto] = []
-    var _options: Google_Protobuf_EnumOptions? = nil
-    var _reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] = []
-    var _reservedName: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _value = source._value
-      _options = source._options
-      _reservedRange = source._reservedRange
-      _reservedName = source._reservedName
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._value) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.value) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._value)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._reservedRange)
-        case 5: try decoder.decodeRepeatedStringField(value: &_storage._reservedName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.value)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.reservedRange)
+      case 5: try decoder.decodeRepeatedStringField(value: &self.reservedName)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._value.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._value, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._reservedRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._reservedRange, fieldNumber: 4)
-      }
-      if !_storage._reservedName.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._reservedName, fieldNumber: 5)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.value.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.value, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.reservedRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.reservedRange, fieldNumber: 4)
+    }
+    if !self.reservedName.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.reservedName, fieldNumber: 5)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_EnumDescriptorProto, rhs: Google_Protobuf_EnumDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._value != rhs_storage._value {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._reservedRange != rhs_storage._reservedRange {return false}
-        if _storage._reservedName != rhs_storage._reservedName {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.value != rhs.value {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs.reservedRange != rhs.reservedRange {return false}
+    if lhs.reservedName != rhs.reservedName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2927,77 +2807,39 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message, Swift
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _number: Int32? = nil
-    var _options: Google_Protobuf_EnumValueOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _number = source._number
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._number)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._number)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._number {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._number {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_EnumValueDescriptorProto, rhs: Google_Protobuf_EnumValueDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._number != rhs_storage._number {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._number != rhs._number {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3011,78 +2853,40 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message, SwiftPr
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _method: [Google_Protobuf_MethodDescriptorProto] = []
-    var _options: Google_Protobuf_ServiceOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _method = source._method
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._method) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.method) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._method)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.method)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._method.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._method, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.method.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.method, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_ServiceDescriptorProto, rhs: Google_Protobuf_ServiceDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._method != rhs_storage._method {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.method != rhs.method {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3099,98 +2903,54 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftPro
     6: .standard(proto: "server_streaming"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _inputType: String? = nil
-    var _outputType: String? = nil
-    var _options: Google_Protobuf_MethodOptions? = nil
-    var _clientStreaming: Bool? = nil
-    var _serverStreaming: Bool? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _inputType = source._inputType
-      _outputType = source._outputType
-      _options = source._options
-      _clientStreaming = source._clientStreaming
-      _serverStreaming = source._serverStreaming
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._inputType)
-        case 3: try decoder.decodeSingularStringField(value: &_storage._outputType)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 5: try decoder.decodeSingularBoolField(value: &_storage._clientStreaming)
-        case 6: try decoder.decodeSingularBoolField(value: &_storage._serverStreaming)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._inputType)
+      case 3: try decoder.decodeSingularStringField(value: &self._outputType)
+      case 4: try decoder.decodeSingularMessageField(value: &self._options)
+      case 5: try decoder.decodeSingularBoolField(value: &self._clientStreaming)
+      case 6: try decoder.decodeSingularBoolField(value: &self._serverStreaming)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._inputType {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._outputType {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._clientStreaming {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._serverStreaming {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._inputType {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._outputType {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if let v = self._clientStreaming {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
+    }
+    if let v = self._serverStreaming {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_MethodDescriptorProto, rhs: Google_Protobuf_MethodDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._inputType != rhs_storage._inputType {return false}
-        if _storage._outputType != rhs_storage._outputType {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._clientStreaming != rhs_storage._clientStreaming {return false}
-        if _storage._serverStreaming != rhs_storage._serverStreaming {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._inputType != rhs._inputType {return false}
+    if lhs._outputType != rhs._outputType {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs._clientStreaming != rhs._clientStreaming {return false}
+    if lhs._serverStreaming != rhs._serverStreaming {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -63,16 +63,11 @@ struct Google_Protobuf_FileDescriptorSet {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var file: [Google_Protobuf_FileDescriptorProto] {
-    get {return _storage._file}
-    set {_uniqueStorage()._file = newValue}
-  }
+  var file: [Google_Protobuf_FileDescriptorProto] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// Describes a complete .proto file.
@@ -83,102 +78,85 @@ struct Google_Protobuf_FileDescriptorProto {
 
   /// file name, relative to root of source tree
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
   /// e.g. "foo", "foo.bar", etc.
   var package: String {
-    get {return _storage._package ?? String()}
-    set {_uniqueStorage()._package = newValue}
+    get {return _package ?? String()}
+    set {_package = newValue}
   }
   /// Returns true if `package` has been explicitly set.
-  var hasPackage: Bool {return _storage._package != nil}
+  var hasPackage: Bool {return self._package != nil}
   /// Clears the value of `package`. Subsequent reads from it will return its default value.
-  mutating func clearPackage() {_uniqueStorage()._package = nil}
+  mutating func clearPackage() {self._package = nil}
 
   /// Names of files imported by this file.
-  var dependency: [String] {
-    get {return _storage._dependency}
-    set {_uniqueStorage()._dependency = newValue}
-  }
+  var dependency: [String] = []
 
   /// Indexes of the public imported files in the dependency list above.
-  var publicDependency: [Int32] {
-    get {return _storage._publicDependency}
-    set {_uniqueStorage()._publicDependency = newValue}
-  }
+  var publicDependency: [Int32] = []
 
   /// Indexes of the weak imported files in the dependency list.
   /// For Google-internal migration only. Do not use.
-  var weakDependency: [Int32] {
-    get {return _storage._weakDependency}
-    set {_uniqueStorage()._weakDependency = newValue}
-  }
+  var weakDependency: [Int32] = []
 
   /// All top-level definitions in this file.
-  var messageType: [Google_Protobuf_DescriptorProto] {
-    get {return _storage._messageType}
-    set {_uniqueStorage()._messageType = newValue}
-  }
+  var messageType: [Google_Protobuf_DescriptorProto] = []
 
-  var enumType: [Google_Protobuf_EnumDescriptorProto] {
-    get {return _storage._enumType}
-    set {_uniqueStorage()._enumType = newValue}
-  }
+  var enumType: [Google_Protobuf_EnumDescriptorProto] = []
 
-  var service: [Google_Protobuf_ServiceDescriptorProto] {
-    get {return _storage._service}
-    set {_uniqueStorage()._service = newValue}
-  }
+  var service: [Google_Protobuf_ServiceDescriptorProto] = []
 
-  var `extension`: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._extension}
-    set {_uniqueStorage()._extension = newValue}
-  }
+  var `extension`: [Google_Protobuf_FieldDescriptorProto] = []
 
   var options: Google_Protobuf_FileOptions {
-    get {return _storage._options ?? Google_Protobuf_FileOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_FileOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
   /// This field contains optional information about the original source code.
   /// You may safely remove this entire field without harming runtime
   /// functionality of the descriptors -- the information is needed only by
   /// development tools.
   var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
-    get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
-    set {_uniqueStorage()._sourceCodeInfo = newValue}
+    get {return _sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
+    set {_sourceCodeInfo = newValue}
   }
   /// Returns true if `sourceCodeInfo` has been explicitly set.
-  var hasSourceCodeInfo: Bool {return _storage._sourceCodeInfo != nil}
+  var hasSourceCodeInfo: Bool {return self._sourceCodeInfo != nil}
   /// Clears the value of `sourceCodeInfo`. Subsequent reads from it will return its default value.
-  mutating func clearSourceCodeInfo() {_uniqueStorage()._sourceCodeInfo = nil}
+  mutating func clearSourceCodeInfo() {self._sourceCodeInfo = nil}
 
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
   var syntax: String {
-    get {return _storage._syntax ?? String()}
-    set {_uniqueStorage()._syntax = newValue}
+    get {return _syntax ?? String()}
+    set {_syntax = newValue}
   }
   /// Returns true if `syntax` has been explicitly set.
-  var hasSyntax: Bool {return _storage._syntax != nil}
+  var hasSyntax: Bool {return self._syntax != nil}
   /// Clears the value of `syntax`. Subsequent reads from it will return its default value.
-  mutating func clearSyntax() {_uniqueStorage()._syntax = nil}
+  mutating func clearSyntax() {self._syntax = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _package: String? = nil
+  fileprivate var _options: Google_Protobuf_FileOptions? = nil
+  fileprivate var _sourceCodeInfo: Google_Protobuf_SourceCodeInfo? = nil
+  fileprivate var _syntax: String? = nil
 }
 
 /// Describes a message type.
@@ -188,64 +166,40 @@ struct Google_Protobuf_DescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return _storage._name != nil}
+  var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {_uniqueStorage()._name = nil}
+  mutating func clearName() {self._name = nil}
 
-  var field: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._field}
-    set {_uniqueStorage()._field = newValue}
-  }
+  var field: [Google_Protobuf_FieldDescriptorProto] = []
 
-  var `extension`: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._extension}
-    set {_uniqueStorage()._extension = newValue}
-  }
+  var `extension`: [Google_Protobuf_FieldDescriptorProto] = []
 
-  var nestedType: [Google_Protobuf_DescriptorProto] {
-    get {return _storage._nestedType}
-    set {_uniqueStorage()._nestedType = newValue}
-  }
+  var nestedType: [Google_Protobuf_DescriptorProto] = []
 
-  var enumType: [Google_Protobuf_EnumDescriptorProto] {
-    get {return _storage._enumType}
-    set {_uniqueStorage()._enumType = newValue}
-  }
+  var enumType: [Google_Protobuf_EnumDescriptorProto] = []
 
-  var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
-    get {return _storage._extensionRange}
-    set {_uniqueStorage()._extensionRange = newValue}
-  }
+  var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] = []
 
-  var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
-    get {return _storage._oneofDecl}
-    set {_uniqueStorage()._oneofDecl = newValue}
-  }
+  var oneofDecl: [Google_Protobuf_OneofDescriptorProto] = []
 
   var options: Google_Protobuf_MessageOptions {
-    get {return _storage._options ?? Google_Protobuf_MessageOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_MessageOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return _storage._options != nil}
+  var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {_uniqueStorage()._options = nil}
+  mutating func clearOptions() {self._options = nil}
 
-  var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
-    get {return _storage._reservedRange}
-    set {_uniqueStorage()._reservedRange = newValue}
-  }
+  var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] = []
 
   /// Reserved field names, which may not be used by fields in the same message.
   /// A given name may only be reserved once.
-  var reservedName: [String] {
-    get {return _storage._reservedName}
-    set {_uniqueStorage()._reservedName = newValue}
-  }
+  var reservedName: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -330,7 +284,8 @@ struct Google_Protobuf_DescriptorProto {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_MessageOptions? = nil
 }
 
 struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobuf.ExtensibleMessage {
@@ -2058,63 +2013,29 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message, SwiftProtobu
     1: .same(proto: "file"),
   ]
 
-  fileprivate class _StorageClass {
-    var _file: [Google_Protobuf_FileDescriptorProto] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _file = source._file
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._file) {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.file) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._file)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.file)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._file.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._file, fieldNumber: 1)
-      }
+    if !self.file.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_FileDescriptorSet, rhs: Google_Protobuf_FileDescriptorSet) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._file != rhs_storage._file {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.file != rhs.file {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2137,144 +2058,88 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message, SwiftProto
     12: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _package: String? = nil
-    var _dependency: [String] = []
-    var _publicDependency: [Int32] = []
-    var _weakDependency: [Int32] = []
-    var _messageType: [Google_Protobuf_DescriptorProto] = []
-    var _enumType: [Google_Protobuf_EnumDescriptorProto] = []
-    var _service: [Google_Protobuf_ServiceDescriptorProto] = []
-    var _extension: [Google_Protobuf_FieldDescriptorProto] = []
-    var _options: Google_Protobuf_FileOptions? = nil
-    var _sourceCodeInfo: Google_Protobuf_SourceCodeInfo? = nil
-    var _syntax: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _package = source._package
-      _dependency = source._dependency
-      _publicDependency = source._publicDependency
-      _weakDependency = source._weakDependency
-      _messageType = source._messageType
-      _enumType = source._enumType
-      _service = source._service
-      _extension = source._extension
-      _options = source._options
-      _sourceCodeInfo = source._sourceCodeInfo
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._messageType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._enumType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._service) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extension) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.messageType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.enumType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.service) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.`extension`) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._package)
-        case 3: try decoder.decodeRepeatedStringField(value: &_storage._dependency)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._messageType)
-        case 5: try decoder.decodeRepeatedMessageField(value: &_storage._enumType)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._service)
-        case 7: try decoder.decodeRepeatedMessageField(value: &_storage._extension)
-        case 8: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 9: try decoder.decodeSingularMessageField(value: &_storage._sourceCodeInfo)
-        case 10: try decoder.decodeRepeatedInt32Field(value: &_storage._publicDependency)
-        case 11: try decoder.decodeRepeatedInt32Field(value: &_storage._weakDependency)
-        case 12: try decoder.decodeSingularStringField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._package)
+      case 3: try decoder.decodeRepeatedStringField(value: &self.dependency)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.messageType)
+      case 5: try decoder.decodeRepeatedMessageField(value: &self.enumType)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.service)
+      case 7: try decoder.decodeRepeatedMessageField(value: &self.`extension`)
+      case 8: try decoder.decodeSingularMessageField(value: &self._options)
+      case 9: try decoder.decodeSingularMessageField(value: &self._sourceCodeInfo)
+      case 10: try decoder.decodeRepeatedInt32Field(value: &self.publicDependency)
+      case 11: try decoder.decodeRepeatedInt32Field(value: &self.weakDependency)
+      case 12: try decoder.decodeSingularStringField(value: &self._syntax)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._package {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if !_storage._dependency.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._dependency, fieldNumber: 3)
-      }
-      if !_storage._messageType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._messageType, fieldNumber: 4)
-      }
-      if !_storage._enumType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumType, fieldNumber: 5)
-      }
-      if !_storage._service.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._service, fieldNumber: 6)
-      }
-      if !_storage._extension.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extension, fieldNumber: 7)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._sourceCodeInfo {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }
-      if !_storage._publicDependency.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._publicDependency, fieldNumber: 10)
-      }
-      if !_storage._weakDependency.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._weakDependency, fieldNumber: 11)
-      }
-      if let v = _storage._syntax {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 12)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._package {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if !self.dependency.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.dependency, fieldNumber: 3)
+    }
+    if !self.messageType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.messageType, fieldNumber: 4)
+    }
+    if !self.enumType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumType, fieldNumber: 5)
+    }
+    if !self.service.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.service, fieldNumber: 6)
+    }
+    if !self.`extension`.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.`extension`, fieldNumber: 7)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }
+    if let v = self._sourceCodeInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }
+    if !self.publicDependency.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.publicDependency, fieldNumber: 10)
+    }
+    if !self.weakDependency.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.weakDependency, fieldNumber: 11)
+    }
+    if let v = self._syntax {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 12)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_FileDescriptorProto, rhs: Google_Protobuf_FileDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._package != rhs_storage._package {return false}
-        if _storage._dependency != rhs_storage._dependency {return false}
-        if _storage._publicDependency != rhs_storage._publicDependency {return false}
-        if _storage._weakDependency != rhs_storage._weakDependency {return false}
-        if _storage._messageType != rhs_storage._messageType {return false}
-        if _storage._enumType != rhs_storage._enumType {return false}
-        if _storage._service != rhs_storage._service {return false}
-        if _storage._extension != rhs_storage._extension {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceCodeInfo != rhs_storage._sourceCodeInfo {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._package != rhs._package {return false}
+    if lhs.dependency != rhs.dependency {return false}
+    if lhs.publicDependency != rhs.publicDependency {return false}
+    if lhs.weakDependency != rhs.weakDependency {return false}
+    if lhs.messageType != rhs.messageType {return false}
+    if lhs.enumType != rhs.enumType {return false}
+    if lhs.service != rhs.service {return false}
+    if lhs.`extension` != rhs.`extension` {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs._sourceCodeInfo != rhs._sourceCodeInfo {return false}
+    if lhs._syntax != rhs._syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2295,132 +2160,80 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobuf.Message, SwiftProtobuf.
     10: .standard(proto: "reserved_name"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _field: [Google_Protobuf_FieldDescriptorProto] = []
-    var _extension: [Google_Protobuf_FieldDescriptorProto] = []
-    var _nestedType: [Google_Protobuf_DescriptorProto] = []
-    var _enumType: [Google_Protobuf_EnumDescriptorProto] = []
-    var _extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] = []
-    var _oneofDecl: [Google_Protobuf_OneofDescriptorProto] = []
-    var _options: Google_Protobuf_MessageOptions? = nil
-    var _reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] = []
-    var _reservedName: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _field = source._field
-      _extension = source._extension
-      _nestedType = source._nestedType
-      _enumType = source._enumType
-      _extensionRange = source._extensionRange
-      _oneofDecl = source._oneofDecl
-      _options = source._options
-      _reservedRange = source._reservedRange
-      _reservedName = source._reservedName
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._field) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extension) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._nestedType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._enumType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extensionRange) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._oneofDecl) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.field) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.`extension`) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.nestedType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.enumType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.extensionRange) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.oneofDecl) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._field)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._nestedType)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._enumType)
-        case 5: try decoder.decodeRepeatedMessageField(value: &_storage._extensionRange)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._extension)
-        case 7: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 8: try decoder.decodeRepeatedMessageField(value: &_storage._oneofDecl)
-        case 9: try decoder.decodeRepeatedMessageField(value: &_storage._reservedRange)
-        case 10: try decoder.decodeRepeatedStringField(value: &_storage._reservedName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.field)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.nestedType)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.enumType)
+      case 5: try decoder.decodeRepeatedMessageField(value: &self.extensionRange)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.`extension`)
+      case 7: try decoder.decodeSingularMessageField(value: &self._options)
+      case 8: try decoder.decodeRepeatedMessageField(value: &self.oneofDecl)
+      case 9: try decoder.decodeRepeatedMessageField(value: &self.reservedRange)
+      case 10: try decoder.decodeRepeatedStringField(value: &self.reservedName)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._field.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._field, fieldNumber: 2)
-      }
-      if !_storage._nestedType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._nestedType, fieldNumber: 3)
-      }
-      if !_storage._enumType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumType, fieldNumber: 4)
-      }
-      if !_storage._extensionRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extensionRange, fieldNumber: 5)
-      }
-      if !_storage._extension.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extension, fieldNumber: 6)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }
-      if !_storage._oneofDecl.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._oneofDecl, fieldNumber: 8)
-      }
-      if !_storage._reservedRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._reservedRange, fieldNumber: 9)
-      }
-      if !_storage._reservedName.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._reservedName, fieldNumber: 10)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.field.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.field, fieldNumber: 2)
+    }
+    if !self.nestedType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.nestedType, fieldNumber: 3)
+    }
+    if !self.enumType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumType, fieldNumber: 4)
+    }
+    if !self.extensionRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.extensionRange, fieldNumber: 5)
+    }
+    if !self.`extension`.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.`extension`, fieldNumber: 6)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }
+    if !self.oneofDecl.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.oneofDecl, fieldNumber: 8)
+    }
+    if !self.reservedRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.reservedRange, fieldNumber: 9)
+    }
+    if !self.reservedName.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.reservedName, fieldNumber: 10)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_DescriptorProto, rhs: Google_Protobuf_DescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._field != rhs_storage._field {return false}
-        if _storage._extension != rhs_storage._extension {return false}
-        if _storage._nestedType != rhs_storage._nestedType {return false}
-        if _storage._enumType != rhs_storage._enumType {return false}
-        if _storage._extensionRange != rhs_storage._extensionRange {return false}
-        if _storage._oneofDecl != rhs_storage._oneofDecl {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._reservedRange != rhs_storage._reservedRange {return false}
-        if _storage._reservedName != rhs_storage._reservedName {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.field != rhs.field {return false}
+    if lhs.`extension` != rhs.`extension` {return false}
+    if lhs.nestedType != rhs.nestedType {return false}
+    if lhs.enumType != rhs.enumType {return false}
+    if lhs.extensionRange != rhs.extensionRange {return false}
+    if lhs.oneofDecl != rhs.oneofDecl {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs.reservedRange != rhs.reservedRange {return false}
+    if lhs.reservedName != rhs.reservedName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/google/protobuf/map_proto2_unittest.pb.swift
@@ -220,19 +220,19 @@ struct ProtobufUnittest_TestSubmessageMaps {
   // methods supported on all messages.
 
   var m: ProtobufUnittest_TestMaps {
-    get {return _storage._m ?? ProtobufUnittest_TestMaps()}
-    set {_uniqueStorage()._m = newValue}
+    get {return _m ?? ProtobufUnittest_TestMaps()}
+    set {_m = newValue}
   }
   /// Returns true if `m` has been explicitly set.
-  var hasM: Bool {return _storage._m != nil}
+  var hasM: Bool {return self._m != nil}
   /// Clears the value of `m`. Subsequent reads from it will return its default value.
-  mutating func clearM() {_uniqueStorage()._m = nil}
+  mutating func clearM() {self._m = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _m: ProtobufUnittest_TestMaps? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -485,56 +485,24 @@ extension ProtobufUnittest_TestSubmessageMaps: SwiftProtobuf.Message, SwiftProto
     1: .same(proto: "m"),
   ]
 
-  fileprivate class _StorageClass {
-    var _m: ProtobufUnittest_TestMaps? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _m = source._m
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._m)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._m)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._m {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._m {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestSubmessageMaps, rhs: ProtobufUnittest_TestSubmessageMaps) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._m != rhs_storage._m {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._m != rhs._m {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -371,10 +371,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> {
-    get {return _storage._type}
-    set {_uniqueStorage()._type = newValue}
-  }
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -404,8 +401,6 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -437,16 +432,11 @@ struct ProtobufUnittest_TestRecursiveMapMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> {
-    get {return _storage._a}
-    set {_uniqueStorage()._a = newValue}
-  }
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -996,56 +986,24 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Messag
     1: .same(proto: "type"),
   ]
 
-  fileprivate class _StorageClass {
-    var _type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _type = source._type
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &_storage._type)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &self.type)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._type.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: _storage._type, fieldNumber: 1)
-      }
+    if !self.type.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: self.type, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_MessageContainingEnumCalledType, rhs: ProtobufUnittest_MessageContainingEnumCalledType) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._type != rhs_storage._type {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.type != rhs.type {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1092,56 +1050,24 @@ extension ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message, Swift
     1: .same(proto: "a"),
   ]
 
-  fileprivate class _StorageClass {
-    var _a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _a = source._a
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &_storage._a)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &self.a)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._a.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: _storage._a, fieldNumber: 1)
-      }
+    if !self.a.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: self.a, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRecursiveMapMessage, rhs: ProtobufUnittest_TestRecursiveMapMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._a != rhs_storage._a {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.a != rhs.a {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -207,19 +207,19 @@ struct ProtobufUnittest_TestMapSubmessage {
   // methods supported on all messages.
 
   var testMap: ProtobufUnittest_TestMap {
-    get {return _storage._testMap ?? ProtobufUnittest_TestMap()}
-    set {_uniqueStorage()._testMap = newValue}
+    get {return _testMap ?? ProtobufUnittest_TestMap()}
+    set {_testMap = newValue}
   }
   /// Returns true if `testMap` has been explicitly set.
-  var hasTestMap: Bool {return _storage._testMap != nil}
+  var hasTestMap: Bool {return self._testMap != nil}
   /// Clears the value of `testMap`. Subsequent reads from it will return its default value.
-  mutating func clearTestMap() {_uniqueStorage()._testMap = nil}
+  mutating func clearTestMap() {self._testMap = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _testMap: ProtobufUnittest_TestMap? = nil
 }
 
 struct ProtobufUnittest_TestMessageMap {
@@ -371,7 +371,10 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> {
+    get {return _storage._type}
+    set {_uniqueStorage()._type = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -401,6 +404,8 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   }
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -432,11 +437,16 @@ struct ProtobufUnittest_TestRecursiveMapMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> {
+    get {return _storage._a}
+    set {_uniqueStorage()._a = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -662,56 +672,24 @@ extension ProtobufUnittest_TestMapSubmessage: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "test_map"),
   ]
 
-  fileprivate class _StorageClass {
-    var _testMap: ProtobufUnittest_TestMap? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _testMap = source._testMap
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._testMap)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._testMap)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._testMap {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._testMap {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMapSubmessage, rhs: ProtobufUnittest_TestMapSubmessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._testMap != rhs_storage._testMap {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._testMap != rhs._testMap {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1018,24 +996,56 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Messag
     1: .same(proto: "type"),
   ]
 
+  fileprivate class _StorageClass {
+    var _type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _type = source._type
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &self.type)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &_storage._type)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.type.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: self.type, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._type.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: _storage._type, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_MessageContainingEnumCalledType, rhs: ProtobufUnittest_MessageContainingEnumCalledType) -> Bool {
-    if lhs.type != rhs.type {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._type != rhs_storage._type {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1082,24 +1092,56 @@ extension ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message, Swift
     1: .same(proto: "a"),
   ]
 
+  fileprivate class _StorageClass {
+    var _a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _a = source._a
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &self.a)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &_storage._a)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.a.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: self.a, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._a.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: _storage._a, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRecursiveMapMessage, rhs: ProtobufUnittest_TestRecursiveMapMessage) -> Bool {
-    if lhs.a != rhs.a {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._a != rhs_storage._a {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -104,11 +104,16 @@ struct Google_Protobuf_Struct {
   // methods supported on all messages.
 
   /// Unordered map of dynamically typed values.
-  var fields: Dictionary<String,Google_Protobuf_Value> = [:]
+  var fields: Dictionary<String,Google_Protobuf_Value> {
+    get {return _storage._fields}
+    set {_uniqueStorage()._fields = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `Value` represents a dynamically typed value which can be either
@@ -214,11 +219,16 @@ struct Google_Protobuf_ListValue {
   // methods supported on all messages.
 
   /// Repeated field of dynamically typed values.
-  var values: [Google_Protobuf_Value] = []
+  var values: [Google_Protobuf_Value] {
+    get {return _storage._values}
+    set {_uniqueStorage()._values = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -237,24 +247,56 @@ extension Google_Protobuf_Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     1: .same(proto: "fields"),
   ]
 
+  fileprivate class _StorageClass {
+    var _fields: Dictionary<String,Google_Protobuf_Value> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _fields = source._fields
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &_storage._fields)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.fields.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._fields.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: _storage._fields, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Struct, rhs: Google_Protobuf_Struct) -> Bool {
-    if lhs.fields != rhs.fields {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._fields != rhs_storage._fields {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -379,24 +421,56 @@ extension Google_Protobuf_ListValue: SwiftProtobuf.Message, SwiftProtobuf._Messa
     1: .same(proto: "values"),
   ]
 
+  fileprivate class _StorageClass {
+    var _values: [Google_Protobuf_Value] = []
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _values = source._values
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeRepeatedMessageField(value: &self.values)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._values)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.values.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._values.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._values, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_ListValue, rhs: Google_Protobuf_ListValue) -> Bool {
-    if lhs.values != rhs.values {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._values != rhs_storage._values {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -104,16 +104,11 @@ struct Google_Protobuf_Struct {
   // methods supported on all messages.
 
   /// Unordered map of dynamically typed values.
-  var fields: Dictionary<String,Google_Protobuf_Value> {
-    get {return _storage._fields}
-    set {_uniqueStorage()._fields = newValue}
-  }
+  var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `Value` represents a dynamically typed value which can be either
@@ -128,63 +123,60 @@ struct Google_Protobuf_Value {
   // methods supported on all messages.
 
   /// The kind of value.
-  var kind: OneOf_Kind? {
-    get {return _storage._kind}
-    set {_uniqueStorage()._kind = newValue}
-  }
+  var kind: Google_Protobuf_Value.OneOf_Kind? = nil
 
   /// Represents a null value.
   var nullValue: Google_Protobuf_NullValue {
     get {
-      if case .nullValue(let v)? = _storage._kind {return v}
+      if case .nullValue(let v)? = kind {return v}
       return .nullValue
     }
-    set {_uniqueStorage()._kind = .nullValue(newValue)}
+    set {kind = .nullValue(newValue)}
   }
 
   /// Represents a double value.
   var numberValue: Double {
     get {
-      if case .numberValue(let v)? = _storage._kind {return v}
+      if case .numberValue(let v)? = kind {return v}
       return 0
     }
-    set {_uniqueStorage()._kind = .numberValue(newValue)}
+    set {kind = .numberValue(newValue)}
   }
 
   /// Represents a string value.
   var stringValue: String {
     get {
-      if case .stringValue(let v)? = _storage._kind {return v}
+      if case .stringValue(let v)? = kind {return v}
       return String()
     }
-    set {_uniqueStorage()._kind = .stringValue(newValue)}
+    set {kind = .stringValue(newValue)}
   }
 
   /// Represents a boolean value.
   var boolValue: Bool {
     get {
-      if case .boolValue(let v)? = _storage._kind {return v}
+      if case .boolValue(let v)? = kind {return v}
       return false
     }
-    set {_uniqueStorage()._kind = .boolValue(newValue)}
+    set {kind = .boolValue(newValue)}
   }
 
   /// Represents a structured value.
   var structValue: Google_Protobuf_Struct {
     get {
-      if case .structValue(let v)? = _storage._kind {return v}
+      if case .structValue(let v)? = kind {return v}
       return Google_Protobuf_Struct()
     }
-    set {_uniqueStorage()._kind = .structValue(newValue)}
+    set {kind = .structValue(newValue)}
   }
 
   /// Represents a repeated `Value`.
   var listValue: Google_Protobuf_ListValue {
     get {
-      if case .listValue(let v)? = _storage._kind {return v}
+      if case .listValue(let v)? = kind {return v}
       return Google_Protobuf_ListValue()
     }
-    set {_uniqueStorage()._kind = .listValue(newValue)}
+    set {kind = .listValue(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -206,8 +198,6 @@ struct Google_Protobuf_Value {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `ListValue` is a wrapper around a repeated field of values.
@@ -219,16 +209,11 @@ struct Google_Protobuf_ListValue {
   // methods supported on all messages.
 
   /// Repeated field of dynamically typed values.
-  var values: [Google_Protobuf_Value] {
-    get {return _storage._values}
-    set {_uniqueStorage()._values = newValue}
-  }
+  var values: [Google_Protobuf_Value] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -247,56 +232,24 @@ extension Google_Protobuf_Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     1: .same(proto: "fields"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fields: Dictionary<String,Google_Protobuf_Value> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fields = source._fields
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &_storage._fields)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._fields.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: _storage._fields, fieldNumber: 1)
-      }
+    if !self.fields.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Struct, rhs: Google_Protobuf_Struct) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fields != rhs_storage._fields {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.fields != rhs.fields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -313,103 +266,71 @@ extension Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     6: .standard(proto: "list_value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _kind: Google_Protobuf_Value.OneOf_Kind?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _kind = source._kind
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Google_Protobuf_NullValue?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._kind = .nullValue(v)}
-        case 2:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Double?
-          try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._kind = .numberValue(v)}
-        case 3:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._kind = .stringValue(v)}
-        case 4:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._kind = .boolValue(v)}
-        case 5:
-          var v: Google_Protobuf_Struct?
-          if let current = _storage._kind {
-            try decoder.handleConflictingOneOf()
-            if case .structValue(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._kind = .structValue(v)}
-        case 6:
-          var v: Google_Protobuf_ListValue?
-          if let current = _storage._kind {
-            try decoder.handleConflictingOneOf()
-            if case .listValue(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._kind = .listValue(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Google_Protobuf_NullValue?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.kind = .nullValue(v)}
+      case 2:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Double?
+        try decoder.decodeSingularDoubleField(value: &v)
+        if let v = v {self.kind = .numberValue(v)}
+      case 3:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.kind = .stringValue(v)}
+      case 4:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {self.kind = .boolValue(v)}
+      case 5:
+        var v: Google_Protobuf_Struct?
+        if let current = self.kind {
+          try decoder.handleConflictingOneOf()
+          if case .structValue(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.kind = .structValue(v)}
+      case 6:
+        var v: Google_Protobuf_ListValue?
+        if let current = self.kind {
+          try decoder.handleConflictingOneOf()
+          if case .listValue(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.kind = .listValue(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._kind {
-      case .nullValue(let v)?:
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-      case .numberValue(let v)?:
-        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-      case .stringValue(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case .boolValue(let v)?:
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-      case .structValue(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      case .listValue(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      case nil: break
-      }
+    switch self.kind {
+    case .nullValue(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+    case .numberValue(let v)?:
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+    case .stringValue(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case .boolValue(let v)?:
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+    case .structValue(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    case .listValue(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Value, rhs: Google_Protobuf_Value) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._kind != rhs_storage._kind {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.kind != rhs.kind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -421,56 +342,24 @@ extension Google_Protobuf_ListValue: SwiftProtobuf.Message, SwiftProtobuf._Messa
     1: .same(proto: "values"),
   ]
 
-  fileprivate class _StorageClass {
-    var _values: [Google_Protobuf_Value] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _values = source._values
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._values)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.values)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._values.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._values, fieldNumber: 1)
-      }
+    if !self.values.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_ListValue, rhs: Google_Protobuf_ListValue) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._values != rhs_storage._values {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.values != rhs.values {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto2.pb.swift
@@ -1103,54 +1103,51 @@ struct ProtobufTestMessages_Proto2_UnknownToTestAllTypes {
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2 {
-    get {return _storage._nestedMessage ?? ProtobufTestMessages_Proto2_ForeignMessageProto2()}
-    set {_uniqueStorage()._nestedMessage = newValue}
+    get {return _nestedMessage ?? ProtobufTestMessages_Proto2_ForeignMessageProto2()}
+    set {_nestedMessage = newValue}
   }
   /// Returns true if `nestedMessage` has been explicitly set.
-  var hasNestedMessage: Bool {return _storage._nestedMessage != nil}
+  var hasNestedMessage: Bool {return self._nestedMessage != nil}
   /// Clears the value of `nestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearNestedMessage() {_uniqueStorage()._nestedMessage = nil}
+  mutating func clearNestedMessage() {self._nestedMessage = nil}
 
   var optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
   var optionalBool: Bool {
-    get {return _storage._optionalBool ?? false}
-    set {_uniqueStorage()._optionalBool = newValue}
+    get {return _optionalBool ?? false}
+    set {_optionalBool = newValue}
   }
   /// Returns true if `optionalBool` has been explicitly set.
-  var hasOptionalBool: Bool {return _storage._optionalBool != nil}
+  var hasOptionalBool: Bool {return self._optionalBool != nil}
   /// Clears the value of `optionalBool`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBool() {_uniqueStorage()._optionalBool = nil}
+  mutating func clearOptionalBool() {self._optionalBool = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1177,7 +1174,11 @@ struct ProtobufTestMessages_Proto2_UnknownToTestAllTypes {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2? = nil
+  fileprivate var _optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup? = nil
+  fileprivate var _optionalBool: Bool? = nil
 }
 
 // MARK: - Extension support defined in test_messages_proto2.proto.
@@ -2544,91 +2545,49 @@ extension ProtobufTestMessages_Proto2_UnknownToTestAllTypes: SwiftProtobuf.Messa
     1011: .standard(proto: "repeated_int32"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _optionalString: String? = nil
-    var _nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2? = nil
-    var _optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup? = nil
-    var _optionalBool: Bool? = nil
-    var _repeatedInt32: [Int32] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _optionalString = source._optionalString
-      _nestedMessage = source._nestedMessage
-      _optionalGroup = source._optionalGroup
-      _optionalBool = source._optionalBool
-      _repeatedInt32 = source._repeatedInt32
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1001: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 1002: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 1003: try decoder.decodeSingularMessageField(value: &_storage._nestedMessage)
-        case 1004: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 1006: try decoder.decodeSingularBoolField(value: &_storage._optionalBool)
-        case 1011: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1001: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 1002: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 1003: try decoder.decodeSingularMessageField(value: &self._nestedMessage)
+      case 1004: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 1006: try decoder.decodeSingularBoolField(value: &self._optionalBool)
+      case 1011: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1001)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1002)
-      }
-      if let v = _storage._nestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1003)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 1004)
-      }
-      if let v = _storage._optionalBool {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 1006)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 1011)
-      }
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1001)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1002)
+    }
+    if let v = self._nestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1003)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 1004)
+    }
+    if let v = self._optionalBool {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 1006)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 1011)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufTestMessages_Proto2_UnknownToTestAllTypes, rhs: ProtobufTestMessages_Proto2_UnknownToTestAllTypes) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._nestedMessage != rhs_storage._nestedMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._optionalBool != rhs_storage._optionalBool {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._nestedMessage != rhs._nestedMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs._optionalBool != rhs._optionalBool {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -100,50 +100,35 @@ struct Google_Protobuf_Type {
   // methods supported on all messages.
 
   /// The fully qualified message name.
-  var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  var name: String = String()
 
   /// The list of fields.
-  var fields: [Google_Protobuf_Field] {
-    get {return _storage._fields}
-    set {_uniqueStorage()._fields = newValue}
-  }
+  var fields: [Google_Protobuf_Field] = []
 
   /// The list of types appearing in `oneof` definitions in this type.
-  var oneofs: [String] {
-    get {return _storage._oneofs}
-    set {_uniqueStorage()._oneofs = newValue}
-  }
+  var oneofs: [String] = []
 
   /// The protocol buffer options.
-  var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  var options: [Google_Protobuf_Option] = []
 
   /// The source context.
   var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// The source syntax.
-  var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  var syntax: Google_Protobuf_Syntax = .proto2
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// A single field of a message type.
@@ -396,44 +381,32 @@ struct Google_Protobuf_Enum {
   // methods supported on all messages.
 
   /// Enum type name.
-  var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  var name: String = String()
 
   /// Enum value definitions.
-  var enumvalue: [Google_Protobuf_EnumValue] {
-    get {return _storage._enumvalue}
-    set {_uniqueStorage()._enumvalue = newValue}
-  }
+  var enumvalue: [Google_Protobuf_EnumValue] = []
 
   /// Protocol buffer options.
-  var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  var options: [Google_Protobuf_Option] = []
 
   /// The source context.
   var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// The source syntax.
-  var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  var syntax: Google_Protobuf_Syntax = .proto2
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// Enum value definition.
@@ -467,29 +440,26 @@ struct Google_Protobuf_Option {
   /// descriptor.proto), this is the short name. For example, `"map_entry"`.
   /// For custom options, it should be the fully-qualified name. For example,
   /// `"google.api.http"`.
-  var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  var name: String = String()
 
   /// The option's value packed in an Any message. If the value is a primitive,
   /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
   /// should be used. If the value is an enum, it should be stored as an int32
   /// value using the google.protobuf.Int32Value type.
   var value: Google_Protobuf_Any {
-    get {return _storage._value ?? Google_Protobuf_Any()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? Google_Protobuf_Any()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  var hasValue: Bool {return _storage._value != nil}
+  var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  mutating func clearValue() {_uniqueStorage()._value = nil}
+  mutating func clearValue() {self._value = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _value: Google_Protobuf_Any? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -514,91 +484,49 @@ extension Google_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     6: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _fields: [Google_Protobuf_Field] = []
-    var _oneofs: [String] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _fields = source._fields
-      _oneofs = source._oneofs
-      _options = source._options
-      _sourceContext = source._sourceContext
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._fields)
-        case 3: try decoder.decodeRepeatedStringField(value: &_storage._oneofs)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 5: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 6: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.fields)
+      case 3: try decoder.decodeRepeatedStringField(value: &self.oneofs)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 5: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 6: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._fields.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._fields, fieldNumber: 2)
-      }
-      if !_storage._oneofs.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._oneofs, fieldNumber: 3)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 4)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 6)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.fields.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.fields, fieldNumber: 2)
+    }
+    if !self.oneofs.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.oneofs, fieldNumber: 3)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 4)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Type, rhs: Google_Protobuf_Type) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._fields != rhs_storage._fields {return false}
-        if _storage._oneofs != rhs_storage._oneofs {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.fields != rhs.fields {return false}
+    if lhs.oneofs != rhs.oneofs {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -730,84 +658,44 @@ extension Google_Protobuf_Enum: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     5: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _enumvalue: [Google_Protobuf_EnumValue] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _enumvalue = source._enumvalue
-      _options = source._options
-      _sourceContext = source._sourceContext
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._enumvalue)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.enumvalue)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 4: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 5: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._enumvalue.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumvalue, fieldNumber: 2)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 3)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 5)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.enumvalue.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumvalue, fieldNumber: 2)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 3)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 5)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Enum, rhs: Google_Protobuf_Enum) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._enumvalue != rhs_storage._enumvalue {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.enumvalue != rhs.enumvalue {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -861,63 +749,29 @@ extension Google_Protobuf_Option: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     2: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _value: Google_Protobuf_Any? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_Option, rhs: Google_Protobuf_Option) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1410,22 +1410,22 @@ struct ProtobufUnittest_TestGroup {
   // methods supported on all messages.
 
   var optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestGroup.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestGroup.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
   var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
-    get {return _storage._optionalForeignEnum ?? .foreignFoo}
-    set {_uniqueStorage()._optionalForeignEnum = newValue}
+    get {return _optionalForeignEnum ?? .foreignFoo}
+    set {_optionalForeignEnum = newValue}
   }
   /// Returns true if `optionalForeignEnum` has been explicitly set.
-  var hasOptionalForeignEnum: Bool {return _storage._optionalForeignEnum != nil}
+  var hasOptionalForeignEnum: Bool {return self._optionalForeignEnum != nil}
   /// Clears the value of `optionalForeignEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalForeignEnum() {_uniqueStorage()._optionalForeignEnum = nil}
+  mutating func clearOptionalForeignEnum() {self._optionalForeignEnum = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1452,7 +1452,8 @@ struct ProtobufUnittest_TestGroup {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup? = nil
+  fileprivate var _optionalForeignEnum: ProtobufUnittest_ForeignEnum? = nil
 }
 
 struct ProtobufUnittest_TestGroupExtension: SwiftProtobuf.ExtensibleMessage {
@@ -1820,33 +1821,31 @@ struct ProtobufUnittest_TestRequiredForeign {
   // methods supported on all messages.
 
   var optionalMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestRequired()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestRequired] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestRequired] = []
 
   var dummy: Int32 {
-    get {return _storage._dummy ?? 0}
-    set {_uniqueStorage()._dummy = newValue}
+    get {return _dummy ?? 0}
+    set {_dummy = newValue}
   }
   /// Returns true if `dummy` has been explicitly set.
-  var hasDummy: Bool {return _storage._dummy != nil}
+  var hasDummy: Bool {return self._dummy != nil}
   /// Clears the value of `dummy`. Subsequent reads from it will return its default value.
-  mutating func clearDummy() {_uniqueStorage()._dummy = nil}
+  mutating func clearDummy() {self._dummy = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestRequired? = nil
+  fileprivate var _dummy: Int32? = nil
 }
 
 struct ProtobufUnittest_TestRequiredMessage {
@@ -1855,33 +1854,31 @@ struct ProtobufUnittest_TestRequiredMessage {
   // methods supported on all messages.
 
   var optionalMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestRequired()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestRequired] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestRequired] = []
 
   var requiredMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._requiredMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._requiredMessage = newValue}
+    get {return _requiredMessage ?? ProtobufUnittest_TestRequired()}
+    set {_requiredMessage = newValue}
   }
   /// Returns true if `requiredMessage` has been explicitly set.
-  var hasRequiredMessage: Bool {return _storage._requiredMessage != nil}
+  var hasRequiredMessage: Bool {return self._requiredMessage != nil}
   /// Clears the value of `requiredMessage`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredMessage() {_uniqueStorage()._requiredMessage = nil}
+  mutating func clearRequiredMessage() {self._requiredMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestRequired? = nil
+  fileprivate var _requiredMessage: ProtobufUnittest_TestRequired? = nil
 }
 
 /// Test that we can use NestedMessage from outside TestAllTypes.
@@ -1891,19 +1888,19 @@ struct ProtobufUnittest_TestForeignNested {
   // methods supported on all messages.
 
   var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return _storage._foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {_uniqueStorage()._foreignNested = newValue}
+    get {return _foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {_foreignNested = newValue}
   }
   /// Returns true if `foreignNested` has been explicitly set.
-  var hasForeignNested: Bool {return _storage._foreignNested != nil}
+  var hasForeignNested: Bool {return self._foreignNested != nil}
   /// Clears the value of `foreignNested`. Subsequent reads from it will return its default value.
-  mutating func clearForeignNested() {_uniqueStorage()._foreignNested = nil}
+  mutating func clearForeignNested() {self._foreignNested = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
 }
 
 /// TestEmptyMessage is used to test unknown field support.
@@ -2126,13 +2123,13 @@ struct ProtobufUnittest_TestIsInitialized {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestIsInitialized.SubMessage {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestIsInitialized.SubMessage()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestIsInitialized.SubMessage()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2142,13 +2139,13 @@ struct ProtobufUnittest_TestIsInitialized {
     // methods supported on all messages.
 
     var subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup {
-      get {return _storage._subGroup ?? ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup()}
-      set {_uniqueStorage()._subGroup = newValue}
+      get {return _subGroup ?? ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup()}
+      set {_subGroup = newValue}
     }
     /// Returns true if `subGroup` has been explicitly set.
-    var hasSubGroup: Bool {return _storage._subGroup != nil}
+    var hasSubGroup: Bool {return self._subGroup != nil}
     /// Clears the value of `subGroup`. Subsequent reads from it will return its default value.
-    mutating func clearSubGroup() {_uniqueStorage()._subGroup = nil}
+    mutating func clearSubGroup() {self._subGroup = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2175,12 +2172,12 @@ struct ProtobufUnittest_TestIsInitialized {
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup? = nil
   }
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestIsInitialized.SubMessage? = nil
 }
 
 /// Test that groups have disjoint field numbers from their siblings and
@@ -2194,31 +2191,31 @@ struct ProtobufUnittest_TestDupFieldNumber {
 
   /// NO_PROTO1
   var a: Int32 {
-    get {return _storage._a ?? 0}
-    set {_uniqueStorage()._a = newValue}
+    get {return _a ?? 0}
+    set {_a = newValue}
   }
   /// Returns true if `a` has been explicitly set.
-  var hasA: Bool {return _storage._a != nil}
+  var hasA: Bool {return self._a != nil}
   /// Clears the value of `a`. Subsequent reads from it will return its default value.
-  mutating func clearA() {_uniqueStorage()._a = nil}
+  mutating func clearA() {self._a = nil}
 
   var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
-    get {return _storage._foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
-    set {_uniqueStorage()._foo = newValue}
+    get {return _foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
+    set {_foo = newValue}
   }
   /// Returns true if `foo` has been explicitly set.
-  var hasFoo: Bool {return _storage._foo != nil}
+  var hasFoo: Bool {return self._foo != nil}
   /// Clears the value of `foo`. Subsequent reads from it will return its default value.
-  mutating func clearFoo() {_uniqueStorage()._foo = nil}
+  mutating func clearFoo() {self._foo = nil}
 
   var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
-    get {return _storage._bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
-    set {_uniqueStorage()._bar = newValue}
+    get {return _bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
+    set {_bar = newValue}
   }
   /// Returns true if `bar` has been explicitly set.
-  var hasBar: Bool {return _storage._bar != nil}
+  var hasBar: Bool {return self._bar != nil}
   /// Clears the value of `bar`. Subsequent reads from it will return its default value.
-  mutating func clearBar() {_uniqueStorage()._bar = nil}
+  mutating func clearBar() {self._bar = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2266,7 +2263,9 @@ struct ProtobufUnittest_TestDupFieldNumber {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _a: Int32? = nil
+  fileprivate var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
+  fileprivate var _bar: ProtobufUnittest_TestDupFieldNumber.Bar? = nil
 }
 
 /// Additional messages for testing lazy fields.
@@ -2276,19 +2275,19 @@ struct ProtobufUnittest_TestEagerMessage {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 }
 
 struct ProtobufUnittest_TestLazyMessage {
@@ -2297,19 +2296,19 @@ struct ProtobufUnittest_TestLazyMessage {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 }
 
 /// Needed for a Python test.
@@ -2319,13 +2318,13 @@ struct ProtobufUnittest_TestNestedMessageHasBits {
   // methods supported on all messages.
 
   var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2345,7 +2344,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
 }
 
 /// Test message with CamelCase field names.  This violates Protocol Buffer
@@ -2356,94 +2355,81 @@ struct ProtobufUnittest_TestCamelCaseFieldNames {
   // methods supported on all messages.
 
   var primitiveField: Int32 {
-    get {return _storage._primitiveField ?? 0}
-    set {_uniqueStorage()._primitiveField = newValue}
+    get {return _primitiveField ?? 0}
+    set {_primitiveField = newValue}
   }
   /// Returns true if `primitiveField` has been explicitly set.
-  var hasPrimitiveField: Bool {return _storage._primitiveField != nil}
+  var hasPrimitiveField: Bool {return self._primitiveField != nil}
   /// Clears the value of `primitiveField`. Subsequent reads from it will return its default value.
-  mutating func clearPrimitiveField() {_uniqueStorage()._primitiveField = nil}
+  mutating func clearPrimitiveField() {self._primitiveField = nil}
 
   var stringField: String {
-    get {return _storage._stringField ?? String()}
-    set {_uniqueStorage()._stringField = newValue}
+    get {return _stringField ?? String()}
+    set {_stringField = newValue}
   }
   /// Returns true if `stringField` has been explicitly set.
-  var hasStringField: Bool {return _storage._stringField != nil}
+  var hasStringField: Bool {return self._stringField != nil}
   /// Clears the value of `stringField`. Subsequent reads from it will return its default value.
-  mutating func clearStringField() {_uniqueStorage()._stringField = nil}
+  mutating func clearStringField() {self._stringField = nil}
 
   var enumField: ProtobufUnittest_ForeignEnum {
-    get {return _storage._enumField ?? .foreignFoo}
-    set {_uniqueStorage()._enumField = newValue}
+    get {return _enumField ?? .foreignFoo}
+    set {_enumField = newValue}
   }
   /// Returns true if `enumField` has been explicitly set.
-  var hasEnumField: Bool {return _storage._enumField != nil}
+  var hasEnumField: Bool {return self._enumField != nil}
   /// Clears the value of `enumField`. Subsequent reads from it will return its default value.
-  mutating func clearEnumField() {_uniqueStorage()._enumField = nil}
+  mutating func clearEnumField() {self._enumField = nil}
 
   var messageField: ProtobufUnittest_ForeignMessage {
-    get {return _storage._messageField ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._messageField = newValue}
+    get {return _messageField ?? ProtobufUnittest_ForeignMessage()}
+    set {_messageField = newValue}
   }
   /// Returns true if `messageField` has been explicitly set.
-  var hasMessageField: Bool {return _storage._messageField != nil}
+  var hasMessageField: Bool {return self._messageField != nil}
   /// Clears the value of `messageField`. Subsequent reads from it will return its default value.
-  mutating func clearMessageField() {_uniqueStorage()._messageField = nil}
+  mutating func clearMessageField() {self._messageField = nil}
 
   var stringPieceField: String {
-    get {return _storage._stringPieceField ?? String()}
-    set {_uniqueStorage()._stringPieceField = newValue}
+    get {return _stringPieceField ?? String()}
+    set {_stringPieceField = newValue}
   }
   /// Returns true if `stringPieceField` has been explicitly set.
-  var hasStringPieceField: Bool {return _storage._stringPieceField != nil}
+  var hasStringPieceField: Bool {return self._stringPieceField != nil}
   /// Clears the value of `stringPieceField`. Subsequent reads from it will return its default value.
-  mutating func clearStringPieceField() {_uniqueStorage()._stringPieceField = nil}
+  mutating func clearStringPieceField() {self._stringPieceField = nil}
 
   var cordField: String {
-    get {return _storage._cordField ?? String()}
-    set {_uniqueStorage()._cordField = newValue}
+    get {return _cordField ?? String()}
+    set {_cordField = newValue}
   }
   /// Returns true if `cordField` has been explicitly set.
-  var hasCordField: Bool {return _storage._cordField != nil}
+  var hasCordField: Bool {return self._cordField != nil}
   /// Clears the value of `cordField`. Subsequent reads from it will return its default value.
-  mutating func clearCordField() {_uniqueStorage()._cordField = nil}
+  mutating func clearCordField() {self._cordField = nil}
 
-  var repeatedPrimitiveField: [Int32] {
-    get {return _storage._repeatedPrimitiveField}
-    set {_uniqueStorage()._repeatedPrimitiveField = newValue}
-  }
+  var repeatedPrimitiveField: [Int32] = []
 
-  var repeatedStringField: [String] {
-    get {return _storage._repeatedStringField}
-    set {_uniqueStorage()._repeatedStringField = newValue}
-  }
+  var repeatedStringField: [String] = []
 
-  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
-    get {return _storage._repeatedEnumField}
-    set {_uniqueStorage()._repeatedEnumField = newValue}
-  }
+  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] = []
 
-  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
-    get {return _storage._repeatedMessageField}
-    set {_uniqueStorage()._repeatedMessageField = newValue}
-  }
+  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] = []
 
-  var repeatedStringPieceField: [String] {
-    get {return _storage._repeatedStringPieceField}
-    set {_uniqueStorage()._repeatedStringPieceField = newValue}
-  }
+  var repeatedStringPieceField: [String] = []
 
-  var repeatedCordField: [String] {
-    get {return _storage._repeatedCordField}
-    set {_uniqueStorage()._repeatedCordField = newValue}
-  }
+  var repeatedCordField: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _primitiveField: Int32? = nil
+  fileprivate var _stringField: String? = nil
+  fileprivate var _enumField: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _messageField: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _stringPieceField: String? = nil
+  fileprivate var _cordField: String? = nil
 }
 
 /// We list fields out of order, to ensure that we're using field number and not
@@ -2454,40 +2440,40 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var myString: String {
-    get {return _storage._myString ?? String()}
-    set {_uniqueStorage()._myString = newValue}
+    get {return _myString ?? String()}
+    set {_myString = newValue}
   }
   /// Returns true if `myString` has been explicitly set.
-  var hasMyString: Bool {return _storage._myString != nil}
+  var hasMyString: Bool {return self._myString != nil}
   /// Clears the value of `myString`. Subsequent reads from it will return its default value.
-  mutating func clearMyString() {_uniqueStorage()._myString = nil}
+  mutating func clearMyString() {self._myString = nil}
 
   var myInt: Int64 {
-    get {return _storage._myInt ?? 0}
-    set {_uniqueStorage()._myInt = newValue}
+    get {return _myInt ?? 0}
+    set {_myInt = newValue}
   }
   /// Returns true if `myInt` has been explicitly set.
-  var hasMyInt: Bool {return _storage._myInt != nil}
+  var hasMyInt: Bool {return self._myInt != nil}
   /// Clears the value of `myInt`. Subsequent reads from it will return its default value.
-  mutating func clearMyInt() {_uniqueStorage()._myInt = nil}
+  mutating func clearMyInt() {self._myInt = nil}
 
   var myFloat: Float {
-    get {return _storage._myFloat ?? 0}
-    set {_uniqueStorage()._myFloat = newValue}
+    get {return _myFloat ?? 0}
+    set {_myFloat = newValue}
   }
   /// Returns true if `myFloat` has been explicitly set.
-  var hasMyFloat: Bool {return _storage._myFloat != nil}
+  var hasMyFloat: Bool {return self._myFloat != nil}
   /// Clears the value of `myFloat`. Subsequent reads from it will return its default value.
-  mutating func clearMyFloat() {_uniqueStorage()._myFloat = nil}
+  mutating func clearMyFloat() {self._myFloat = nil}
 
   var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2528,7 +2514,10 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _myString: String? = nil
+  fileprivate var _myInt: Int64? = nil
+  fileprivate var _myFloat: Float? = nil
+  fileprivate var _optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage? = nil
 }
 
 struct ProtobufUnittest_TestExtensionOrderings1 {
@@ -3061,41 +3050,38 @@ struct ProtobufUnittest_TestOneof {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOneof.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {return v}
+      if case .fooGroup(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof.FooGroup()
     }
-    set {_uniqueStorage()._foo = .fooGroup(newValue)}
+    set {foo = .fooGroup(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3139,8 +3125,6 @@ struct ProtobufUnittest_TestOneof {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtobufUnittest_TestOneofBackwardsCompatible {
@@ -3149,40 +3133,40 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible {
   // methods supported on all messages.
 
   var fooInt: Int32 {
-    get {return _storage._fooInt ?? 0}
-    set {_uniqueStorage()._fooInt = newValue}
+    get {return _fooInt ?? 0}
+    set {_fooInt = newValue}
   }
   /// Returns true if `fooInt` has been explicitly set.
-  var hasFooInt: Bool {return _storage._fooInt != nil}
+  var hasFooInt: Bool {return self._fooInt != nil}
   /// Clears the value of `fooInt`. Subsequent reads from it will return its default value.
-  mutating func clearFooInt() {_uniqueStorage()._fooInt = nil}
+  mutating func clearFooInt() {self._fooInt = nil}
 
   var fooString: String {
-    get {return _storage._fooString ?? String()}
-    set {_uniqueStorage()._fooString = newValue}
+    get {return _fooString ?? String()}
+    set {_fooString = newValue}
   }
   /// Returns true if `fooString` has been explicitly set.
-  var hasFooString: Bool {return _storage._fooString != nil}
+  var hasFooString: Bool {return self._fooString != nil}
   /// Clears the value of `fooString`. Subsequent reads from it will return its default value.
-  mutating func clearFooString() {_uniqueStorage()._fooString = nil}
+  mutating func clearFooString() {self._fooString = nil}
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._fooMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._fooMessage = newValue}
+    get {return _fooMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_fooMessage = newValue}
   }
   /// Returns true if `fooMessage` has been explicitly set.
-  var hasFooMessage: Bool {return _storage._fooMessage != nil}
+  var hasFooMessage: Bool {return self._fooMessage != nil}
   /// Clears the value of `fooMessage`. Subsequent reads from it will return its default value.
-  mutating func clearFooMessage() {_uniqueStorage()._fooMessage = nil}
+  mutating func clearFooMessage() {self._fooMessage = nil}
 
   var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
-    get {return _storage._fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
-    set {_uniqueStorage()._fooGroup = newValue}
+    get {return _fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
+    set {_fooGroup = newValue}
   }
   /// Returns true if `fooGroup` has been explicitly set.
-  var hasFooGroup: Bool {return _storage._fooGroup != nil}
+  var hasFooGroup: Bool {return self._fooGroup != nil}
   /// Clears the value of `fooGroup`. Subsequent reads from it will return its default value.
-  mutating func clearFooGroup() {_uniqueStorage()._fooGroup = nil}
+  mutating func clearFooGroup() {self._fooGroup = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3219,7 +3203,10 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _fooInt: Int32? = nil
+  fileprivate var _fooString: String? = nil
+  fileprivate var _fooMessage: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup? = nil
 }
 
 struct ProtobufUnittest_TestOneof2 {
@@ -3499,33 +3486,30 @@ struct ProtobufUnittest_TestRequiredOneof {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3558,8 +3542,6 @@ struct ProtobufUnittest_TestRequiredOneof {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtobufUnittest_TestPackedTypes {
@@ -3673,59 +3655,53 @@ struct ProtobufUnittest_TestDynamicExtensions {
   // methods supported on all messages.
 
   var scalarExtension: UInt32 {
-    get {return _storage._scalarExtension ?? 0}
-    set {_uniqueStorage()._scalarExtension = newValue}
+    get {return _scalarExtension ?? 0}
+    set {_scalarExtension = newValue}
   }
   /// Returns true if `scalarExtension` has been explicitly set.
-  var hasScalarExtension: Bool {return _storage._scalarExtension != nil}
+  var hasScalarExtension: Bool {return self._scalarExtension != nil}
   /// Clears the value of `scalarExtension`. Subsequent reads from it will return its default value.
-  mutating func clearScalarExtension() {_uniqueStorage()._scalarExtension = nil}
+  mutating func clearScalarExtension() {self._scalarExtension = nil}
 
   var enumExtension: ProtobufUnittest_ForeignEnum {
-    get {return _storage._enumExtension ?? .foreignFoo}
-    set {_uniqueStorage()._enumExtension = newValue}
+    get {return _enumExtension ?? .foreignFoo}
+    set {_enumExtension = newValue}
   }
   /// Returns true if `enumExtension` has been explicitly set.
-  var hasEnumExtension: Bool {return _storage._enumExtension != nil}
+  var hasEnumExtension: Bool {return self._enumExtension != nil}
   /// Clears the value of `enumExtension`. Subsequent reads from it will return its default value.
-  mutating func clearEnumExtension() {_uniqueStorage()._enumExtension = nil}
+  mutating func clearEnumExtension() {self._enumExtension = nil}
 
   var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
-    get {return _storage._dynamicEnumExtension ?? .dynamicFoo}
-    set {_uniqueStorage()._dynamicEnumExtension = newValue}
+    get {return _dynamicEnumExtension ?? .dynamicFoo}
+    set {_dynamicEnumExtension = newValue}
   }
   /// Returns true if `dynamicEnumExtension` has been explicitly set.
-  var hasDynamicEnumExtension: Bool {return _storage._dynamicEnumExtension != nil}
+  var hasDynamicEnumExtension: Bool {return self._dynamicEnumExtension != nil}
   /// Clears the value of `dynamicEnumExtension`. Subsequent reads from it will return its default value.
-  mutating func clearDynamicEnumExtension() {_uniqueStorage()._dynamicEnumExtension = nil}
+  mutating func clearDynamicEnumExtension() {self._dynamicEnumExtension = nil}
 
   var messageExtension: ProtobufUnittest_ForeignMessage {
-    get {return _storage._messageExtension ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._messageExtension = newValue}
+    get {return _messageExtension ?? ProtobufUnittest_ForeignMessage()}
+    set {_messageExtension = newValue}
   }
   /// Returns true if `messageExtension` has been explicitly set.
-  var hasMessageExtension: Bool {return _storage._messageExtension != nil}
+  var hasMessageExtension: Bool {return self._messageExtension != nil}
   /// Clears the value of `messageExtension`. Subsequent reads from it will return its default value.
-  mutating func clearMessageExtension() {_uniqueStorage()._messageExtension = nil}
+  mutating func clearMessageExtension() {self._messageExtension = nil}
 
   var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
-    get {return _storage._dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
-    set {_uniqueStorage()._dynamicMessageExtension = newValue}
+    get {return _dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
+    set {_dynamicMessageExtension = newValue}
   }
   /// Returns true if `dynamicMessageExtension` has been explicitly set.
-  var hasDynamicMessageExtension: Bool {return _storage._dynamicMessageExtension != nil}
+  var hasDynamicMessageExtension: Bool {return self._dynamicMessageExtension != nil}
   /// Clears the value of `dynamicMessageExtension`. Subsequent reads from it will return its default value.
-  mutating func clearDynamicMessageExtension() {_uniqueStorage()._dynamicMessageExtension = nil}
+  mutating func clearDynamicMessageExtension() {self._dynamicMessageExtension = nil}
 
-  var repeatedExtension: [String] {
-    get {return _storage._repeatedExtension}
-    set {_uniqueStorage()._repeatedExtension = newValue}
-  }
+  var repeatedExtension: [String] = []
 
-  var packedExtension: [Int32] {
-    get {return _storage._packedExtension}
-    set {_uniqueStorage()._packedExtension = newValue}
-  }
+  var packedExtension: [Int32] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3781,7 +3757,11 @@ struct ProtobufUnittest_TestDynamicExtensions {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _scalarExtension: UInt32? = nil
+  fileprivate var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType? = nil
+  fileprivate var _messageExtension: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType? = nil
 }
 
 #if swift(>=4.2)
@@ -3828,41 +3808,35 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var requiredAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._requiredAllTypes = newValue}
+    get {return _requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
+    set {_requiredAllTypes = newValue}
   }
   /// Returns true if `requiredAllTypes` has been explicitly set.
-  var hasRequiredAllTypes: Bool {return _storage._requiredAllTypes != nil}
+  var hasRequiredAllTypes: Bool {return self._requiredAllTypes != nil}
   /// Clears the value of `requiredAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredAllTypes() {_uniqueStorage()._requiredAllTypes = nil}
+  mutating func clearRequiredAllTypes() {self._requiredAllTypes = nil}
 
   var optionalAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._optionalAllTypes = newValue}
+    get {return _optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
+    set {_optionalAllTypes = newValue}
   }
   /// Returns true if `optionalAllTypes` has been explicitly set.
-  var hasOptionalAllTypes: Bool {return _storage._optionalAllTypes != nil}
+  var hasOptionalAllTypes: Bool {return self._optionalAllTypes != nil}
   /// Clears the value of `optionalAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalAllTypes() {_uniqueStorage()._optionalAllTypes = nil}
+  mutating func clearOptionalAllTypes() {self._optionalAllTypes = nil}
 
-  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
-    get {return _storage._repeatedAllTypes}
-    set {_uniqueStorage()._repeatedAllTypes = newValue}
-  }
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] = []
 
   var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
-    get {return _storage._repeatedGroup}
-    set {_uniqueStorage()._repeatedGroup = newValue}
-  }
+  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3898,19 +3872,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypes {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypes()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypes? = nil
     }
 
     struct Group2 {
@@ -3919,19 +3893,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypes {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypes()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypes? = nil
     }
 
     init() {}
@@ -3943,19 +3917,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
-      get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
-      set {_uniqueStorage()._optionalGroupAllTypes = newValue}
+      get {return _optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
+      set {_optionalGroupAllTypes = newValue}
     }
     /// Returns true if `optionalGroupAllTypes` has been explicitly set.
-    var hasOptionalGroupAllTypes: Bool {return _storage._optionalGroupAllTypes != nil}
+    var hasOptionalGroupAllTypes: Bool {return self._optionalGroupAllTypes != nil}
     /// Clears the value of `optionalGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearOptionalGroupAllTypes() {_uniqueStorage()._optionalGroupAllTypes = nil}
+    mutating func clearOptionalGroupAllTypes() {self._optionalGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
   }
 
   struct RepeatedGroup {
@@ -3964,25 +3938,27 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
-      get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
-      set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
+      get {return _repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
+      set {_repeatedGroupAllTypes = newValue}
     }
     /// Returns true if `repeatedGroupAllTypes` has been explicitly set.
-    var hasRepeatedGroupAllTypes: Bool {return _storage._repeatedGroupAllTypes != nil}
+    var hasRepeatedGroupAllTypes: Bool {return self._repeatedGroupAllTypes != nil}
     /// Clears the value of `repeatedGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearRepeatedGroupAllTypes() {_uniqueStorage()._repeatedGroupAllTypes = nil}
+    mutating func clearRepeatedGroupAllTypes() {self._repeatedGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
   }
 
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _requiredAllTypes: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _optionalAllTypes: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestCommentInjectionMessage {
@@ -4145,118 +4121,106 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var fixed32: Int32 {
-    get {return _storage._fixed32 ?? 0}
-    set {_uniqueStorage()._fixed32 = newValue}
+    get {return _fixed32 ?? 0}
+    set {_fixed32 = newValue}
   }
   /// Returns true if `fixed32` has been explicitly set.
-  var hasFixed32: Bool {return _storage._fixed32 != nil}
+  var hasFixed32: Bool {return self._fixed32 != nil}
   /// Clears the value of `fixed32`. Subsequent reads from it will return its default value.
-  mutating func clearFixed32() {_uniqueStorage()._fixed32 = nil}
+  mutating func clearFixed32() {self._fixed32 = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
-  var packedInt32: [Int32] {
-    get {return _storage._packedInt32}
-    set {_uniqueStorage()._packedInt32 = newValue}
-  }
+  var packedInt32: [Int32] = []
 
   var optionalEnum: ProtobufUnittest_ForeignEnum {
-    get {return _storage._optionalEnum ?? .foreignFoo}
-    set {_uniqueStorage()._optionalEnum = newValue}
+    get {return _optionalEnum ?? .foreignFoo}
+    set {_optionalEnum = newValue}
   }
   /// Returns true if `optionalEnum` has been explicitly set.
-  var hasOptionalEnum: Bool {return _storage._optionalEnum != nil}
+  var hasOptionalEnum: Bool {return self._optionalEnum != nil}
   /// Clears the value of `optionalEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalEnum() {_uniqueStorage()._optionalEnum = nil}
+  mutating func clearOptionalEnum() {self._optionalEnum = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
-    set {_uniqueStorage()._optionalBytes = newValue}
+    get {return _optionalBytes ?? SwiftProtobuf.Internal.emptyData}
+    set {_optionalBytes = newValue}
   }
   /// Returns true if `optionalBytes` has been explicitly set.
-  var hasOptionalBytes: Bool {return _storage._optionalBytes != nil}
+  var hasOptionalBytes: Bool {return self._optionalBytes != nil}
   /// Clears the value of `optionalBytes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBytes() {_uniqueStorage()._optionalBytes = nil}
+  mutating func clearOptionalBytes() {self._optionalBytes = nil}
 
   var optionalMessage: ProtobufUnittest_ForeignMessage {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_ForeignMessage()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
   var optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var stringStringMap: Dictionary<String,String> {
-    get {return _storage._stringStringMap}
-    set {_uniqueStorage()._stringStringMap = newValue}
-  }
+  var stringStringMap: Dictionary<String,String> = [:]
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
+      if case .oneofTestAllTypes(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
+    set {oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -4292,7 +4256,13 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _fixed32: Int32? = nil
+  fileprivate var _optionalEnum: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _optionalBytes: Data? = nil
+  fileprivate var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestExtensionInsideTable: SwiftProtobuf.ExtensibleMessage {
@@ -8128,63 +8098,29 @@ extension ProtobufUnittest_TestGroup: SwiftProtobuf.Message, SwiftProtobuf._Mess
     22: .standard(proto: "optional_foreign_enum"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup? = nil
-    var _optionalForeignEnum: ProtobufUnittest_ForeignEnum? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroup = source._optionalGroup
-      _optionalForeignEnum = source._optionalForeignEnum
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 16: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 22: try decoder.decodeSingularEnumField(value: &_storage._optionalForeignEnum)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 16: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 22: try decoder.decodeSingularEnumField(value: &self._optionalForeignEnum)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 16)
-      }
-      if let v = _storage._optionalForeignEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 22)
-      }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 16)
+    }
+    if let v = self._optionalForeignEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 22)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestGroup, rhs: ProtobufUnittest_TestGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._optionalForeignEnum != rhs_storage._optionalForeignEnum {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs._optionalForeignEnum != rhs._optionalForeignEnum {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8630,78 +8566,40 @@ extension ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message, SwiftProt
     3: .same(proto: "dummy"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestRequired? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
-    var _dummy: Int32? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-      _dummy = source._dummy
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      return true
-    }
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        case 3: try decoder.decodeSingularInt32Field(value: &_storage._dummy)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      case 3: try decoder.decodeSingularInt32Field(value: &self._dummy)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
-      if let v = _storage._dummy {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
+    }
+    if let v = self._dummy {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredForeign, rhs: ProtobufUnittest_TestRequiredForeign) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        if _storage._dummy != rhs_storage._dummy {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
+    if lhs._dummy != rhs._dummy {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8715,80 +8613,42 @@ extension ProtobufUnittest_TestRequiredMessage: SwiftProtobuf.Message, SwiftProt
     3: .standard(proto: "required_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestRequired? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
-    var _requiredMessage: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-      _requiredMessage = source._requiredMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredMessage == nil {return false}
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      if let v = _storage._requiredMessage, !v.isInitialized {return false}
-      return true
-    }
+    if self._requiredMessage == nil {return false}
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    if let v = self._requiredMessage, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._requiredMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      case 3: try decoder.decodeSingularMessageField(value: &self._requiredMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
-      if let v = _storage._requiredMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
+    }
+    if let v = self._requiredMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredMessage, rhs: ProtobufUnittest_TestRequiredMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        if _storage._requiredMessage != rhs_storage._requiredMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
+    if lhs._requiredMessage != rhs._requiredMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8800,56 +8660,24 @@ extension ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "foreign_nested"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foreignNested = source._foreignNested
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._foreignNested)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._foreignNested)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._foreignNested {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._foreignNested {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestForeignNested, rhs: ProtobufUnittest_TestForeignNested) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foreignNested != rhs_storage._foreignNested {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._foreignNested != rhs._foreignNested {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9312,63 +9140,29 @@ extension ProtobufUnittest_TestIsInitialized: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestIsInitialized.SubMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._subMessage, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestIsInitialized, rhs: ProtobufUnittest_TestIsInitialized) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9380,63 +9174,29 @@ extension ProtobufUnittest_TestIsInitialized.SubMessage: SwiftProtobuf.Message, 
     1: .unique(proto: "SubGroup", json: "subgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subGroup = source._subGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subGroup, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._subGroup, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularGroupField(value: &_storage._subGroup)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularGroupField(value: &self._subGroup)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestIsInitialized.SubMessage, rhs: ProtobufUnittest_TestIsInitialized.SubMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subGroup != rhs_storage._subGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subGroup != rhs._subGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9484,70 +9244,34 @@ extension ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message, SwiftProto
     3: .unique(proto: "Bar", json: "bar"),
   ]
 
-  fileprivate class _StorageClass {
-    var _a: Int32? = nil
-    var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
-    var _bar: ProtobufUnittest_TestDupFieldNumber.Bar? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _a = source._a
-      _foo = source._foo
-      _bar = source._bar
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._a)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._foo)
-        case 3: try decoder.decodeSingularGroupField(value: &_storage._bar)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._a)
+      case 2: try decoder.decodeSingularGroupField(value: &self._foo)
+      case 3: try decoder.decodeSingularGroupField(value: &self._bar)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._a {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._foo {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._bar {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-      }
+    if let v = self._a {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._foo {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
+    }
+    if let v = self._bar {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestDupFieldNumber, rhs: ProtobufUnittest_TestDupFieldNumber) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._a != rhs_storage._a {return false}
-        if _storage._foo != rhs_storage._foo {return false}
-        if _storage._bar != rhs_storage._bar {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._a != rhs._a {return false}
+    if lhs._foo != rhs._foo {return false}
+    if lhs._bar != rhs._bar {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9617,56 +9341,24 @@ extension ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message, SwiftProtobu
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestEagerMessage, rhs: ProtobufUnittest_TestEagerMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9678,56 +9370,24 @@ extension ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message, SwiftProtobuf
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestLazyMessage, rhs: ProtobufUnittest_TestLazyMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9739,56 +9399,24 @@ extension ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message, Swif
     1: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestNestedMessageHasBits, rhs: ProtobufUnittest_TestNestedMessageHasBits) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9846,133 +9474,79 @@ extension ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message, Swift
     12: .same(proto: "RepeatedCordField"),
   ]
 
-  fileprivate class _StorageClass {
-    var _primitiveField: Int32? = nil
-    var _stringField: String? = nil
-    var _enumField: ProtobufUnittest_ForeignEnum? = nil
-    var _messageField: ProtobufUnittest_ForeignMessage? = nil
-    var _stringPieceField: String? = nil
-    var _cordField: String? = nil
-    var _repeatedPrimitiveField: [Int32] = []
-    var _repeatedStringField: [String] = []
-    var _repeatedEnumField: [ProtobufUnittest_ForeignEnum] = []
-    var _repeatedMessageField: [ProtobufUnittest_ForeignMessage] = []
-    var _repeatedStringPieceField: [String] = []
-    var _repeatedCordField: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _primitiveField = source._primitiveField
-      _stringField = source._stringField
-      _enumField = source._enumField
-      _messageField = source._messageField
-      _stringPieceField = source._stringPieceField
-      _cordField = source._cordField
-      _repeatedPrimitiveField = source._repeatedPrimitiveField
-      _repeatedStringField = source._repeatedStringField
-      _repeatedEnumField = source._repeatedEnumField
-      _repeatedMessageField = source._repeatedMessageField
-      _repeatedStringPieceField = source._repeatedStringPieceField
-      _repeatedCordField = source._repeatedCordField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._primitiveField)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._stringField)
-        case 3: try decoder.decodeSingularEnumField(value: &_storage._enumField)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._messageField)
-        case 5: try decoder.decodeSingularStringField(value: &_storage._stringPieceField)
-        case 6: try decoder.decodeSingularStringField(value: &_storage._cordField)
-        case 7: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedPrimitiveField)
-        case 8: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringField)
-        case 9: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnumField)
-        case 10: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessageField)
-        case 11: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPieceField)
-        case 12: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCordField)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._primitiveField)
+      case 2: try decoder.decodeSingularStringField(value: &self._stringField)
+      case 3: try decoder.decodeSingularEnumField(value: &self._enumField)
+      case 4: try decoder.decodeSingularMessageField(value: &self._messageField)
+      case 5: try decoder.decodeSingularStringField(value: &self._stringPieceField)
+      case 6: try decoder.decodeSingularStringField(value: &self._cordField)
+      case 7: try decoder.decodeRepeatedInt32Field(value: &self.repeatedPrimitiveField)
+      case 8: try decoder.decodeRepeatedStringField(value: &self.repeatedStringField)
+      case 9: try decoder.decodeRepeatedEnumField(value: &self.repeatedEnumField)
+      case 10: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessageField)
+      case 11: try decoder.decodeRepeatedStringField(value: &self.repeatedStringPieceField)
+      case 12: try decoder.decodeRepeatedStringField(value: &self.repeatedCordField)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._primitiveField {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._stringField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._enumField {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._messageField {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._stringPieceField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._cordField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-      }
-      if !_storage._repeatedPrimitiveField.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedPrimitiveField, fieldNumber: 7)
-      }
-      if !_storage._repeatedStringField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedStringField, fieldNumber: 8)
-      }
-      if !_storage._repeatedEnumField.isEmpty {
-        try visitor.visitRepeatedEnumField(value: _storage._repeatedEnumField, fieldNumber: 9)
-      }
-      if !_storage._repeatedMessageField.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessageField, fieldNumber: 10)
-      }
-      if !_storage._repeatedStringPieceField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedStringPieceField, fieldNumber: 11)
-      }
-      if !_storage._repeatedCordField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedCordField, fieldNumber: 12)
-      }
+    if let v = self._primitiveField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._stringField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._enumField {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
+    }
+    if let v = self._messageField {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if let v = self._stringPieceField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    }
+    if let v = self._cordField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    }
+    if !self.repeatedPrimitiveField.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedPrimitiveField, fieldNumber: 7)
+    }
+    if !self.repeatedStringField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedStringField, fieldNumber: 8)
+    }
+    if !self.repeatedEnumField.isEmpty {
+      try visitor.visitRepeatedEnumField(value: self.repeatedEnumField, fieldNumber: 9)
+    }
+    if !self.repeatedMessageField.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessageField, fieldNumber: 10)
+    }
+    if !self.repeatedStringPieceField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedStringPieceField, fieldNumber: 11)
+    }
+    if !self.repeatedCordField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedCordField, fieldNumber: 12)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestCamelCaseFieldNames, rhs: ProtobufUnittest_TestCamelCaseFieldNames) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._primitiveField != rhs_storage._primitiveField {return false}
-        if _storage._stringField != rhs_storage._stringField {return false}
-        if _storage._enumField != rhs_storage._enumField {return false}
-        if _storage._messageField != rhs_storage._messageField {return false}
-        if _storage._stringPieceField != rhs_storage._stringPieceField {return false}
-        if _storage._cordField != rhs_storage._cordField {return false}
-        if _storage._repeatedPrimitiveField != rhs_storage._repeatedPrimitiveField {return false}
-        if _storage._repeatedStringField != rhs_storage._repeatedStringField {return false}
-        if _storage._repeatedEnumField != rhs_storage._repeatedEnumField {return false}
-        if _storage._repeatedMessageField != rhs_storage._repeatedMessageField {return false}
-        if _storage._repeatedStringPieceField != rhs_storage._repeatedStringPieceField {return false}
-        if _storage._repeatedCordField != rhs_storage._repeatedCordField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._primitiveField != rhs._primitiveField {return false}
+    if lhs._stringField != rhs._stringField {return false}
+    if lhs._enumField != rhs._enumField {return false}
+    if lhs._messageField != rhs._messageField {return false}
+    if lhs._stringPieceField != rhs._stringPieceField {return false}
+    if lhs._cordField != rhs._cordField {return false}
+    if lhs.repeatedPrimitiveField != rhs.repeatedPrimitiveField {return false}
+    if lhs.repeatedStringField != rhs.repeatedStringField {return false}
+    if lhs.repeatedEnumField != rhs.repeatedEnumField {return false}
+    if lhs.repeatedMessageField != rhs.repeatedMessageField {return false}
+    if lhs.repeatedStringPieceField != rhs.repeatedStringPieceField {return false}
+    if lhs.repeatedCordField != rhs.repeatedCordField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9987,86 +9561,48 @@ extension ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProto
     200: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _myString: String? = nil
-    var _myInt: Int64? = nil
-    var _myFloat: Float? = nil
-    var _optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _myString = source._myString
-      _myInt = source._myInt
-      _myFloat = source._myFloat
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
-        case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
-        case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-        case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        case 2..<11, 12..<101:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt64Field(value: &self._myInt)
+      case 11: try decoder.decodeSingularStringField(value: &self._myString)
+      case 101: try decoder.decodeSingularFloatField(value: &self._myFloat)
+      case 200: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      case 2..<11, 12..<101:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._myInt {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 11)
-      if let v = _storage._myString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 101)
-      if let v = _storage._myFloat {
-        try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
-      }
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
-      }
+    if let v = self._myInt {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 11)
+    if let v = self._myString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 101)
+    if let v = self._myFloat {
+      try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
+    }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestFieldOrderings, rhs: ProtobufUnittest_TestFieldOrderings) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._myString != rhs_storage._myString {return false}
-        if _storage._myInt != rhs_storage._myInt {return false}
-        if _storage._myFloat != rhs_storage._myFloat {return false}
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._myString != rhs._myString {return false}
+    if lhs._myInt != rhs._myInt {return false}
+    if lhs._myFloat != rhs._myFloat {return false}
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -10763,89 +10299,57 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._Mess
     4: .unique(proto: "FooGroup", json: "foogroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        case 3:
-          var v: ProtobufUnittest_TestAllTypes?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        case 4:
-          var v: ProtobufUnittest_TestOneof.FooGroup?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooGroup(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._foo = .fooGroup(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      case 3:
+        var v: ProtobufUnittest_TestAllTypes?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      case 4:
+        var v: ProtobufUnittest_TestOneof.FooGroup?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooGroup(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.foo = .fooGroup(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._foo {
-      case .fooInt(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .fooString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case .fooMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      case .fooGroup(let v)?:
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      case nil: break
-      }
+    switch self.foo {
+    case .fooInt(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .fooString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .fooMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    case .fooGroup(let v)?:
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneof, rhs: ProtobufUnittest_TestOneof) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -10895,77 +10399,39 @@ extension ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message, 
     4: .unique(proto: "FooGroup", json: "foogroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fooInt: Int32? = nil
-    var _fooString: String? = nil
-    var _fooMessage: ProtobufUnittest_TestAllTypes? = nil
-    var _fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fooInt = source._fooInt
-      _fooString = source._fooString
-      _fooMessage = source._fooMessage
-      _fooGroup = source._fooGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._fooInt)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._fooString)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._fooMessage)
-        case 4: try decoder.decodeSingularGroupField(value: &_storage._fooGroup)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._fooInt)
+      case 2: try decoder.decodeSingularStringField(value: &self._fooString)
+      case 3: try decoder.decodeSingularMessageField(value: &self._fooMessage)
+      case 4: try decoder.decodeSingularGroupField(value: &self._fooGroup)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._fooInt {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._fooString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._fooMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._fooGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      }
+    if let v = self._fooInt {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._fooString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._fooMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._fooGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneofBackwardsCompatible, rhs: ProtobufUnittest_TestOneofBackwardsCompatible) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fooInt != rhs_storage._fooInt {return false}
-        if _storage._fooString != rhs_storage._fooString {return false}
-        if _storage._fooMessage != rhs_storage._fooMessage {return false}
-        if _storage._fooGroup != rhs_storage._fooGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._fooInt != rhs._fooInt {return false}
+    if lhs._fooString != rhs._fooString {return false}
+    if lhs._fooMessage != rhs._fooMessage {return false}
+    if lhs._fooGroup != rhs._fooGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11302,86 +10768,52 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
     3: .standard(proto: "foo_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if case .fooMessage(let v)? = _storage._foo, !v.isInitialized {return false}
-      return true
-    }
+    if case .fooMessage(let v)? = self.foo, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        case 3:
-          var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      case 3:
+        var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._foo {
-      case .fooInt(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .fooString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case .fooMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      case nil: break
-      }
+    switch self.foo {
+    case .fooInt(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .fooString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .fooMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredOneof, rhs: ProtobufUnittest_TestRequiredOneof) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11705,98 +11137,54 @@ extension ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message, SwiftPr
     2006: .standard(proto: "packed_extension"),
   ]
 
-  fileprivate class _StorageClass {
-    var _scalarExtension: UInt32? = nil
-    var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
-    var _dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType? = nil
-    var _messageExtension: ProtobufUnittest_ForeignMessage? = nil
-    var _dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType? = nil
-    var _repeatedExtension: [String] = []
-    var _packedExtension: [Int32] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _scalarExtension = source._scalarExtension
-      _enumExtension = source._enumExtension
-      _dynamicEnumExtension = source._dynamicEnumExtension
-      _messageExtension = source._messageExtension
-      _dynamicMessageExtension = source._dynamicMessageExtension
-      _repeatedExtension = source._repeatedExtension
-      _packedExtension = source._packedExtension
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 2000: try decoder.decodeSingularFixed32Field(value: &_storage._scalarExtension)
-        case 2001: try decoder.decodeSingularEnumField(value: &_storage._enumExtension)
-        case 2002: try decoder.decodeSingularEnumField(value: &_storage._dynamicEnumExtension)
-        case 2003: try decoder.decodeSingularMessageField(value: &_storage._messageExtension)
-        case 2004: try decoder.decodeSingularMessageField(value: &_storage._dynamicMessageExtension)
-        case 2005: try decoder.decodeRepeatedStringField(value: &_storage._repeatedExtension)
-        case 2006: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedExtension)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 2000: try decoder.decodeSingularFixed32Field(value: &self._scalarExtension)
+      case 2001: try decoder.decodeSingularEnumField(value: &self._enumExtension)
+      case 2002: try decoder.decodeSingularEnumField(value: &self._dynamicEnumExtension)
+      case 2003: try decoder.decodeSingularMessageField(value: &self._messageExtension)
+      case 2004: try decoder.decodeSingularMessageField(value: &self._dynamicMessageExtension)
+      case 2005: try decoder.decodeRepeatedStringField(value: &self.repeatedExtension)
+      case 2006: try decoder.decodeRepeatedSInt32Field(value: &self.packedExtension)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._scalarExtension {
-        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 2000)
-      }
-      if let v = _storage._enumExtension {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 2001)
-      }
-      if let v = _storage._dynamicEnumExtension {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 2002)
-      }
-      if let v = _storage._messageExtension {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2003)
-      }
-      if let v = _storage._dynamicMessageExtension {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2004)
-      }
-      if !_storage._repeatedExtension.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedExtension, fieldNumber: 2005)
-      }
-      if !_storage._packedExtension.isEmpty {
-        try visitor.visitPackedSInt32Field(value: _storage._packedExtension, fieldNumber: 2006)
-      }
+    if let v = self._scalarExtension {
+      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 2000)
+    }
+    if let v = self._enumExtension {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 2001)
+    }
+    if let v = self._dynamicEnumExtension {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 2002)
+    }
+    if let v = self._messageExtension {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2003)
+    }
+    if let v = self._dynamicMessageExtension {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2004)
+    }
+    if !self.repeatedExtension.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedExtension, fieldNumber: 2005)
+    }
+    if !self.packedExtension.isEmpty {
+      try visitor.visitPackedSInt32Field(value: self.packedExtension, fieldNumber: 2006)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestDynamicExtensions, rhs: ProtobufUnittest_TestDynamicExtensions) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._scalarExtension != rhs_storage._scalarExtension {return false}
-        if _storage._enumExtension != rhs_storage._enumExtension {return false}
-        if _storage._dynamicEnumExtension != rhs_storage._dynamicEnumExtension {return false}
-        if _storage._messageExtension != rhs_storage._messageExtension {return false}
-        if _storage._dynamicMessageExtension != rhs_storage._dynamicMessageExtension {return false}
-        if _storage._repeatedExtension != rhs_storage._repeatedExtension {return false}
-        if _storage._packedExtension != rhs_storage._packedExtension {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._scalarExtension != rhs._scalarExtension {return false}
+    if lhs._enumExtension != rhs._enumExtension {return false}
+    if lhs._dynamicEnumExtension != rhs._dynamicEnumExtension {return false}
+    if lhs._messageExtension != rhs._messageExtension {return false}
+    if lhs._dynamicMessageExtension != rhs._dynamicMessageExtension {return false}
+    if lhs.repeatedExtension != rhs.repeatedExtension {return false}
+    if lhs.packedExtension != rhs.packedExtension {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11908,95 +11296,53 @@ extension ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobu
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _requiredAllTypes: ProtobufUnittest_TestAllTypes? = nil
-    var _optionalAllTypes: ProtobufUnittest_TestAllTypes? = nil
-    var _repeatedAllTypes: [ProtobufUnittest_TestAllTypes] = []
-    var _optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup? = nil
-    var _repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _requiredAllTypes = source._requiredAllTypes
-      _optionalAllTypes = source._optionalAllTypes
-      _repeatedAllTypes = source._repeatedAllTypes
-      _optionalGroup = source._optionalGroup
-      _repeatedGroup = source._repeatedGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredAllTypes == nil {return false}
-      return true
-    }
+    if self._requiredAllTypes == nil {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._requiredAllTypes)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._optionalAllTypes)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
-        case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._requiredAllTypes)
+      case 2: try decoder.decodeSingularMessageField(value: &self._optionalAllTypes)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAllTypes)
+      case 10: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 20: try decoder.decodeRepeatedGroupField(value: &self.repeatedGroup)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._requiredAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._optionalAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAllTypes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAllTypes, fieldNumber: 3)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
-      }
-      if !_storage._repeatedGroup.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._repeatedGroup, fieldNumber: 20)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._requiredAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._optionalAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAllTypes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAllTypes, fieldNumber: 3)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
+    }
+    if !self.repeatedGroup.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.repeatedGroup, fieldNumber: 20)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge, rhs: ProtobufUnittest_TestParsingMerge) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._requiredAllTypes != rhs_storage._requiredAllTypes {return false}
-        if _storage._optionalAllTypes != rhs_storage._optionalAllTypes {return false}
-        if _storage._repeatedAllTypes != rhs_storage._repeatedAllTypes {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._repeatedGroup != rhs_storage._repeatedGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._requiredAllTypes != rhs._requiredAllTypes {return false}
+    if lhs._optionalAllTypes != rhs._optionalAllTypes {return false}
+    if lhs.repeatedAllTypes != rhs.repeatedAllTypes {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.repeatedGroup != rhs.repeatedGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -12074,56 +11420,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1: Swif
     11: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1, rhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12135,56 +11449,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2: Swif
     21: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2, rhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12196,56 +11478,24 @@ extension ProtobufUnittest_TestParsingMerge.OptionalGroup: SwiftProtobuf.Message
     11: .standard(proto: "optional_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroupAllTypes = source._optionalGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._optionalGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._optionalGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._optionalGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.OptionalGroup, rhs: ProtobufUnittest_TestParsingMerge.OptionalGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroupAllTypes != rhs_storage._optionalGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroupAllTypes != rhs._optionalGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12257,56 +11507,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedGroup: SwiftProtobuf.Message
     21: .standard(proto: "repeated_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _repeatedGroupAllTypes = source._repeatedGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._repeatedGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._repeatedGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._repeatedGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._repeatedGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedGroup, rhs: ProtobufUnittest_TestParsingMerge.RepeatedGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._repeatedGroupAllTypes != rhs_storage._repeatedGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._repeatedGroupAllTypes != rhs._repeatedGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12533,164 +11751,112 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
     536870014: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _fixed32: Int32? = nil
-    var _repeatedInt32: [Int32] = []
-    var _packedInt32: [Int32] = []
-    var _optionalEnum: ProtobufUnittest_ForeignEnum? = nil
-    var _optionalString: String? = nil
-    var _optionalBytes: Data? = nil
-    var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
-    var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
-    var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _fixed32 = source._fixed32
-      _repeatedInt32 = source._repeatedInt32
-      _packedInt32 = source._packedInt32
-      _optionalEnum = source._optionalEnum
-      _optionalString = source._optionalString
-      _optionalBytes = source._optionalBytes
-      _optionalMessage = source._optionalMessage
-      _optionalGroup = source._optionalGroup
-      _stringStringMap = source._stringStringMap
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 536870000: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 536870001: try decoder.decodeSingularInt32Field(value: &_storage._fixed32)
-        case 536870002: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        case 536870003: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
-        case 536870004: try decoder.decodeSingularEnumField(value: &_storage._optionalEnum)
-        case 536870005: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 536870006: try decoder.decodeSingularBytesField(value: &_storage._optionalBytes)
-        case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-        case 536870011:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 536870012:
-          var v: ProtobufUnittest_TestAllTypes?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofTestAllTypes(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofTestAllTypes(v)}
-        case 536870013:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 536870014:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 536860000..<536870000:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 536870000: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 536870001: try decoder.decodeSingularInt32Field(value: &self._fixed32)
+      case 536870002: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      case 536870003: try decoder.decodeRepeatedInt32Field(value: &self.packedInt32)
+      case 536870004: try decoder.decodeSingularEnumField(value: &self._optionalEnum)
+      case 536870005: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 536870006: try decoder.decodeSingularBytesField(value: &self._optionalBytes)
+      case 536870007: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 536870008: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap)
+      case 536870011:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 536870012:
+        var v: ProtobufUnittest_TestAllTypes?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofTestAllTypes(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofTestAllTypes(v)}
+      case 536870013:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 536870014:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 536860000..<536870000:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
-      }
-      if let v = _storage._fixed32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 536870002)
-      }
-      if !_storage._packedInt32.isEmpty {
-        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 536870003)
-      }
-      if let v = _storage._optionalEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
-      }
-      if let v = _storage._optionalBytes {
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
-      }
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
-      }
-      if !_storage._stringStringMap.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
-      }
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-      case .oneofTestAllTypes(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      case nil: break
-      }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
+    }
+    if let v = self._fixed32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 536870002)
+    }
+    if !self.packedInt32.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.packedInt32, fieldNumber: 536870003)
+    }
+    if let v = self._optionalEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
+    }
+    if let v = self._optionalBytes {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
+    }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
+    }
+    if !self.stringStringMap.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.stringStringMap, fieldNumber: 536870010)
+    }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+    case .oneofTestAllTypes(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers, rhs: ProtobufUnittest_TestHugeFieldNumbers) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._fixed32 != rhs_storage._fixed32 {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
-        if _storage._optionalEnum != rhs_storage._optionalEnum {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._optionalBytes != rhs_storage._optionalBytes {return false}
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._stringStringMap != rhs_storage._stringStringMap {return false}
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._fixed32 != rhs._fixed32 {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
+    if lhs.packedInt32 != rhs.packedInt32 {return false}
+    if lhs._optionalEnum != rhs._optionalEnum {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._optionalBytes != rhs._optionalBytes {return false}
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.stringStringMap != rhs.stringStringMap {return false}
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -387,36 +387,33 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var bar: ProtobufUnittest_ComplexOptionType1 {
-    get {return _storage._bar ?? ProtobufUnittest_ComplexOptionType1()}
-    set {_uniqueStorage()._bar = newValue}
+    get {return _bar ?? ProtobufUnittest_ComplexOptionType1()}
+    set {_bar = newValue}
   }
   /// Returns true if `bar` has been explicitly set.
-  var hasBar: Bool {return _storage._bar != nil}
+  var hasBar: Bool {return self._bar != nil}
   /// Clears the value of `bar`. Subsequent reads from it will return its default value.
-  mutating func clearBar() {_uniqueStorage()._bar = nil}
+  mutating func clearBar() {self._bar = nil}
 
   var baz: Int32 {
-    get {return _storage._baz ?? 0}
-    set {_uniqueStorage()._baz = newValue}
+    get {return _baz ?? 0}
+    set {_baz = newValue}
   }
   /// Returns true if `baz` has been explicitly set.
-  var hasBaz: Bool {return _storage._baz != nil}
+  var hasBaz: Bool {return self._baz != nil}
   /// Clears the value of `baz`. Subsequent reads from it will return its default value.
-  mutating func clearBaz() {_uniqueStorage()._baz = nil}
+  mutating func clearBaz() {self._baz = nil}
 
   var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return _storage._fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {_uniqueStorage()._fred = newValue}
+    get {return _fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {_fred = newValue}
   }
   /// Returns true if `fred` has been explicitly set.
-  var hasFred: Bool {return _storage._fred != nil}
+  var hasFred: Bool {return self._fred != nil}
   /// Clears the value of `fred`. Subsequent reads from it will return its default value.
-  mutating func clearFred() {_uniqueStorage()._fred = nil}
+  mutating func clearFred() {self._fred = nil}
 
-  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
-    get {return _storage._barney}
-    set {_uniqueStorage()._barney = newValue}
-  }
+  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -444,7 +441,9 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _bar: ProtobufUnittest_ComplexOptionType1? = nil
+  fileprivate var _baz: Int32? = nil
+  fileprivate var _fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4? = nil
 }
 
 struct ProtobufUnittest_ComplexOptionType3 {
@@ -453,22 +452,22 @@ struct ProtobufUnittest_ComplexOptionType3 {
   // methods supported on all messages.
 
   var qux: Int32 {
-    get {return _storage._qux ?? 0}
-    set {_uniqueStorage()._qux = newValue}
+    get {return _qux ?? 0}
+    set {_qux = newValue}
   }
   /// Returns true if `qux` has been explicitly set.
-  var hasQux: Bool {return _storage._qux != nil}
+  var hasQux: Bool {return self._qux != nil}
   /// Clears the value of `qux`. Subsequent reads from it will return its default value.
-  mutating func clearQux() {_uniqueStorage()._qux = nil}
+  mutating func clearQux() {self._qux = nil}
 
   var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
-    get {return _storage._complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
-    set {_uniqueStorage()._complexOptionType5 = newValue}
+    get {return _complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
+    set {_complexOptionType5 = newValue}
   }
   /// Returns true if `complexOptionType5` has been explicitly set.
-  var hasComplexOptionType5: Bool {return _storage._complexOptionType5 != nil}
+  var hasComplexOptionType5: Bool {return self._complexOptionType5 != nil}
   /// Clears the value of `complexOptionType5`. Subsequent reads from it will return its default value.
-  mutating func clearComplexOptionType5() {_uniqueStorage()._complexOptionType5 = nil}
+  mutating func clearComplexOptionType5() {self._complexOptionType5 = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -495,7 +494,8 @@ struct ProtobufUnittest_ComplexOptionType3 {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _qux: Int32? = nil
+  fileprivate var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
 }
 
 struct ProtobufUnittest_ComplexOpt6 {
@@ -2202,88 +2202,48 @@ extension ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProto
     4: .same(proto: "barney"),
   ]
 
-  fileprivate class _StorageClass {
-    var _bar: ProtobufUnittest_ComplexOptionType1? = nil
-    var _baz: Int32? = nil
-    var _fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4? = nil
-    var _barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _bar = source._bar
-      _baz = source._baz
-      _fred = source._fred
-      _barney = source._barney
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._bar, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._bar, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._bar)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._baz)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._fred)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._barney)
-        case 100..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._bar)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._baz)
+      case 3: try decoder.decodeSingularMessageField(value: &self._fred)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.barney)
+      case 100..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._bar {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._baz {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._fred {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._barney.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._barney, fieldNumber: 4)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 100, end: 536870912)
+    if let v = self._bar {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._baz {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._fred {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.barney.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.barney, fieldNumber: 4)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 100, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_ComplexOptionType2, rhs: ProtobufUnittest_ComplexOptionType2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._bar != rhs_storage._bar {return false}
-        if _storage._baz != rhs_storage._baz {return false}
-        if _storage._fred != rhs_storage._fred {return false}
-        if _storage._barney != rhs_storage._barney {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._bar != rhs._bar {return false}
+    if lhs._baz != rhs._baz {return false}
+    if lhs._fred != rhs._fred {return false}
+    if lhs.barney != rhs.barney {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -2326,63 +2286,29 @@ extension ProtobufUnittest_ComplexOptionType3: SwiftProtobuf.Message, SwiftProto
     2: .unique(proto: "ComplexOptionType5", json: "complexoptiontype5"),
   ]
 
-  fileprivate class _StorageClass {
-    var _qux: Int32? = nil
-    var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _qux = source._qux
-      _complexOptionType5 = source._complexOptionType5
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._qux)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._complexOptionType5)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._qux)
+      case 2: try decoder.decodeSingularGroupField(value: &self._complexOptionType5)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._qux {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._complexOptionType5 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
+    if let v = self._qux {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._complexOptionType5 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_ComplexOptionType3, rhs: ProtobufUnittest_ComplexOptionType3) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._qux != rhs_storage._qux {return false}
-        if _storage._complexOptionType5 != rhs_storage._complexOptionType5 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._qux != rhs._qux {return false}
+    if lhs._complexOptionType5 != rhs._complexOptionType5 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -63,24 +63,21 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize {
   /// Test that embedding a message which has optimize_for = CODE_SIZE into
   /// one optimized for speed works.
   var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -94,71 +91,35 @@ extension ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message, Swi
     2: .standard(proto: "repeated_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      return true
-    }
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestEmbedOptimizedForSize, rhs: ProtobufUnittest_TestEmbedOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_lazy_dependencies.pb.swift
+++ b/Reference/google/protobuf/unittest_lazy_dependencies.pb.swift
@@ -61,19 +61,19 @@ struct ProtobufUnittest_LazyImports_ImportedMessage {
   // methods supported on all messages.
 
   var lazyMessage: ProtobufUnittest_LazyImports_LazyMessage {
-    get {return _storage._lazyMessage ?? ProtobufUnittest_LazyImports_LazyMessage()}
-    set {_uniqueStorage()._lazyMessage = newValue}
+    get {return _lazyMessage ?? ProtobufUnittest_LazyImports_LazyMessage()}
+    set {_lazyMessage = newValue}
   }
   /// Returns true if `lazyMessage` has been explicitly set.
-  var hasLazyMessage: Bool {return _storage._lazyMessage != nil}
+  var hasLazyMessage: Bool {return self._lazyMessage != nil}
   /// Clears the value of `lazyMessage`. Subsequent reads from it will return its default value.
-  mutating func clearLazyMessage() {_uniqueStorage()._lazyMessage = nil}
+  mutating func clearLazyMessage() {self._lazyMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _lazyMessage: ProtobufUnittest_LazyImports_LazyMessage? = nil
 }
 
 struct ProtobufUnittest_LazyImports_MessageCustomOption {
@@ -106,56 +106,24 @@ extension ProtobufUnittest_LazyImports_ImportedMessage: SwiftProtobuf.Message, S
     1: .standard(proto: "lazy_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _lazyMessage: ProtobufUnittest_LazyImports_LazyMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _lazyMessage = source._lazyMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._lazyMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._lazyMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._lazyMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._lazyMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_LazyImports_ImportedMessage, rhs: ProtobufUnittest_LazyImports_ImportedMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._lazyMessage != rhs_storage._lazyMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._lazyMessage != rhs._lazyMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1051,41 +1051,35 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
-    get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-    set {_uniqueStorage()._requiredAllTypes = newValue}
+    get {return _requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+    set {_requiredAllTypes = newValue}
   }
   /// Returns true if `requiredAllTypes` has been explicitly set.
-  var hasRequiredAllTypes: Bool {return _storage._requiredAllTypes != nil}
+  var hasRequiredAllTypes: Bool {return self._requiredAllTypes != nil}
   /// Clears the value of `requiredAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredAllTypes() {_uniqueStorage()._requiredAllTypes = nil}
+  mutating func clearRequiredAllTypes() {self._requiredAllTypes = nil}
 
   var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
-    get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-    set {_uniqueStorage()._optionalAllTypes = newValue}
+    get {return _optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+    set {_optionalAllTypes = newValue}
   }
   /// Returns true if `optionalAllTypes` has been explicitly set.
-  var hasOptionalAllTypes: Bool {return _storage._optionalAllTypes != nil}
+  var hasOptionalAllTypes: Bool {return self._optionalAllTypes != nil}
   /// Clears the value of `optionalAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalAllTypes() {_uniqueStorage()._optionalAllTypes = nil}
+  mutating func clearOptionalAllTypes() {self._optionalAllTypes = nil}
 
-  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
-    get {return _storage._repeatedAllTypes}
-    set {_uniqueStorage()._repeatedAllTypes = newValue}
-  }
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] = []
 
   var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
-    get {return _storage._repeatedGroup}
-    set {_uniqueStorage()._repeatedGroup = newValue}
-  }
+  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1116,19 +1110,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypesLite {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypesLite()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypesLite? = nil
     }
 
     struct Group2 {
@@ -1137,19 +1131,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypesLite {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypesLite()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypesLite? = nil
     }
 
     init() {}
@@ -1161,19 +1155,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
-      get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-      set {_uniqueStorage()._optionalGroupAllTypes = newValue}
+      get {return _optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+      set {_optionalGroupAllTypes = newValue}
     }
     /// Returns true if `optionalGroupAllTypes` has been explicitly set.
-    var hasOptionalGroupAllTypes: Bool {return _storage._optionalGroupAllTypes != nil}
+    var hasOptionalGroupAllTypes: Bool {return self._optionalGroupAllTypes != nil}
     /// Clears the value of `optionalGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearOptionalGroupAllTypes() {_uniqueStorage()._optionalGroupAllTypes = nil}
+    mutating func clearOptionalGroupAllTypes() {self._optionalGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
   }
 
   struct RepeatedGroup {
@@ -1182,25 +1176,27 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
-      get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-      set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
+      get {return _repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+      set {_repeatedGroupAllTypes = newValue}
     }
     /// Returns true if `repeatedGroupAllTypes` has been explicitly set.
-    var hasRepeatedGroupAllTypes: Bool {return _storage._repeatedGroupAllTypes != nil}
+    var hasRepeatedGroupAllTypes: Bool {return self._repeatedGroupAllTypes != nil}
     /// Clears the value of `repeatedGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearRepeatedGroupAllTypes() {_uniqueStorage()._repeatedGroupAllTypes = nil}
+    mutating func clearRepeatedGroupAllTypes() {self._repeatedGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
   }
 
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _requiredAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
+  fileprivate var _optionalAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup? = nil
 }
 
 /// TestEmptyMessageLite is used to test unknown fields support in lite mode.
@@ -1296,118 +1292,106 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var fixed32: Int32 {
-    get {return _storage._fixed32 ?? 0}
-    set {_uniqueStorage()._fixed32 = newValue}
+    get {return _fixed32 ?? 0}
+    set {_fixed32 = newValue}
   }
   /// Returns true if `fixed32` has been explicitly set.
-  var hasFixed32: Bool {return _storage._fixed32 != nil}
+  var hasFixed32: Bool {return self._fixed32 != nil}
   /// Clears the value of `fixed32`. Subsequent reads from it will return its default value.
-  mutating func clearFixed32() {_uniqueStorage()._fixed32 = nil}
+  mutating func clearFixed32() {self._fixed32 = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
-  var packedInt32: [Int32] {
-    get {return _storage._packedInt32}
-    set {_uniqueStorage()._packedInt32 = newValue}
-  }
+  var packedInt32: [Int32] = []
 
   var optionalEnum: ProtobufUnittest_ForeignEnumLite {
-    get {return _storage._optionalEnum ?? .foreignLiteFoo}
-    set {_uniqueStorage()._optionalEnum = newValue}
+    get {return _optionalEnum ?? .foreignLiteFoo}
+    set {_optionalEnum = newValue}
   }
   /// Returns true if `optionalEnum` has been explicitly set.
-  var hasOptionalEnum: Bool {return _storage._optionalEnum != nil}
+  var hasOptionalEnum: Bool {return self._optionalEnum != nil}
   /// Clears the value of `optionalEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalEnum() {_uniqueStorage()._optionalEnum = nil}
+  mutating func clearOptionalEnum() {self._optionalEnum = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
-    set {_uniqueStorage()._optionalBytes = newValue}
+    get {return _optionalBytes ?? SwiftProtobuf.Internal.emptyData}
+    set {_optionalBytes = newValue}
   }
   /// Returns true if `optionalBytes` has been explicitly set.
-  var hasOptionalBytes: Bool {return _storage._optionalBytes != nil}
+  var hasOptionalBytes: Bool {return self._optionalBytes != nil}
   /// Clears the value of `optionalBytes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBytes() {_uniqueStorage()._optionalBytes = nil}
+  mutating func clearOptionalBytes() {self._optionalBytes = nil}
 
   var optionalMessage: ProtobufUnittest_ForeignMessageLite {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_ForeignMessageLite()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_ForeignMessageLite()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
   var optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var stringStringMap: Dictionary<String,String> {
-    get {return _storage._stringStringMap}
-    set {_uniqueStorage()._stringStringMap = newValue}
-  }
+  var stringStringMap: Dictionary<String,String> = [:]
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
+      if case .oneofTestAllTypes(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
+    set {oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1443,7 +1427,13 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _fixed32: Int32? = nil
+  fileprivate var _optionalEnum: ProtobufUnittest_ForeignEnumLite? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _optionalBytes: Data? = nil
+  fileprivate var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestOneofParsingLite {
@@ -1451,81 +1441,78 @@ struct ProtobufUnittest_TestOneofParsingLite {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField? = nil
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._oneofField {return v}
+      if case .oneofInt32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofInt32(newValue)}
+    set {oneofField = .oneofInt32(newValue)}
   }
 
   var oneofSubmessage: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofSubmessage(let v)? = _storage._oneofField {return v}
+      if case .oneofSubmessage(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {_uniqueStorage()._oneofField = .oneofSubmessage(newValue)}
+    set {oneofField = .oneofSubmessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return Data([100, 101, 102, 97, 117, 108, 116, 32, 98, 121, 116, 101, 115])
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var oneofStringCord: String {
     get {
-      if case .oneofStringCord(let v)? = _storage._oneofField {return v}
+      if case .oneofStringCord(let v)? = oneofField {return v}
       return "default Cord"
     }
-    set {_uniqueStorage()._oneofField = .oneofStringCord(newValue)}
+    set {oneofField = .oneofStringCord(newValue)}
   }
 
   var oneofBytesCord: Data {
     get {
-      if case .oneofBytesCord(let v)? = _storage._oneofField {return v}
+      if case .oneofBytesCord(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytesCord(newValue)}
+    set {oneofField = .oneofBytesCord(newValue)}
   }
 
   var oneofStringStringPiece: String {
     get {
-      if case .oneofStringStringPiece(let v)? = _storage._oneofField {return v}
+      if case .oneofStringStringPiece(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofStringStringPiece(newValue)}
+    set {oneofField = .oneofStringStringPiece(newValue)}
   }
 
   var oneofBytesStringPiece: Data {
     get {
-      if case .oneofBytesStringPiece(let v)? = _storage._oneofField {return v}
+      if case .oneofBytesStringPiece(let v)? = oneofField {return v}
       return Data([100, 101, 102, 97, 117, 108, 116, 32, 83, 116, 114, 105, 110, 103, 80, 105, 101, 99, 101])
     }
-    set {_uniqueStorage()._oneofField = .oneofBytesStringPiece(newValue)}
+    set {oneofField = .oneofBytesStringPiece(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_V2EnumLite {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {return v}
+      if case .oneofEnum(let v)? = oneofField {return v}
       return .v2First
     }
-    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
+    set {oneofField = .oneofEnum(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1543,8 +1530,6 @@ struct ProtobufUnittest_TestOneofParsingLite {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// The following four messages are set up to test for wire compatibility between
@@ -4756,95 +4741,53 @@ extension ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftPro
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _requiredAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-    var _optionalAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-    var _repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] = []
-    var _optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup? = nil
-    var _repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _requiredAllTypes = source._requiredAllTypes
-      _optionalAllTypes = source._optionalAllTypes
-      _repeatedAllTypes = source._repeatedAllTypes
-      _optionalGroup = source._optionalGroup
-      _repeatedGroup = source._repeatedGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredAllTypes == nil {return false}
-      return true
-    }
+    if self._requiredAllTypes == nil {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._requiredAllTypes)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._optionalAllTypes)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
-        case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._requiredAllTypes)
+      case 2: try decoder.decodeSingularMessageField(value: &self._optionalAllTypes)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAllTypes)
+      case 10: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 20: try decoder.decodeRepeatedGroupField(value: &self.repeatedGroup)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._requiredAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._optionalAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAllTypes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAllTypes, fieldNumber: 3)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
-      }
-      if !_storage._repeatedGroup.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._repeatedGroup, fieldNumber: 20)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._requiredAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._optionalAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAllTypes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAllTypes, fieldNumber: 3)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
+    }
+    if !self.repeatedGroup.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.repeatedGroup, fieldNumber: 20)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite, rhs: ProtobufUnittest_TestParsingMergeLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._requiredAllTypes != rhs_storage._requiredAllTypes {return false}
-        if _storage._optionalAllTypes != rhs_storage._optionalAllTypes {return false}
-        if _storage._repeatedAllTypes != rhs_storage._repeatedAllTypes {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._repeatedGroup != rhs_storage._repeatedGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._requiredAllTypes != rhs._requiredAllTypes {return false}
+    if lhs._optionalAllTypes != rhs._optionalAllTypes {return false}
+    if lhs.repeatedAllTypes != rhs.repeatedAllTypes {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.repeatedGroup != rhs.repeatedGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -4922,56 +4865,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1: 
     11: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -4983,56 +4894,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2: 
     21: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5044,56 +4923,24 @@ extension ProtobufUnittest_TestParsingMergeLite.OptionalGroup: SwiftProtobuf.Mes
     11: .standard(proto: "optional_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroupAllTypes = source._optionalGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._optionalGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._optionalGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._optionalGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.OptionalGroup, rhs: ProtobufUnittest_TestParsingMergeLite.OptionalGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroupAllTypes != rhs_storage._optionalGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroupAllTypes != rhs._optionalGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5105,56 +4952,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedGroup: SwiftProtobuf.Mes
     21: .standard(proto: "repeated_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _repeatedGroupAllTypes = source._repeatedGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._repeatedGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._repeatedGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._repeatedGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._repeatedGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedGroup, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._repeatedGroupAllTypes != rhs_storage._repeatedGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._repeatedGroupAllTypes != rhs._repeatedGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5307,164 +5122,112 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
     536870014: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _fixed32: Int32? = nil
-    var _repeatedInt32: [Int32] = []
-    var _packedInt32: [Int32] = []
-    var _optionalEnum: ProtobufUnittest_ForeignEnumLite? = nil
-    var _optionalString: String? = nil
-    var _optionalBytes: Data? = nil
-    var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
-    var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
-    var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _fixed32 = source._fixed32
-      _repeatedInt32 = source._repeatedInt32
-      _packedInt32 = source._packedInt32
-      _optionalEnum = source._optionalEnum
-      _optionalString = source._optionalString
-      _optionalBytes = source._optionalBytes
-      _optionalMessage = source._optionalMessage
-      _optionalGroup = source._optionalGroup
-      _stringStringMap = source._stringStringMap
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 536870000: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 536870001: try decoder.decodeSingularInt32Field(value: &_storage._fixed32)
-        case 536870002: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        case 536870003: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
-        case 536870004: try decoder.decodeSingularEnumField(value: &_storage._optionalEnum)
-        case 536870005: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 536870006: try decoder.decodeSingularBytesField(value: &_storage._optionalBytes)
-        case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-        case 536870011:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 536870012:
-          var v: ProtobufUnittest_TestAllTypesLite?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofTestAllTypes(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofTestAllTypes(v)}
-        case 536870013:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 536870014:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 536860000..<536870000:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 536870000: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 536870001: try decoder.decodeSingularInt32Field(value: &self._fixed32)
+      case 536870002: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      case 536870003: try decoder.decodeRepeatedInt32Field(value: &self.packedInt32)
+      case 536870004: try decoder.decodeSingularEnumField(value: &self._optionalEnum)
+      case 536870005: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 536870006: try decoder.decodeSingularBytesField(value: &self._optionalBytes)
+      case 536870007: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 536870008: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap)
+      case 536870011:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 536870012:
+        var v: ProtobufUnittest_TestAllTypesLite?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofTestAllTypes(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofTestAllTypes(v)}
+      case 536870013:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 536870014:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 536860000..<536870000:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
-      }
-      if let v = _storage._fixed32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 536870002)
-      }
-      if !_storage._packedInt32.isEmpty {
-        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 536870003)
-      }
-      if let v = _storage._optionalEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
-      }
-      if let v = _storage._optionalBytes {
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
-      }
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
-      }
-      if !_storage._stringStringMap.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
-      }
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-      case .oneofTestAllTypes(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      case nil: break
-      }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
+    }
+    if let v = self._fixed32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 536870002)
+    }
+    if !self.packedInt32.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.packedInt32, fieldNumber: 536870003)
+    }
+    if let v = self._optionalEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
+    }
+    if let v = self._optionalBytes {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
+    }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
+    }
+    if !self.stringStringMap.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.stringStringMap, fieldNumber: 536870010)
+    }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+    case .oneofTestAllTypes(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite, rhs: ProtobufUnittest_TestHugeFieldNumbersLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._fixed32 != rhs_storage._fixed32 {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
-        if _storage._optionalEnum != rhs_storage._optionalEnum {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._optionalBytes != rhs_storage._optionalBytes {return false}
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._stringStringMap != rhs_storage._stringStringMap {return false}
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._fixed32 != rhs._fixed32 {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
+    if lhs.packedInt32 != rhs.packedInt32 {return false}
+    if lhs._optionalEnum != rhs._optionalEnum {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._optionalBytes != rhs._optionalBytes {return false}
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.stringStringMap != rhs.stringStringMap {return false}
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -5514,121 +5277,89 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
     9: .standard(proto: "oneof_enum"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofInt32(v)}
-        case 2:
-          var v: ProtobufUnittest_TestAllTypesLite?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofSubmessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofSubmessage(v)}
-        case 3:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 4:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 5:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofStringCord(v)}
-        case 6:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytesCord(v)}
-        case 7:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofStringStringPiece(v)}
-        case 8:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytesStringPiece(v)}
-        case 9:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_V2EnumLite?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofInt32(v)}
+      case 2:
+        var v: ProtobufUnittest_TestAllTypesLite?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofSubmessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofSubmessage(v)}
+      case 3:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 4:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 5:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofStringCord(v)}
+      case 6:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytesCord(v)}
+      case 7:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofStringStringPiece(v)}
+      case 8:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytesStringPiece(v)}
+      case 9:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_V2EnumLite?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.oneofField = .oneofEnum(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._oneofField {
-      case .oneofInt32(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .oneofSubmessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
-      case .oneofStringCord(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-      case .oneofBytesCord(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 6)
-      case .oneofStringStringPiece(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      case .oneofBytesStringPiece(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 8)
-      case .oneofEnum(let v)?:
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 9)
-      case nil: break
-      }
+    switch self.oneofField {
+    case .oneofInt32(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .oneofSubmessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
+    case .oneofStringCord(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    case .oneofBytesCord(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 6)
+    case .oneofStringStringPiece(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    case .oneofBytesStringPiece(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 8)
+    case .oneofEnum(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 9)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneofParsingLite, rhs: ProtobufUnittest_TestOneofParsingLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -59,29 +59,30 @@ struct ProtobufUnittest_TestLiteImportsNonlite {
   // methods supported on all messages.
 
   var message: ProtobufUnittest_TestAllTypes {
-    get {return _storage._message ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._message = newValue}
+    get {return _message ?? ProtobufUnittest_TestAllTypes()}
+    set {_message = newValue}
   }
   /// Returns true if `message` has been explicitly set.
-  var hasMessage: Bool {return _storage._message != nil}
+  var hasMessage: Bool {return self._message != nil}
   /// Clears the value of `message`. Subsequent reads from it will return its default value.
-  mutating func clearMessage() {_uniqueStorage()._message = nil}
+  mutating func clearMessage() {self._message = nil}
 
   /// Verifies that transitive required fields generates valid code.
   var messageWithRequired: ProtobufUnittest_TestRequired {
-    get {return _storage._messageWithRequired ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._messageWithRequired = newValue}
+    get {return _messageWithRequired ?? ProtobufUnittest_TestRequired()}
+    set {_messageWithRequired = newValue}
   }
   /// Returns true if `messageWithRequired` has been explicitly set.
-  var hasMessageWithRequired: Bool {return _storage._messageWithRequired != nil}
+  var hasMessageWithRequired: Bool {return self._messageWithRequired != nil}
   /// Clears the value of `messageWithRequired`. Subsequent reads from it will return its default value.
-  mutating func clearMessageWithRequired() {_uniqueStorage()._messageWithRequired = nil}
+  mutating func clearMessageWithRequired() {self._messageWithRequired = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _message: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _messageWithRequired: ProtobufUnittest_TestRequired? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -95,70 +96,34 @@ extension ProtobufUnittest_TestLiteImportsNonlite: SwiftProtobuf.Message, SwiftP
     2: .standard(proto: "message_with_required"),
   ]
 
-  fileprivate class _StorageClass {
-    var _message: ProtobufUnittest_TestAllTypes? = nil
-    var _messageWithRequired: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _message = source._message
-      _messageWithRequired = source._messageWithRequired
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageWithRequired, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageWithRequired, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._message)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._messageWithRequired)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._message)
+      case 2: try decoder.decodeSingularMessageField(value: &self._messageWithRequired)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._message {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._messageWithRequired {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if let v = self._message {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if let v = self._messageWithRequired {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestLiteImportsNonlite, rhs: ProtobufUnittest_TestLiteImportsNonlite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._message != rhs_storage._message {return false}
-        if _storage._messageWithRequired != rhs_storage._messageWithRequired {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._message != rhs._message {return false}
+    if lhs._messageWithRequired != rhs._messageWithRequired {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -62,19 +62,19 @@ struct ProtobufUnittest_TestMessageSetContainer {
   // methods supported on all messages.
 
   var messageSet: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._messageSet = newValue}
+    get {return _messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_messageSet = newValue}
   }
   /// Returns true if `messageSet` has been explicitly set.
-  var hasMessageSet: Bool {return _storage._messageSet != nil}
+  var hasMessageSet: Bool {return self._messageSet != nil}
   /// Clears the value of `messageSet`. Subsequent reads from it will return its default value.
-  mutating func clearMessageSet() {_uniqueStorage()._messageSet = nil}
+  mutating func clearMessageSet() {self._messageSet = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 }
 
 struct ProtobufUnittest_TestMessageSetExtension1 {
@@ -83,37 +83,39 @@ struct ProtobufUnittest_TestMessageSetExtension1 {
   // methods supported on all messages.
 
   var i: Int32 {
-    get {return _storage._i ?? 0}
-    set {_uniqueStorage()._i = newValue}
+    get {return _i ?? 0}
+    set {_i = newValue}
   }
   /// Returns true if `i` has been explicitly set.
-  var hasI: Bool {return _storage._i != nil}
+  var hasI: Bool {return self._i != nil}
   /// Clears the value of `i`. Subsequent reads from it will return its default value.
-  mutating func clearI() {_uniqueStorage()._i = nil}
+  mutating func clearI() {self._i = nil}
 
   var recursive: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._recursive ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._recursive = newValue}
+    get {return _recursive ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_recursive = newValue}
   }
   /// Returns true if `recursive` has been explicitly set.
-  var hasRecursive: Bool {return _storage._recursive != nil}
+  var hasRecursive: Bool {return self._recursive != nil}
   /// Clears the value of `recursive`. Subsequent reads from it will return its default value.
-  mutating func clearRecursive() {_uniqueStorage()._recursive = nil}
+  mutating func clearRecursive() {self._recursive = nil}
 
   var testAliasing: String {
-    get {return _storage._testAliasing ?? String()}
-    set {_uniqueStorage()._testAliasing = newValue}
+    get {return _testAliasing ?? String()}
+    set {_testAliasing = newValue}
   }
   /// Returns true if `testAliasing` has been explicitly set.
-  var hasTestAliasing: Bool {return _storage._testAliasing != nil}
+  var hasTestAliasing: Bool {return self._testAliasing != nil}
   /// Clears the value of `testAliasing`. Subsequent reads from it will return its default value.
-  mutating func clearTestAliasing() {_uniqueStorage()._testAliasing = nil}
+  mutating func clearTestAliasing() {self._testAliasing = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _i: Int32? = nil
+  fileprivate var _recursive: Proto2WireformatUnittest_TestMessageSet? = nil
+  fileprivate var _testAliasing: String? = nil
 }
 
 struct ProtobufUnittest_TestMessageSetExtension2 {
@@ -254,63 +256,29 @@ extension ProtobufUnittest_TestMessageSetContainer: SwiftProtobuf.Message, Swift
     1: .standard(proto: "message_set"),
   ]
 
-  fileprivate class _StorageClass {
-    var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _messageSet = source._messageSet
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageSet, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._messageSet)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._messageSet)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._messageSet {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMessageSetContainer, rhs: ProtobufUnittest_TestMessageSetContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._messageSet != rhs_storage._messageSet {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._messageSet != rhs._messageSet {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -324,77 +292,39 @@ extension ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message, Swif
     17: .standard(proto: "test_aliasing"),
   ]
 
-  fileprivate class _StorageClass {
-    var _i: Int32? = nil
-    var _recursive: Proto2WireformatUnittest_TestMessageSet? = nil
-    var _testAliasing: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _i = source._i
-      _recursive = source._recursive
-      _testAliasing = source._testAliasing
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._recursive, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._recursive, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 15: try decoder.decodeSingularInt32Field(value: &_storage._i)
-        case 16: try decoder.decodeSingularMessageField(value: &_storage._recursive)
-        case 17: try decoder.decodeSingularStringField(value: &_storage._testAliasing)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 15: try decoder.decodeSingularInt32Field(value: &self._i)
+      case 16: try decoder.decodeSingularMessageField(value: &self._recursive)
+      case 17: try decoder.decodeSingularStringField(value: &self._testAliasing)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._i {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 15)
-      }
-      if let v = _storage._recursive {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-      }
-      if let v = _storage._testAliasing {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 17)
-      }
+    if let v = self._i {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 15)
+    }
+    if let v = self._recursive {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+    }
+    if let v = self._testAliasing {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 17)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMessageSetExtension1, rhs: ProtobufUnittest_TestMessageSetExtension1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._i != rhs_storage._i {return false}
-        if _storage._recursive != rhs_storage._recursive {return false}
-        if _storage._testAliasing != rhs_storage._testAliasing {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._i != rhs._i {return false}
+    if lhs._recursive != rhs._recursive {return false}
+    if lhs._testAliasing != rhs._testAliasing {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -74,19 +74,19 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer {
   // methods supported on all messages.
 
   var messageSet: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._messageSet = newValue}
+    get {return _messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_messageSet = newValue}
   }
   /// Returns true if `messageSet` has been explicitly set.
-  var hasMessageSet: Bool {return _storage._messageSet != nil}
+  var hasMessageSet: Bool {return self._messageSet != nil}
   /// Clears the value of `messageSet`. Subsequent reads from it will return its default value.
-  mutating func clearMessageSet() {_uniqueStorage()._messageSet = nil}
+  mutating func clearMessageSet() {self._messageSet = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -124,63 +124,29 @@ extension Proto2WireformatUnittest_TestMessageSetWireFormatContainer: SwiftProto
     1: .standard(proto: "message_set"),
   ]
 
-  fileprivate class _StorageClass {
-    var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _messageSet = source._messageSet
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageSet, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._messageSet)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._messageSet)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._messageSet {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Proto2WireformatUnittest_TestMessageSetWireFormatContainer, rhs: Proto2WireformatUnittest_TestMessageSetWireFormatContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._messageSet != rhs_storage._messageSet {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._messageSet != rhs._messageSet {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -843,19 +843,19 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage {
   // methods supported on all messages.
 
   var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
-    get {return _storage._arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
-    set {_uniqueStorage()._arenaMessage = newValue}
+    get {return _arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
+    set {_arenaMessage = newValue}
   }
   /// Returns true if `arenaMessage` has been explicitly set.
-  var hasArenaMessage: Bool {return _storage._arenaMessage != nil}
+  var hasArenaMessage: Bool {return self._arenaMessage != nil}
   /// Clears the value of `arenaMessage`. Subsequent reads from it will return its default value.
-  mutating func clearArenaMessage() {_uniqueStorage()._arenaMessage = nil}
+  mutating func clearArenaMessage() {self._arenaMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
 }
 
 struct ProtobufUnittestNoArena_OneString {
@@ -1695,56 +1695,24 @@ extension ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, Swi
     1: .standard(proto: "arena_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _arenaMessage = source._arenaMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._arenaMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._arenaMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._arenaMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._arenaMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittestNoArena_TestNoArenaMessage, rhs: ProtobufUnittestNoArena_TestNoArenaMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._arenaMessage != rhs_storage._arenaMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._arenaMessage != rhs._arenaMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -468,19 +468,19 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required {
   // methods supported on all messages.
 
   var proto2: ProtobufUnittest_TestRequired {
-    get {return _storage._proto2 ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._proto2 = newValue}
+    get {return _proto2 ?? ProtobufUnittest_TestRequired()}
+    set {_proto2 = newValue}
   }
   /// Returns true if `proto2` has been explicitly set.
-  var hasProto2: Bool {return _storage._proto2 != nil}
+  var hasProto2: Bool {return self._proto2 != nil}
   /// Clears the value of `proto2`. Subsequent reads from it will return its default value.
-  mutating func clearProto2() {_uniqueStorage()._proto2 = nil}
+  mutating func clearProto2() {self._proto2 = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _proto2: ProtobufUnittest_TestRequired? = nil
 }
 
 /// Define these after TestAllTypes to make sure the compiler can handle
@@ -1014,63 +1014,29 @@ extension Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Messag
     1: .same(proto: "proto2"),
   ]
 
-  fileprivate class _StorageClass {
-    var _proto2: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _proto2 = source._proto2
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._proto2, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._proto2, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._proto2)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._proto2)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._proto2 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._proto2 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Proto2NofieldpresenceUnittest_TestProto2Required, rhs: Proto2NofieldpresenceUnittest_TestProto2Required) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._proto2 != rhs_storage._proto2 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._proto2 != rhs._proto2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -61,42 +61,39 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var i: Int32 {
-    get {return _storage._i ?? 0}
-    set {_uniqueStorage()._i = newValue}
+    get {return _i ?? 0}
+    set {_i = newValue}
   }
   /// Returns true if `i` has been explicitly set.
-  var hasI: Bool {return _storage._i != nil}
+  var hasI: Bool {return self._i != nil}
   /// Clears the value of `i`. Subsequent reads from it will return its default value.
-  mutating func clearI() {_uniqueStorage()._i = nil}
+  mutating func clearI() {self._i = nil}
 
   var msg: ProtobufUnittest_ForeignMessage {
-    get {return _storage._msg ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._msg = newValue}
+    get {return _msg ?? ProtobufUnittest_ForeignMessage()}
+    set {_msg = newValue}
   }
   /// Returns true if `msg` has been explicitly set.
-  var hasMsg: Bool {return _storage._msg != nil}
+  var hasMsg: Bool {return self._msg != nil}
   /// Clears the value of `msg`. Subsequent reads from it will return its default value.
-  mutating func clearMsg() {_uniqueStorage()._msg = nil}
+  mutating func clearMsg() {self._msg = nil}
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo? = nil
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v)? = _storage._foo {return v}
+      if case .integerField(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .integerField(newValue)}
+    set {foo = .integerField(newValue)}
   }
 
   var stringField: String {
     get {
-      if case .stringField(let v)? = _storage._foo {return v}
+      if case .stringField(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .stringField(newValue)}
+    set {foo = .stringField(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -109,7 +106,8 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _i: Int32? = nil
+  fileprivate var _msg: ProtobufUnittest_ForeignMessage? = nil
 }
 
 struct ProtobufUnittest_TestRequiredOptimizedForSize {
@@ -139,19 +137,19 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize {
   // methods supported on all messages.
 
   var o: ProtobufUnittest_TestRequiredOptimizedForSize {
-    get {return _storage._o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
-    set {_uniqueStorage()._o = newValue}
+    get {return _o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
+    set {_o = newValue}
   }
   /// Returns true if `o` has been explicitly set.
-  var hasO: Bool {return _storage._o != nil}
+  var hasO: Bool {return self._o != nil}
   /// Clears the value of `o`. Subsequent reads from it will return its default value.
-  mutating func clearO() {_uniqueStorage()._o = nil}
+  mutating func clearO() {self._o = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
 }
 
 // MARK: - Extension support defined in unittest_optimize_for.proto.
@@ -226,91 +224,55 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftPro
     3: .standard(proto: "string_field"),
   ]
 
-  fileprivate class _StorageClass {
-    var _i: Int32? = nil
-    var _msg: ProtobufUnittest_ForeignMessage? = nil
-    var _foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _i = source._i
-      _msg = source._msg
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._i)
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .integerField(v)}
-        case 3:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .stringField(v)}
-        case 19: try decoder.decodeSingularMessageField(value: &_storage._msg)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._i)
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .integerField(v)}
+      case 3:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .stringField(v)}
+      case 19: try decoder.decodeSingularMessageField(value: &self._msg)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._i {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      switch _storage._foo {
-      case .integerField(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      case .stringField(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case nil: break
-      }
-      if let v = _storage._msg {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._i {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
     }
+    switch self.foo {
+    case .integerField(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    case .stringField(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case nil: break
+    }
+    if let v = self._msg {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOptimizedForSize, rhs: ProtobufUnittest_TestOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._i != rhs_storage._i {return false}
-        if _storage._msg != rhs_storage._msg {return false}
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._i != rhs._i {return false}
+    if lhs._msg != rhs._msg {return false}
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -357,63 +319,29 @@ extension ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, 
     1: .same(proto: "o"),
   ]
 
-  fileprivate class _StorageClass {
-    var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _o = source._o
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._o, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._o, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._o)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._o)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._o {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._o {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOptionalOptimizedForSize, rhs: ProtobufUnittest_TestOptionalOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._o != rhs_storage._o {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._o != rhs._o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -258,28 +258,29 @@ struct SDTExternalRefs {
   // methods supported on all messages.
 
   var desc: SwiftProtobuf.Google_Protobuf_DescriptorProto {
-    get {return _storage._desc ?? SwiftProtobuf.Google_Protobuf_DescriptorProto()}
-    set {_uniqueStorage()._desc = newValue}
+    get {return _desc ?? SwiftProtobuf.Google_Protobuf_DescriptorProto()}
+    set {_desc = newValue}
   }
   /// Returns true if `desc` has been explicitly set.
-  var hasDesc: Bool {return _storage._desc != nil}
+  var hasDesc: Bool {return self._desc != nil}
   /// Clears the value of `desc`. Subsequent reads from it will return its default value.
-  mutating func clearDesc() {_uniqueStorage()._desc = nil}
+  mutating func clearDesc() {self._desc = nil}
 
   var ver: Google_Protobuf_Compiler_Version {
-    get {return _storage._ver ?? Google_Protobuf_Compiler_Version()}
-    set {_uniqueStorage()._ver = newValue}
+    get {return _ver ?? Google_Protobuf_Compiler_Version()}
+    set {_ver = newValue}
   }
   /// Returns true if `ver` has been explicitly set.
-  var hasVer: Bool {return _storage._ver != nil}
+  var hasVer: Bool {return self._ver != nil}
   /// Clears the value of `ver`. Subsequent reads from it will return its default value.
-  mutating func clearVer() {_uniqueStorage()._ver = nil}
+  mutating func clearVer() {self._ver = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _desc: SwiftProtobuf.Google_Protobuf_DescriptorProto? = nil
+  fileprivate var _ver: Google_Protobuf_Compiler_Version? = nil
 }
 
 struct SDTScoperForExt {
@@ -661,70 +662,34 @@ extension SDTExternalRefs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
     2: .same(proto: "ver"),
   ]
 
-  fileprivate class _StorageClass {
-    var _desc: SwiftProtobuf.Google_Protobuf_DescriptorProto? = nil
-    var _ver: Google_Protobuf_Compiler_Version? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _desc = source._desc
-      _ver = source._ver
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._desc, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._desc, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._desc)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._ver)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._desc)
+      case 2: try decoder.decodeSingularMessageField(value: &self._ver)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._desc {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._ver {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if let v = self._desc {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if let v = self._ver {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SDTExternalRefs, rhs: SDTExternalRefs) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._desc != rhs_storage._desc {return false}
-        if _storage._ver != rhs_storage._ver {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._desc != rhs._desc {return false}
+    if lhs._ver != rhs._ver {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -41,77 +41,74 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var myString: String {
-    get {return _storage._myString ?? String()}
-    set {_uniqueStorage()._myString = newValue}
+    get {return _myString ?? String()}
+    set {_myString = newValue}
   }
   /// Returns true if `myString` has been explicitly set.
-  var hasMyString: Bool {return _storage._myString != nil}
+  var hasMyString: Bool {return self._myString != nil}
   /// Clears the value of `myString`. Subsequent reads from it will return its default value.
-  mutating func clearMyString() {_uniqueStorage()._myString = nil}
+  mutating func clearMyString() {self._myString = nil}
 
   var myInt: Int64 {
-    get {return _storage._myInt ?? 0}
-    set {_uniqueStorage()._myInt = newValue}
+    get {return _myInt ?? 0}
+    set {_myInt = newValue}
   }
   /// Returns true if `myInt` has been explicitly set.
-  var hasMyInt: Bool {return _storage._myInt != nil}
+  var hasMyInt: Bool {return self._myInt != nil}
   /// Clears the value of `myInt`. Subsequent reads from it will return its default value.
-  mutating func clearMyInt() {_uniqueStorage()._myInt = nil}
+  mutating func clearMyInt() {self._myInt = nil}
 
   var myFloat: Float {
-    get {return _storage._myFloat ?? 0}
-    set {_uniqueStorage()._myFloat = newValue}
+    get {return _myFloat ?? 0}
+    set {_myFloat = newValue}
   }
   /// Returns true if `myFloat` has been explicitly set.
-  var hasMyFloat: Bool {return _storage._myFloat != nil}
+  var hasMyFloat: Bool {return self._myFloat != nil}
   /// Clears the value of `myFloat`. Subsequent reads from it will return its default value.
-  mutating func clearMyFloat() {_uniqueStorage()._myFloat = nil}
+  mutating func clearMyFloat() {self._myFloat = nil}
 
-  var options: OneOf_Options? {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  var options: Swift_Protobuf_TestFieldOrderings.OneOf_Options? = nil
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._options {return v}
+      if case .oneofInt64(let v)? = options {return v}
       return 0
     }
-    set {_uniqueStorage()._options = .oneofInt64(newValue)}
+    set {options = .oneofInt64(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._options {return v}
+      if case .oneofBool(let v)? = options {return v}
       return false
     }
-    set {_uniqueStorage()._options = .oneofBool(newValue)}
+    set {options = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._options {return v}
+      if case .oneofString(let v)? = options {return v}
       return String()
     }
-    set {_uniqueStorage()._options = .oneofString(newValue)}
+    set {options = .oneofString(newValue)}
   }
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._options {return v}
+      if case .oneofInt32(let v)? = options {return v}
       return 0
     }
-    set {_uniqueStorage()._options = .oneofInt32(newValue)}
+    set {options = .oneofInt32(newValue)}
   }
 
   var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -156,7 +153,10 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _myString: String? = nil
+  fileprivate var _myInt: Int64? = nil
+  fileprivate var _myFloat: Float? = nil
+  fileprivate var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
 }
 
 /// These checks how the traverse() generated for a oneof
@@ -356,123 +356,83 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobu
     200: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _myString: String? = nil
-    var _myInt: Int64? = nil
-    var _myFloat: Float? = nil
-    var _options: Swift_Protobuf_TestFieldOrderings.OneOf_Options?
-    var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _myString = source._myString
-      _myInt = source._myInt
-      _myFloat = source._myFloat
-      _options = source._options
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
-        case 9:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._options = .oneofBool(v)}
-        case 10:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._options = .oneofInt32(v)}
-        case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
-        case 60:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Int64?
-          try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._options = .oneofInt64(v)}
-        case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-        case 150:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._options = .oneofString(v)}
-        case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        case 2..<9, 12..<56:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt64Field(value: &self._myInt)
+      case 9:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {self.options = .oneofBool(v)}
+      case 10:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.options = .oneofInt32(v)}
+      case 11: try decoder.decodeSingularStringField(value: &self._myString)
+      case 60:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Int64?
+        try decoder.decodeSingularInt64Field(value: &v)
+        if let v = v {self.options = .oneofInt64(v)}
+      case 101: try decoder.decodeSingularFloatField(value: &self._myFloat)
+      case 150:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.options = .oneofString(v)}
+      case 200: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      case 2..<9, 12..<56:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._myInt {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
-      switch _storage._options {
-      case .oneofBool(let v)?:
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-      case .oneofInt32(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-      case nil: break
-      default: break
-      }
-      if let v = _storage._myString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
-      if case .oneofInt64(let v)? = _storage._options {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-      }
-      if let v = _storage._myFloat {
-        try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
-      }
-      if case .oneofString(let v)? = _storage._options {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-      }
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
-      }
+    if let v = self._myInt {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
+    switch self.options {
+    case .oneofBool(let v)?:
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+    case .oneofInt32(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+    case nil: break
+    default: break
+    }
+    if let v = self._myString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
+    if case .oneofInt64(let v)? = self.options {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+    }
+    if let v = self._myFloat {
+      try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
+    }
+    if case .oneofString(let v)? = self.options {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+    }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Swift_Protobuf_TestFieldOrderings, rhs: Swift_Protobuf_TestFieldOrderings) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._myString != rhs_storage._myString {return false}
-        if _storage._myInt != rhs_storage._myInt {return false}
-        if _storage._myFloat != rhs_storage._myFloat {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._myString != rhs._myString {return false}
+    if lhs._myInt != rhs._myInt {return false}
+    if lhs._myFloat != rhs._myFloat {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -141,27 +141,24 @@ struct SwiftTestNestingGroupsMessage {
   // methods supported on all messages.
 
   var outerA: Int32 {
-    get {return _storage._outerA ?? 0}
-    set {_uniqueStorage()._outerA = newValue}
+    get {return _outerA ?? 0}
+    set {_outerA = newValue}
   }
   /// Returns true if `outerA` has been explicitly set.
-  var hasOuterA: Bool {return _storage._outerA != nil}
+  var hasOuterA: Bool {return self._outerA != nil}
   /// Clears the value of `outerA`. Subsequent reads from it will return its default value.
-  mutating func clearOuterA() {_uniqueStorage()._outerA = nil}
+  mutating func clearOuterA() {self._outerA = nil}
 
   var subGroup1: SwiftTestNestingGroupsMessage.SubGroup1 {
-    get {return _storage._subGroup1 ?? SwiftTestNestingGroupsMessage.SubGroup1()}
-    set {_uniqueStorage()._subGroup1 = newValue}
+    get {return _subGroup1 ?? SwiftTestNestingGroupsMessage.SubGroup1()}
+    set {_subGroup1 = newValue}
   }
   /// Returns true if `subGroup1` has been explicitly set.
-  var hasSubGroup1: Bool {return _storage._subGroup1 != nil}
+  var hasSubGroup1: Bool {return self._subGroup1 != nil}
   /// Clears the value of `subGroup1`. Subsequent reads from it will return its default value.
-  mutating func clearSubGroup1() {_uniqueStorage()._subGroup1 = nil}
+  mutating func clearSubGroup1() {self._subGroup1 = nil}
 
-  var subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] {
-    get {return _storage._subGroup3}
-    set {_uniqueStorage()._subGroup3 = newValue}
-  }
+  var subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -171,22 +168,22 @@ struct SwiftTestNestingGroupsMessage {
     // methods supported on all messages.
 
     var sub1A: Int32 {
-      get {return _storage._sub1A ?? 0}
-      set {_uniqueStorage()._sub1A = newValue}
+      get {return _sub1A ?? 0}
+      set {_sub1A = newValue}
     }
     /// Returns true if `sub1A` has been explicitly set.
-    var hasSub1A: Bool {return _storage._sub1A != nil}
+    var hasSub1A: Bool {return self._sub1A != nil}
     /// Clears the value of `sub1A`. Subsequent reads from it will return its default value.
-    mutating func clearSub1A() {_uniqueStorage()._sub1A = nil}
+    mutating func clearSub1A() {self._sub1A = nil}
 
     var subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2 {
-      get {return _storage._subGroup2 ?? SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2()}
-      set {_uniqueStorage()._subGroup2 = newValue}
+      get {return _subGroup2 ?? SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2()}
+      set {_subGroup2 = newValue}
     }
     /// Returns true if `subGroup2` has been explicitly set.
-    var hasSubGroup2: Bool {return _storage._subGroup2 != nil}
+    var hasSubGroup2: Bool {return self._subGroup2 != nil}
     /// Clears the value of `subGroup2`. Subsequent reads from it will return its default value.
-    mutating func clearSubGroup2() {_uniqueStorage()._subGroup2 = nil}
+    mutating func clearSubGroup2() {self._subGroup2 = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -213,7 +210,8 @@ struct SwiftTestNestingGroupsMessage {
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _sub1A: Int32? = nil
+    fileprivate var _subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2? = nil
   }
 
   struct SubGroup3 {
@@ -262,7 +260,8 @@ struct SwiftTestNestingGroupsMessage {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _outerA: Int32? = nil
+  fileprivate var _subGroup1: SwiftTestNestingGroupsMessage.SubGroup1? = nil
 }
 
 // MARK: - Extension support defined in unittest_swift_groups.proto.
@@ -455,70 +454,34 @@ extension SwiftTestNestingGroupsMessage: SwiftProtobuf.Message, SwiftProtobuf._M
     3: .unique(proto: "SubGroup3", json: "subgroup3"),
   ]
 
-  fileprivate class _StorageClass {
-    var _outerA: Int32? = nil
-    var _subGroup1: SwiftTestNestingGroupsMessage.SubGroup1? = nil
-    var _subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _outerA = source._outerA
-      _subGroup1 = source._subGroup1
-      _subGroup3 = source._subGroup3
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._outerA)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._subGroup1)
-        case 3: try decoder.decodeRepeatedGroupField(value: &_storage._subGroup3)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._outerA)
+      case 2: try decoder.decodeSingularGroupField(value: &self._subGroup1)
+      case 3: try decoder.decodeRepeatedGroupField(value: &self.subGroup3)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._outerA {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._subGroup1 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
-      if !_storage._subGroup3.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._subGroup3, fieldNumber: 3)
-      }
+    if let v = self._outerA {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._subGroup1 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
+    }
+    if !self.subGroup3.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.subGroup3, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftTestNestingGroupsMessage, rhs: SwiftTestNestingGroupsMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._outerA != rhs_storage._outerA {return false}
-        if _storage._subGroup1 != rhs_storage._subGroup1 {return false}
-        if _storage._subGroup3 != rhs_storage._subGroup3 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._outerA != rhs._outerA {return false}
+    if lhs._subGroup1 != rhs._subGroup1 {return false}
+    if lhs.subGroup3 != rhs.subGroup3 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -531,63 +494,29 @@ extension SwiftTestNestingGroupsMessage.SubGroup1: SwiftProtobuf.Message, SwiftP
     2: .unique(proto: "SubGroup2", json: "subgroup2"),
   ]
 
-  fileprivate class _StorageClass {
-    var _sub1A: Int32? = nil
-    var _subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _sub1A = source._sub1A
-      _subGroup2 = source._subGroup2
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._sub1A)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._subGroup2)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._sub1A)
+      case 2: try decoder.decodeSingularGroupField(value: &self._subGroup2)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._sub1A {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._subGroup2 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
+    if let v = self._sub1A {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._subGroup2 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftTestNestingGroupsMessage.SubGroup1, rhs: SwiftTestNestingGroupsMessage.SubGroup1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._sub1A != rhs_storage._sub1A {return false}
-        if _storage._subGroup2 != rhs_storage._subGroup2 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._sub1A != rhs._sub1A {return false}
+    if lhs._subGroup2 != rhs._subGroup2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -96,41 +96,38 @@ struct ProtobufUnittest_OneOfContainer {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var option: OneOf_Option? {
-    get {return _storage._option}
-    set {_uniqueStorage()._option = newValue}
-  }
+  var option: ProtobufUnittest_OneOfContainer.OneOf_Option? = nil
 
   var option1: ProtobufUnittest_OneOfOptionMessage1 {
     get {
-      if case .option1(let v)? = _storage._option {return v}
+      if case .option1(let v)? = option {return v}
       return ProtobufUnittest_OneOfOptionMessage1()
     }
-    set {_uniqueStorage()._option = .option1(newValue)}
+    set {option = .option1(newValue)}
   }
 
   var option2: ProtobufUnittest_OneOfOptionMessage2 {
     get {
-      if case .option2(let v)? = _storage._option {return v}
+      if case .option2(let v)? = option {return v}
       return ProtobufUnittest_OneOfOptionMessage2()
     }
-    set {_uniqueStorage()._option = .option2(newValue)}
+    set {option = .option2(newValue)}
   }
 
   var option3: ProtobufUnittest_OneOfContainer.Option3 {
     get {
-      if case .option3(let v)? = _storage._option {return v}
+      if case .option3(let v)? = option {return v}
       return ProtobufUnittest_OneOfContainer.Option3()
     }
-    set {_uniqueStorage()._option = .option3(newValue)}
+    set {option = .option3(newValue)}
   }
 
   var option4: Int32 {
     get {
-      if case .option4(let v)? = _storage._option {return v}
+      if case .option4(let v)? = option {return v}
       return 0
     }
-    set {_uniqueStorage()._option = .option4(newValue)}
+    set {option = .option4(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -174,8 +171,6 @@ struct ProtobufUnittest_OneOfContainer {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -259,104 +254,70 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
     6: .same(proto: "option4"),
   ]
 
-  fileprivate class _StorageClass {
-    var _option: ProtobufUnittest_OneOfContainer.OneOf_Option?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _option = source._option
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._option {
-      case .option1(let v)?: if !v.isInitialized {return false}
-      case .option2(let v)?: if !v.isInitialized {return false}
-      case .option3(let v)?: if !v.isInitialized {return false}
-      default: break
-      }
-      return true
+    switch self.option {
+    case .option1(let v)?: if !v.isInitialized {return false}
+    case .option2(let v)?: if !v.isInitialized {return false}
+    case .option3(let v)?: if !v.isInitialized {return false}
+    default: break
     }
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          var v: ProtobufUnittest_OneOfOptionMessage1?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option1(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._option = .option1(v)}
-        case 2:
-          var v: ProtobufUnittest_OneOfOptionMessage2?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option2(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._option = .option2(v)}
-        case 3:
-          var v: ProtobufUnittest_OneOfContainer.Option3?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option3(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._option = .option3(v)}
-        case 6:
-          if _storage._option != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._option = .option4(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        var v: ProtobufUnittest_OneOfOptionMessage1?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option1(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.option = .option1(v)}
+      case 2:
+        var v: ProtobufUnittest_OneOfOptionMessage2?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option2(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.option = .option2(v)}
+      case 3:
+        var v: ProtobufUnittest_OneOfContainer.Option3?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option3(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.option = .option3(v)}
+      case 6:
+        if self.option != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.option = .option4(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._option {
-      case .option1(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      case .option2(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      case .option3(let v)?:
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-      case .option4(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-      case nil: break
-      }
+    switch self.option {
+    case .option1(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    case .option2(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    case .option3(let v)?:
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
+    case .option4(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_OneOfContainer, rhs: ProtobufUnittest_OneOfContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._option != rhs_storage._option {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.option != rhs.option {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_oneof_merging.pb.swift
+++ b/Reference/unittest_swift_oneof_merging.pb.swift
@@ -42,41 +42,38 @@ struct SwiftUnittest_TestMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: SwiftUnittest_TestMessage.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: SwiftUnittest_TestMessage.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
+      if case .oneofNestedMessage(let v)? = oneofField {return v}
       return SwiftUnittest_TestMessage.NestedMessage()
     }
-    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
+    set {oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -130,8 +127,6 @@ struct SwiftUnittest_TestMessage {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct SwiftUnittest_TestParsingMerge {
@@ -140,18 +135,15 @@ struct SwiftUnittest_TestParsingMerge {
   // methods supported on all messages.
 
   var optionalMessage: SwiftUnittest_TestMessage {
-    get {return _storage._optionalMessage ?? SwiftUnittest_TestMessage()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? SwiftUnittest_TestMessage()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [SwiftUnittest_TestMessage] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [SwiftUnittest_TestMessage] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -171,7 +163,7 @@ struct SwiftUnittest_TestParsingMerge {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: SwiftUnittest_TestMessage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -187,86 +179,54 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
     114: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: SwiftUnittest_TestMessage.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 111:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 112:
-          var v: SwiftUnittest_TestMessage.NestedMessage?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofNestedMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
-        case 113:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 114:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 111:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 112:
+        var v: SwiftUnittest_TestMessage.NestedMessage?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofNestedMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofNestedMessage(v)}
+      case 113:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 114:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-      case .oneofNestedMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      case nil: break
-      }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+    case .oneofNestedMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftUnittest_TestMessage, rhs: SwiftUnittest_TestMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -320,63 +280,29 @@ extension SwiftUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf._
     2: .standard(proto: "repeated_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: SwiftUnittest_TestMessage? = nil
-    var _repeatedMessage: [SwiftUnittest_TestMessage] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftUnittest_TestParsingMerge, rhs: SwiftUnittest_TestParsingMerge) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -772,38 +772,40 @@ struct ProtobufUnittest_Msg2NamesUsesStorage {
   // methods supported on all messages.
 
   var isInitialized_p: Int32 {
-    get {return _storage._isInitialized_p ?? 0}
-    set {_uniqueStorage()._isInitialized_p = newValue}
+    get {return _isInitialized_p ?? 0}
+    set {_isInitialized_p = newValue}
   }
   /// Returns true if `isInitialized_p` has been explicitly set.
-  var hasIsInitialized_p: Bool {return _storage._isInitialized_p != nil}
+  var hasIsInitialized_p: Bool {return self._isInitialized_p != nil}
   /// Clears the value of `isInitialized_p`. Subsequent reads from it will return its default value.
-  mutating func clearIsInitialized_p() {_uniqueStorage()._isInitialized_p = nil}
+  mutating func clearIsInitialized_p() {self._isInitialized_p = nil}
 
   var debugDescription_p: Int32 {
-    get {return _storage._debugDescription_p ?? 0}
-    set {_uniqueStorage()._debugDescription_p = newValue}
+    get {return _debugDescription_p ?? 0}
+    set {_debugDescription_p = newValue}
   }
   /// Returns true if `debugDescription_p` has been explicitly set.
-  var hasDebugDescription_p: Bool {return _storage._debugDescription_p != nil}
+  var hasDebugDescription_p: Bool {return self._debugDescription_p != nil}
   /// Clears the value of `debugDescription_p`. Subsequent reads from it will return its default value.
-  mutating func clearDebugDescription_p() {_uniqueStorage()._debugDescription_p = nil}
+  mutating func clearDebugDescription_p() {self._debugDescription_p = nil}
 
   /// Recursive class, forces _StorageClass
   var value: ProtobufUnittest_Msg2UsesStorage {
-    get {return _storage._value ?? ProtobufUnittest_Msg2UsesStorage()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? ProtobufUnittest_Msg2UsesStorage()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  var hasValue: Bool {return _storage._value != nil}
+  var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  mutating func clearValue() {_uniqueStorage()._value = nil}
+  mutating func clearValue() {self._value = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _isInitialized_p: Int32? = nil
+  fileprivate var _debugDescription_p: Int32? = nil
+  fileprivate var _value: ProtobufUnittest_Msg2UsesStorage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -1690,70 +1692,34 @@ extension ProtobufUnittest_Msg2NamesUsesStorage: SwiftProtobuf.Message, SwiftPro
     3: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _isInitialized_p: Int32? = nil
-    var _debugDescription_p: Int32? = nil
-    var _value: ProtobufUnittest_Msg2UsesStorage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _isInitialized_p = source._isInitialized_p
-      _debugDescription_p = source._debugDescription_p
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._isInitialized_p)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._debugDescription_p)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._isInitialized_p)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._debugDescription_p)
+      case 3: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._isInitialized_p {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._debugDescription_p {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._isInitialized_p {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._debugDescription_p {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_Msg2NamesUsesStorage, rhs: ProtobufUnittest_Msg2NamesUsesStorage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._isInitialized_p != rhs_storage._isInitialized_p {return false}
-        if _storage._debugDescription_p != rhs_storage._debugDescription_p {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._isInitialized_p != rhs._isInitialized_p {return false}
+    if lhs._debugDescription_p != rhs._debugDescription_p {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -598,31 +598,25 @@ struct ProtobufUnittest_Msg3NamesUsesStorage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var isInitialized_p: Int32 {
-    get {return _storage._isInitialized_p}
-    set {_uniqueStorage()._isInitialized_p = newValue}
-  }
+  var isInitialized_p: Int32 = 0
 
-  var debugDescription_p: Int32 {
-    get {return _storage._debugDescription_p}
-    set {_uniqueStorage()._debugDescription_p = newValue}
-  }
+  var debugDescription_p: Int32 = 0
 
   /// Recursive class, forces _StorageClass
   var value: ProtobufUnittest_Msg3UsesStorage {
-    get {return _storage._value ?? ProtobufUnittest_Msg3UsesStorage()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? ProtobufUnittest_Msg3UsesStorage()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  var hasValue: Bool {return _storage._value != nil}
+  var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  mutating func clearValue() {_uniqueStorage()._value = nil}
+  mutating func clearValue() {self._value = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _value: ProtobufUnittest_Msg3UsesStorage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -1389,70 +1383,34 @@ extension ProtobufUnittest_Msg3NamesUsesStorage: SwiftProtobuf.Message, SwiftPro
     3: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _isInitialized_p: Int32 = 0
-    var _debugDescription_p: Int32 = 0
-    var _value: ProtobufUnittest_Msg3UsesStorage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _isInitialized_p = source._isInitialized_p
-      _debugDescription_p = source._debugDescription_p
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._isInitialized_p)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._debugDescription_p)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self.isInitialized_p)
+      case 2: try decoder.decodeSingularInt32Field(value: &self.debugDescription_p)
+      case 3: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._isInitialized_p != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._isInitialized_p, fieldNumber: 1)
-      }
-      if _storage._debugDescription_p != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._debugDescription_p, fieldNumber: 2)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if self.isInitialized_p != 0 {
+      try visitor.visitSingularInt32Field(value: self.isInitialized_p, fieldNumber: 1)
+    }
+    if self.debugDescription_p != 0 {
+      try visitor.visitSingularInt32Field(value: self.debugDescription_p, fieldNumber: 2)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_Msg3NamesUsesStorage, rhs: ProtobufUnittest_Msg3NamesUsesStorage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._isInitialized_p != rhs_storage._isInitialized_p {return false}
-        if _storage._debugDescription_p != rhs_storage._debugDescription_p {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.isInitialized_p != rhs.isInitialized_p {return false}
+    if lhs.debugDescription_p != rhs.debugDescription_p {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -206,82 +206,67 @@ struct Conformance_ConformanceRequest {
   /// TODO(haberman): if/when we expand the conformance tests to support proto2,
   /// we will want to include a field that lets the payload/response be a
   /// protobuf_test_messages.proto2.TestAllTypes message instead.
-  var payload: OneOf_Payload? {
-    get {return _storage._payload}
-    set {_uniqueStorage()._payload = newValue}
-  }
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = _storage._payload {return v}
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._payload = .protobufPayload(newValue)}
+    set {payload = .protobufPayload(newValue)}
   }
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = _storage._payload {return v}
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jsonPayload(newValue)}
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Google internal only.  Opensource testees just skip it.
   var jspbPayload: String {
     get {
-      if case .jspbPayload(let v)? = _storage._payload {return v}
+      if case .jspbPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jspbPayload(newValue)}
+    set {payload = .jspbPayload(newValue)}
   }
 
   var textPayload: String {
     get {
-      if case .textPayload(let v)? = _storage._payload {return v}
+      if case .textPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .textPayload(newValue)}
+    set {payload = .textPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
-  var requestedOutputFormat: Conformance_WireFormat {
-    get {return _storage._requestedOutputFormat}
-    set {_uniqueStorage()._requestedOutputFormat = newValue}
-  }
+  var requestedOutputFormat: Conformance_WireFormat = .unspecified
 
   /// The full name for the test message to use; for the moment, either:
   /// protobuf_test_messages.proto3.TestAllTypesProto3 or
   /// protobuf_test_messages.proto2.TestAllTypesProto2.
-  var messageType: String {
-    get {return _storage._messageType}
-    set {_uniqueStorage()._messageType = newValue}
-  }
+  var messageType: String = String()
 
   /// Each test is given a specific test category. Some category may need
   /// spedific support in testee programs. Refer to the defintion of TestCategory
   /// for more information.
-  var testCategory: Conformance_TestCategory {
-    get {return _storage._testCategory}
-    set {_uniqueStorage()._testCategory = newValue}
-  }
+  var testCategory: Conformance_TestCategory = .unspecifiedTest
 
   /// Specify details for how to encode jspb.
   var jspbEncodingOptions: Conformance_JspbEncodingConfig {
-    get {return _storage._jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
-    set {_uniqueStorage()._jspbEncodingOptions = newValue}
+    get {return _jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
+    set {_jspbEncodingOptions = newValue}
   }
   /// Returns true if `jspbEncodingOptions` has been explicitly set.
-  var hasJspbEncodingOptions: Bool {return _storage._jspbEncodingOptions != nil}
+  var hasJspbEncodingOptions: Bool {return self._jspbEncodingOptions != nil}
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
-  mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
+  mutating func clearJspbEncodingOptions() {self._jspbEncodingOptions = nil}
 
   /// This can be used in json and text format. If true, testee should print
   /// unknown fields instead of ignore. This feature is optional.
-  var printUnknownFields: Bool {
-    get {return _storage._printUnknownFields}
-    set {_uniqueStorage()._printUnknownFields = newValue}
-  }
+  var printUnknownFields: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -302,7 +287,7 @@ struct Conformance_ConformanceRequest {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
 }
 
 /// Represents a single test case's output.
@@ -519,123 +504,81 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     9: .standard(proto: "print_unknown_fields"),
   ]
 
-  fileprivate class _StorageClass {
-    var _payload: Conformance_ConformanceRequest.OneOf_Payload?
-    var _requestedOutputFormat: Conformance_WireFormat = .unspecified
-    var _messageType: String = String()
-    var _testCategory: Conformance_TestCategory = .unspecifiedTest
-    var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
-    var _printUnknownFields: Bool = false
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _payload = source._payload
-      _requestedOutputFormat = source._requestedOutputFormat
-      _messageType = source._messageType
-      _testCategory = source._testCategory
-      _jspbEncodingOptions = source._jspbEncodingOptions
-      _printUnknownFields = source._printUnknownFields
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._payload = .protobufPayload(v)}
-        case 2:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jsonPayload(v)}
-        case 3: try decoder.decodeSingularEnumField(value: &_storage._requestedOutputFormat)
-        case 4: try decoder.decodeSingularStringField(value: &_storage._messageType)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._testCategory)
-        case 6: try decoder.decodeSingularMessageField(value: &_storage._jspbEncodingOptions)
-        case 7:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jspbPayload(v)}
-        case 8:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .textPayload(v)}
-        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.payload = .protobufPayload(v)}
+      case 2:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jsonPayload(v)}
+      case 3: try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat)
+      case 4: try decoder.decodeSingularStringField(value: &self.messageType)
+      case 5: try decoder.decodeSingularEnumField(value: &self.testCategory)
+      case 6: try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions)
+      case 7:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jspbPayload(v)}
+      case 8:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .textPayload(v)}
+      case 9: try decoder.decodeSingularBoolField(value: &self.printUnknownFields)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._payload {
-      case .protobufPayload(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-      case .jsonPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case nil: break
-      default: break
-      }
-      if _storage._requestedOutputFormat != .unspecified {
-        try visitor.visitSingularEnumField(value: _storage._requestedOutputFormat, fieldNumber: 3)
-      }
-      if !_storage._messageType.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._messageType, fieldNumber: 4)
-      }
-      if _storage._testCategory != .unspecifiedTest {
-        try visitor.visitSingularEnumField(value: _storage._testCategory, fieldNumber: 5)
-      }
-      if let v = _storage._jspbEncodingOptions {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }
-      switch _storage._payload {
-      case .jspbPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      case .textPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 8)
-      case nil: break
-      default: break
-      }
-      if _storage._printUnknownFields != false {
-        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
-      }
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case nil: break
+    default: break
+    }
+    if self.requestedOutputFormat != .unspecified {
+      try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
+    }
+    if !self.messageType.isEmpty {
+      try visitor.visitSingularStringField(value: self.messageType, fieldNumber: 4)
+    }
+    if self.testCategory != .unspecifiedTest {
+      try visitor.visitSingularEnumField(value: self.testCategory, fieldNumber: 5)
+    }
+    if let v = self._jspbEncodingOptions {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }
+    switch self.payload {
+    case .jspbPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    case .textPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 8)
+    case nil: break
+    default: break
+    }
+    if self.printUnknownFields != false {
+      try visitor.visitSingularBoolField(value: self.printUnknownFields, fieldNumber: 9)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._payload != rhs_storage._payload {return false}
-        if _storage._requestedOutputFormat != rhs_storage._requestedOutputFormat {return false}
-        if _storage._messageType != rhs_storage._messageType {return false}
-        if _storage._testCategory != rhs_storage._testCategory {return false}
-        if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
-        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.payload != rhs.payload {return false}
+    if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
+    if lhs.messageType != rhs.messageType {return false}
+    if lhs.testCategory != rhs.testCategory {return false}
+    if lhs._jspbEncodingOptions != rhs._jspbEncodingOptions {return false}
+    if lhs.printUnknownFields != rhs.printUnknownFields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -1103,54 +1103,51 @@ struct ProtobufTestMessages_Proto2_UnknownToTestAllTypes {
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2 {
-    get {return _storage._nestedMessage ?? ProtobufTestMessages_Proto2_ForeignMessageProto2()}
-    set {_uniqueStorage()._nestedMessage = newValue}
+    get {return _nestedMessage ?? ProtobufTestMessages_Proto2_ForeignMessageProto2()}
+    set {_nestedMessage = newValue}
   }
   /// Returns true if `nestedMessage` has been explicitly set.
-  var hasNestedMessage: Bool {return _storage._nestedMessage != nil}
+  var hasNestedMessage: Bool {return self._nestedMessage != nil}
   /// Clears the value of `nestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearNestedMessage() {_uniqueStorage()._nestedMessage = nil}
+  mutating func clearNestedMessage() {self._nestedMessage = nil}
 
   var optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
   var optionalBool: Bool {
-    get {return _storage._optionalBool ?? false}
-    set {_uniqueStorage()._optionalBool = newValue}
+    get {return _optionalBool ?? false}
+    set {_optionalBool = newValue}
   }
   /// Returns true if `optionalBool` has been explicitly set.
-  var hasOptionalBool: Bool {return _storage._optionalBool != nil}
+  var hasOptionalBool: Bool {return self._optionalBool != nil}
   /// Clears the value of `optionalBool`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBool() {_uniqueStorage()._optionalBool = nil}
+  mutating func clearOptionalBool() {self._optionalBool = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1177,7 +1174,11 @@ struct ProtobufTestMessages_Proto2_UnknownToTestAllTypes {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2? = nil
+  fileprivate var _optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup? = nil
+  fileprivate var _optionalBool: Bool? = nil
 }
 
 // MARK: - Extension support defined in test_messages_proto2.proto.
@@ -2544,91 +2545,49 @@ extension ProtobufTestMessages_Proto2_UnknownToTestAllTypes: SwiftProtobuf.Messa
     1011: .standard(proto: "repeated_int32"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _optionalString: String? = nil
-    var _nestedMessage: ProtobufTestMessages_Proto2_ForeignMessageProto2? = nil
-    var _optionalGroup: ProtobufTestMessages_Proto2_UnknownToTestAllTypes.OptionalGroup? = nil
-    var _optionalBool: Bool? = nil
-    var _repeatedInt32: [Int32] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _optionalString = source._optionalString
-      _nestedMessage = source._nestedMessage
-      _optionalGroup = source._optionalGroup
-      _optionalBool = source._optionalBool
-      _repeatedInt32 = source._repeatedInt32
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1001: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 1002: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 1003: try decoder.decodeSingularMessageField(value: &_storage._nestedMessage)
-        case 1004: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 1006: try decoder.decodeSingularBoolField(value: &_storage._optionalBool)
-        case 1011: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1001: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 1002: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 1003: try decoder.decodeSingularMessageField(value: &self._nestedMessage)
+      case 1004: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 1006: try decoder.decodeSingularBoolField(value: &self._optionalBool)
+      case 1011: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1001)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1002)
-      }
-      if let v = _storage._nestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1003)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 1004)
-      }
-      if let v = _storage._optionalBool {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 1006)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 1011)
-      }
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1001)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1002)
+    }
+    if let v = self._nestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1003)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 1004)
+    }
+    if let v = self._optionalBool {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 1006)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 1011)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufTestMessages_Proto2_UnknownToTestAllTypes, rhs: ProtobufTestMessages_Proto2_UnknownToTestAllTypes) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._nestedMessage != rhs_storage._nestedMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._optionalBool != rhs_storage._optionalBool {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._nestedMessage != rhs._nestedMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs._optionalBool != rhs._optionalBool {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -64,22 +64,13 @@ public struct Google_Protobuf_Api {
 
   /// The fully qualified name of this interface, including package name
   /// followed by the interface's simple name.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// The methods of this interface, in unspecified order.
-  public var methods: [Google_Protobuf_Method] {
-    get {return _storage._methods}
-    set {_uniqueStorage()._methods = newValue}
-  }
+  public var methods: [Google_Protobuf_Method] = []
 
   /// Any metadata attached to the interface.
-  public var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  public var options: [Google_Protobuf_Option] = []
 
   /// A version string for this interface. If specified, must have the form
   /// `major-version.minor-version`, as in `1.10`. If the minor version is
@@ -100,39 +91,30 @@ public struct Google_Protobuf_Api {
   /// `google.feature.v1`. For major versions 0 and 1, the suffix can
   /// be omitted. Zero major versions must only be used for
   /// experimental, non-GA interfaces.
-  public var version: String {
-    get {return _storage._version}
-    set {_uniqueStorage()._version = newValue}
-  }
+  public var version: String = String()
 
   /// Source context for the protocol buffer service represented by this
   /// message.
   public var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  public var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  public var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  public mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  public mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// Included interfaces. See [Mixin][].
-  public var mixins: [Google_Protobuf_Mixin] {
-    get {return _storage._mixins}
-    set {_uniqueStorage()._mixins = newValue}
-  }
+  public var mixins: [Google_Protobuf_Mixin] = []
 
   /// The source syntax of the service.
-  public var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  public var syntax: Google_Protobuf_Syntax = .proto2
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// Method represents a method of an API interface.
@@ -278,98 +260,54 @@ extension Google_Protobuf_Api: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     7: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _methods: [Google_Protobuf_Method] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _version: String = String()
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _mixins: [Google_Protobuf_Mixin] = []
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _methods = source._methods
-      _options = source._options
-      _version = source._version
-      _sourceContext = source._sourceContext
-      _mixins = source._mixins
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._methods)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 4: try decoder.decodeSingularStringField(value: &_storage._version)
-        case 5: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._mixins)
-        case 7: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.methods)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 4: try decoder.decodeSingularStringField(value: &self.version)
+      case 5: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.mixins)
+      case 7: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._methods.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._methods, fieldNumber: 2)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 3)
-      }
-      if !_storage._version.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._version, fieldNumber: 4)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if !_storage._mixins.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._mixins, fieldNumber: 6)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 7)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.methods.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.methods, fieldNumber: 2)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 3)
+    }
+    if !self.version.isEmpty {
+      try visitor.visitSingularStringField(value: self.version, fieldNumber: 4)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }
+    if !self.mixins.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.mixins, fieldNumber: 6)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 7)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Api, rhs: Google_Protobuf_Api) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._methods != rhs_storage._methods {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._version != rhs_storage._version {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._mixins != rhs_storage._mixins {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.methods != rhs.methods {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs.version != rhs.version {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.mixins != rhs.mixins {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -63,16 +63,11 @@ public struct Google_Protobuf_FileDescriptorSet {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var file: [Google_Protobuf_FileDescriptorProto] {
-    get {return _storage._file}
-    set {_uniqueStorage()._file = newValue}
-  }
+  public var file: [Google_Protobuf_FileDescriptorProto] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// Describes a complete .proto file.
@@ -83,102 +78,85 @@ public struct Google_Protobuf_FileDescriptorProto {
 
   /// file name, relative to root of source tree
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
   /// e.g. "foo", "foo.bar", etc.
   public var package: String {
-    get {return _storage._package ?? String()}
-    set {_uniqueStorage()._package = newValue}
+    get {return _package ?? String()}
+    set {_package = newValue}
   }
   /// Returns true if `package` has been explicitly set.
-  public var hasPackage: Bool {return _storage._package != nil}
+  public var hasPackage: Bool {return self._package != nil}
   /// Clears the value of `package`. Subsequent reads from it will return its default value.
-  public mutating func clearPackage() {_uniqueStorage()._package = nil}
+  public mutating func clearPackage() {self._package = nil}
 
   /// Names of files imported by this file.
-  public var dependency: [String] {
-    get {return _storage._dependency}
-    set {_uniqueStorage()._dependency = newValue}
-  }
+  public var dependency: [String] = []
 
   /// Indexes of the public imported files in the dependency list above.
-  public var publicDependency: [Int32] {
-    get {return _storage._publicDependency}
-    set {_uniqueStorage()._publicDependency = newValue}
-  }
+  public var publicDependency: [Int32] = []
 
   /// Indexes of the weak imported files in the dependency list.
   /// For Google-internal migration only. Do not use.
-  public var weakDependency: [Int32] {
-    get {return _storage._weakDependency}
-    set {_uniqueStorage()._weakDependency = newValue}
-  }
+  public var weakDependency: [Int32] = []
 
   /// All top-level definitions in this file.
-  public var messageType: [Google_Protobuf_DescriptorProto] {
-    get {return _storage._messageType}
-    set {_uniqueStorage()._messageType = newValue}
-  }
+  public var messageType: [Google_Protobuf_DescriptorProto] = []
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
-    get {return _storage._enumType}
-    set {_uniqueStorage()._enumType = newValue}
-  }
+  public var enumType: [Google_Protobuf_EnumDescriptorProto] = []
 
-  public var service: [Google_Protobuf_ServiceDescriptorProto] {
-    get {return _storage._service}
-    set {_uniqueStorage()._service = newValue}
-  }
+  public var service: [Google_Protobuf_ServiceDescriptorProto] = []
 
-  public var `extension`: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._extension}
-    set {_uniqueStorage()._extension = newValue}
-  }
+  public var `extension`: [Google_Protobuf_FieldDescriptorProto] = []
 
   public var options: Google_Protobuf_FileOptions {
-    get {return _storage._options ?? Google_Protobuf_FileOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_FileOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   /// This field contains optional information about the original source code.
   /// You may safely remove this entire field without harming runtime
   /// functionality of the descriptors -- the information is needed only by
   /// development tools.
   public var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
-    get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
-    set {_uniqueStorage()._sourceCodeInfo = newValue}
+    get {return _sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
+    set {_sourceCodeInfo = newValue}
   }
   /// Returns true if `sourceCodeInfo` has been explicitly set.
-  public var hasSourceCodeInfo: Bool {return _storage._sourceCodeInfo != nil}
+  public var hasSourceCodeInfo: Bool {return self._sourceCodeInfo != nil}
   /// Clears the value of `sourceCodeInfo`. Subsequent reads from it will return its default value.
-  public mutating func clearSourceCodeInfo() {_uniqueStorage()._sourceCodeInfo = nil}
+  public mutating func clearSourceCodeInfo() {self._sourceCodeInfo = nil}
 
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
   public var syntax: String {
-    get {return _storage._syntax ?? String()}
-    set {_uniqueStorage()._syntax = newValue}
+    get {return _syntax ?? String()}
+    set {_syntax = newValue}
   }
   /// Returns true if `syntax` has been explicitly set.
-  public var hasSyntax: Bool {return _storage._syntax != nil}
+  public var hasSyntax: Bool {return self._syntax != nil}
   /// Clears the value of `syntax`. Subsequent reads from it will return its default value.
-  public mutating func clearSyntax() {_uniqueStorage()._syntax = nil}
+  public mutating func clearSyntax() {self._syntax = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _package: String? = nil
+  fileprivate var _options: Google_Protobuf_FileOptions? = nil
+  fileprivate var _sourceCodeInfo: Google_Protobuf_SourceCodeInfo? = nil
+  fileprivate var _syntax: String? = nil
 }
 
 /// Describes a message type.
@@ -188,64 +166,40 @@ public struct Google_Protobuf_DescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
-  public var field: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._field}
-    set {_uniqueStorage()._field = newValue}
-  }
+  public var field: [Google_Protobuf_FieldDescriptorProto] = []
 
-  public var `extension`: [Google_Protobuf_FieldDescriptorProto] {
-    get {return _storage._extension}
-    set {_uniqueStorage()._extension = newValue}
-  }
+  public var `extension`: [Google_Protobuf_FieldDescriptorProto] = []
 
-  public var nestedType: [Google_Protobuf_DescriptorProto] {
-    get {return _storage._nestedType}
-    set {_uniqueStorage()._nestedType = newValue}
-  }
+  public var nestedType: [Google_Protobuf_DescriptorProto] = []
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
-    get {return _storage._enumType}
-    set {_uniqueStorage()._enumType = newValue}
-  }
+  public var enumType: [Google_Protobuf_EnumDescriptorProto] = []
 
-  public var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
-    get {return _storage._extensionRange}
-    set {_uniqueStorage()._extensionRange = newValue}
-  }
+  public var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] = []
 
-  public var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
-    get {return _storage._oneofDecl}
-    set {_uniqueStorage()._oneofDecl = newValue}
-  }
+  public var oneofDecl: [Google_Protobuf_OneofDescriptorProto] = []
 
   public var options: Google_Protobuf_MessageOptions {
-    get {return _storage._options ?? Google_Protobuf_MessageOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_MessageOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
-  public var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
-    get {return _storage._reservedRange}
-    set {_uniqueStorage()._reservedRange = newValue}
-  }
+  public var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] = []
 
   /// Reserved field names, which may not be used by fields in the same message.
   /// A given name may only be reserved once.
-  public var reservedName: [String] {
-    get {return _storage._reservedName}
-    set {_uniqueStorage()._reservedName = newValue}
-  }
+  public var reservedName: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -330,7 +284,8 @@ public struct Google_Protobuf_DescriptorProto {
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_MessageOptions? = nil
 }
 
 public struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobuf.ExtensibleMessage {
@@ -2058,63 +2013,29 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message, SwiftProtobu
     1: .same(proto: "file"),
   ]
 
-  fileprivate class _StorageClass {
-    var _file: [Google_Protobuf_FileDescriptorProto] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _file = source._file
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._file) {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.file) {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._file)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.file)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._file.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._file, fieldNumber: 1)
-      }
+    if !self.file.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_FileDescriptorSet, rhs: Google_Protobuf_FileDescriptorSet) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._file != rhs_storage._file {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.file != rhs.file {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2137,144 +2058,88 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message, SwiftProto
     12: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _package: String? = nil
-    var _dependency: [String] = []
-    var _publicDependency: [Int32] = []
-    var _weakDependency: [Int32] = []
-    var _messageType: [Google_Protobuf_DescriptorProto] = []
-    var _enumType: [Google_Protobuf_EnumDescriptorProto] = []
-    var _service: [Google_Protobuf_ServiceDescriptorProto] = []
-    var _extension: [Google_Protobuf_FieldDescriptorProto] = []
-    var _options: Google_Protobuf_FileOptions? = nil
-    var _sourceCodeInfo: Google_Protobuf_SourceCodeInfo? = nil
-    var _syntax: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _package = source._package
-      _dependency = source._dependency
-      _publicDependency = source._publicDependency
-      _weakDependency = source._weakDependency
-      _messageType = source._messageType
-      _enumType = source._enumType
-      _service = source._service
-      _extension = source._extension
-      _options = source._options
-      _sourceCodeInfo = source._sourceCodeInfo
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._messageType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._enumType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._service) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extension) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.messageType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.enumType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.service) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.`extension`) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._package)
-        case 3: try decoder.decodeRepeatedStringField(value: &_storage._dependency)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._messageType)
-        case 5: try decoder.decodeRepeatedMessageField(value: &_storage._enumType)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._service)
-        case 7: try decoder.decodeRepeatedMessageField(value: &_storage._extension)
-        case 8: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 9: try decoder.decodeSingularMessageField(value: &_storage._sourceCodeInfo)
-        case 10: try decoder.decodeRepeatedInt32Field(value: &_storage._publicDependency)
-        case 11: try decoder.decodeRepeatedInt32Field(value: &_storage._weakDependency)
-        case 12: try decoder.decodeSingularStringField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._package)
+      case 3: try decoder.decodeRepeatedStringField(value: &self.dependency)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.messageType)
+      case 5: try decoder.decodeRepeatedMessageField(value: &self.enumType)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.service)
+      case 7: try decoder.decodeRepeatedMessageField(value: &self.`extension`)
+      case 8: try decoder.decodeSingularMessageField(value: &self._options)
+      case 9: try decoder.decodeSingularMessageField(value: &self._sourceCodeInfo)
+      case 10: try decoder.decodeRepeatedInt32Field(value: &self.publicDependency)
+      case 11: try decoder.decodeRepeatedInt32Field(value: &self.weakDependency)
+      case 12: try decoder.decodeSingularStringField(value: &self._syntax)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._package {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if !_storage._dependency.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._dependency, fieldNumber: 3)
-      }
-      if !_storage._messageType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._messageType, fieldNumber: 4)
-      }
-      if !_storage._enumType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumType, fieldNumber: 5)
-      }
-      if !_storage._service.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._service, fieldNumber: 6)
-      }
-      if !_storage._extension.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extension, fieldNumber: 7)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._sourceCodeInfo {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }
-      if !_storage._publicDependency.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._publicDependency, fieldNumber: 10)
-      }
-      if !_storage._weakDependency.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._weakDependency, fieldNumber: 11)
-      }
-      if let v = _storage._syntax {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 12)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._package {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if !self.dependency.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.dependency, fieldNumber: 3)
+    }
+    if !self.messageType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.messageType, fieldNumber: 4)
+    }
+    if !self.enumType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumType, fieldNumber: 5)
+    }
+    if !self.service.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.service, fieldNumber: 6)
+    }
+    if !self.`extension`.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.`extension`, fieldNumber: 7)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }
+    if let v = self._sourceCodeInfo {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }
+    if !self.publicDependency.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.publicDependency, fieldNumber: 10)
+    }
+    if !self.weakDependency.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.weakDependency, fieldNumber: 11)
+    }
+    if let v = self._syntax {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 12)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_FileDescriptorProto, rhs: Google_Protobuf_FileDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._package != rhs_storage._package {return false}
-        if _storage._dependency != rhs_storage._dependency {return false}
-        if _storage._publicDependency != rhs_storage._publicDependency {return false}
-        if _storage._weakDependency != rhs_storage._weakDependency {return false}
-        if _storage._messageType != rhs_storage._messageType {return false}
-        if _storage._enumType != rhs_storage._enumType {return false}
-        if _storage._service != rhs_storage._service {return false}
-        if _storage._extension != rhs_storage._extension {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceCodeInfo != rhs_storage._sourceCodeInfo {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._package != rhs._package {return false}
+    if lhs.dependency != rhs.dependency {return false}
+    if lhs.publicDependency != rhs.publicDependency {return false}
+    if lhs.weakDependency != rhs.weakDependency {return false}
+    if lhs.messageType != rhs.messageType {return false}
+    if lhs.enumType != rhs.enumType {return false}
+    if lhs.service != rhs.service {return false}
+    if lhs.`extension` != rhs.`extension` {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs._sourceCodeInfo != rhs._sourceCodeInfo {return false}
+    if lhs._syntax != rhs._syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2295,132 +2160,80 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobuf.Message, SwiftProtobuf.
     10: .standard(proto: "reserved_name"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _field: [Google_Protobuf_FieldDescriptorProto] = []
-    var _extension: [Google_Protobuf_FieldDescriptorProto] = []
-    var _nestedType: [Google_Protobuf_DescriptorProto] = []
-    var _enumType: [Google_Protobuf_EnumDescriptorProto] = []
-    var _extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] = []
-    var _oneofDecl: [Google_Protobuf_OneofDescriptorProto] = []
-    var _options: Google_Protobuf_MessageOptions? = nil
-    var _reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] = []
-    var _reservedName: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _field = source._field
-      _extension = source._extension
-      _nestedType = source._nestedType
-      _enumType = source._enumType
-      _extensionRange = source._extensionRange
-      _oneofDecl = source._oneofDecl
-      _options = source._options
-      _reservedRange = source._reservedRange
-      _reservedName = source._reservedName
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._field) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extension) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._nestedType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._enumType) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._extensionRange) {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._oneofDecl) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.field) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.`extension`) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.nestedType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.enumType) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.extensionRange) {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.oneofDecl) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._field)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._nestedType)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._enumType)
-        case 5: try decoder.decodeRepeatedMessageField(value: &_storage._extensionRange)
-        case 6: try decoder.decodeRepeatedMessageField(value: &_storage._extension)
-        case 7: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 8: try decoder.decodeRepeatedMessageField(value: &_storage._oneofDecl)
-        case 9: try decoder.decodeRepeatedMessageField(value: &_storage._reservedRange)
-        case 10: try decoder.decodeRepeatedStringField(value: &_storage._reservedName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.field)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.nestedType)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.enumType)
+      case 5: try decoder.decodeRepeatedMessageField(value: &self.extensionRange)
+      case 6: try decoder.decodeRepeatedMessageField(value: &self.`extension`)
+      case 7: try decoder.decodeSingularMessageField(value: &self._options)
+      case 8: try decoder.decodeRepeatedMessageField(value: &self.oneofDecl)
+      case 9: try decoder.decodeRepeatedMessageField(value: &self.reservedRange)
+      case 10: try decoder.decodeRepeatedStringField(value: &self.reservedName)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._field.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._field, fieldNumber: 2)
-      }
-      if !_storage._nestedType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._nestedType, fieldNumber: 3)
-      }
-      if !_storage._enumType.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumType, fieldNumber: 4)
-      }
-      if !_storage._extensionRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extensionRange, fieldNumber: 5)
-      }
-      if !_storage._extension.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._extension, fieldNumber: 6)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }
-      if !_storage._oneofDecl.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._oneofDecl, fieldNumber: 8)
-      }
-      if !_storage._reservedRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._reservedRange, fieldNumber: 9)
-      }
-      if !_storage._reservedName.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._reservedName, fieldNumber: 10)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.field.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.field, fieldNumber: 2)
+    }
+    if !self.nestedType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.nestedType, fieldNumber: 3)
+    }
+    if !self.enumType.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumType, fieldNumber: 4)
+    }
+    if !self.extensionRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.extensionRange, fieldNumber: 5)
+    }
+    if !self.`extension`.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.`extension`, fieldNumber: 6)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }
+    if !self.oneofDecl.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.oneofDecl, fieldNumber: 8)
+    }
+    if !self.reservedRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.reservedRange, fieldNumber: 9)
+    }
+    if !self.reservedName.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.reservedName, fieldNumber: 10)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_DescriptorProto, rhs: Google_Protobuf_DescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._field != rhs_storage._field {return false}
-        if _storage._extension != rhs_storage._extension {return false}
-        if _storage._nestedType != rhs_storage._nestedType {return false}
-        if _storage._enumType != rhs_storage._enumType {return false}
-        if _storage._extensionRange != rhs_storage._extensionRange {return false}
-        if _storage._oneofDecl != rhs_storage._oneofDecl {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._reservedRange != rhs_storage._reservedRange {return false}
-        if _storage._reservedName != rhs_storage._reservedName {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.field != rhs.field {return false}
+    if lhs.`extension` != rhs.`extension` {return false}
+    if lhs.nestedType != rhs.nestedType {return false}
+    if lhs.enumType != rhs.enumType {return false}
+    if lhs.extensionRange != rhs.extensionRange {return false}
+    if lhs.oneofDecl != rhs.oneofDecl {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs.reservedRange != rhs.reservedRange {return false}
+    if lhs.reservedName != rhs.reservedName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -63,11 +63,16 @@ public struct Google_Protobuf_FileDescriptorSet {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var file: [Google_Protobuf_FileDescriptorProto] = []
+  public var file: [Google_Protobuf_FileDescriptorProto] {
+    get {return _storage._file}
+    set {_uniqueStorage()._file = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// Describes a complete .proto file.
@@ -251,38 +256,40 @@ public struct Google_Protobuf_DescriptorProto {
 
     /// Inclusive.
     public var start: Int32 {
-      get {return _storage._start ?? 0}
-      set {_uniqueStorage()._start = newValue}
+      get {return _start ?? 0}
+      set {_start = newValue}
     }
     /// Returns true if `start` has been explicitly set.
-    public var hasStart: Bool {return _storage._start != nil}
+    public var hasStart: Bool {return self._start != nil}
     /// Clears the value of `start`. Subsequent reads from it will return its default value.
-    public mutating func clearStart() {_uniqueStorage()._start = nil}
+    public mutating func clearStart() {self._start = nil}
 
     /// Exclusive.
     public var end: Int32 {
-      get {return _storage._end ?? 0}
-      set {_uniqueStorage()._end = newValue}
+      get {return _end ?? 0}
+      set {_end = newValue}
     }
     /// Returns true if `end` has been explicitly set.
-    public var hasEnd: Bool {return _storage._end != nil}
+    public var hasEnd: Bool {return self._end != nil}
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
-    public mutating func clearEnd() {_uniqueStorage()._end = nil}
+    public mutating func clearEnd() {self._end = nil}
 
     public var options: Google_Protobuf_ExtensionRangeOptions {
-      get {return _storage._options ?? Google_Protobuf_ExtensionRangeOptions()}
-      set {_uniqueStorage()._options = newValue}
+      get {return _options ?? Google_Protobuf_ExtensionRangeOptions()}
+      set {_options = newValue}
     }
     /// Returns true if `options` has been explicitly set.
-    public var hasOptions: Bool {return _storage._options != nil}
+    public var hasOptions: Bool {return self._options != nil}
     /// Clears the value of `options`. Subsequent reads from it will return its default value.
-    public mutating func clearOptions() {_uniqueStorage()._options = nil}
+    public mutating func clearOptions() {self._options = nil}
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
     public init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _start: Int32? = nil
+    fileprivate var _end: Int32? = nil
+    fileprivate var _options: Google_Protobuf_ExtensionRangeOptions? = nil
   }
 
   /// Range of reserved tag numbers. Reserved tag numbers may not be used by
@@ -348,42 +355,42 @@ public struct Google_Protobuf_FieldDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
   public var number: Int32 {
-    get {return _storage._number ?? 0}
-    set {_uniqueStorage()._number = newValue}
+    get {return _number ?? 0}
+    set {_number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  public var hasNumber: Bool {return _storage._number != nil}
+  public var hasNumber: Bool {return self._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  public mutating func clearNumber() {_uniqueStorage()._number = nil}
+  public mutating func clearNumber() {self._number = nil}
 
   public var label: Google_Protobuf_FieldDescriptorProto.Label {
-    get {return _storage._label ?? .optional}
-    set {_uniqueStorage()._label = newValue}
+    get {return _label ?? .optional}
+    set {_label = newValue}
   }
   /// Returns true if `label` has been explicitly set.
-  public var hasLabel: Bool {return _storage._label != nil}
+  public var hasLabel: Bool {return self._label != nil}
   /// Clears the value of `label`. Subsequent reads from it will return its default value.
-  public mutating func clearLabel() {_uniqueStorage()._label = nil}
+  public mutating func clearLabel() {self._label = nil}
 
   /// If type_name is set, this need not be set.  If both this and type_name
   /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   public var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
-    get {return _storage._type ?? .double}
-    set {_uniqueStorage()._type = newValue}
+    get {return _type ?? .double}
+    set {_type = newValue}
   }
   /// Returns true if `type` has been explicitly set.
-  public var hasType: Bool {return _storage._type != nil}
+  public var hasType: Bool {return self._type != nil}
   /// Clears the value of `type`. Subsequent reads from it will return its default value.
-  public mutating func clearType() {_uniqueStorage()._type = nil}
+  public mutating func clearType() {self._type = nil}
 
   /// For message and enum types, this is the name of the type.  If the name
   /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
@@ -391,24 +398,24 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   public var typeName: String {
-    get {return _storage._typeName ?? String()}
-    set {_uniqueStorage()._typeName = newValue}
+    get {return _typeName ?? String()}
+    set {_typeName = newValue}
   }
   /// Returns true if `typeName` has been explicitly set.
-  public var hasTypeName: Bool {return _storage._typeName != nil}
+  public var hasTypeName: Bool {return self._typeName != nil}
   /// Clears the value of `typeName`. Subsequent reads from it will return its default value.
-  public mutating func clearTypeName() {_uniqueStorage()._typeName = nil}
+  public mutating func clearTypeName() {self._typeName = nil}
 
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   public var extendee: String {
-    get {return _storage._extendee ?? String()}
-    set {_uniqueStorage()._extendee = newValue}
+    get {return _extendee ?? String()}
+    set {_extendee = newValue}
   }
   /// Returns true if `extendee` has been explicitly set.
-  public var hasExtendee: Bool {return _storage._extendee != nil}
+  public var hasExtendee: Bool {return self._extendee != nil}
   /// Clears the value of `extendee`. Subsequent reads from it will return its default value.
-  public mutating func clearExtendee() {_uniqueStorage()._extendee = nil}
+  public mutating func clearExtendee() {self._extendee = nil}
 
   /// For numeric types, contains the original text representation of the value.
   /// For booleans, "true" or "false".
@@ -416,46 +423,46 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   public var defaultValue: String {
-    get {return _storage._defaultValue ?? String()}
-    set {_uniqueStorage()._defaultValue = newValue}
+    get {return _defaultValue ?? String()}
+    set {_defaultValue = newValue}
   }
   /// Returns true if `defaultValue` has been explicitly set.
-  public var hasDefaultValue: Bool {return _storage._defaultValue != nil}
+  public var hasDefaultValue: Bool {return self._defaultValue != nil}
   /// Clears the value of `defaultValue`. Subsequent reads from it will return its default value.
-  public mutating func clearDefaultValue() {_uniqueStorage()._defaultValue = nil}
+  public mutating func clearDefaultValue() {self._defaultValue = nil}
 
   /// If set, gives the index of a oneof in the containing type's oneof_decl
   /// list.  This field is a member of that oneof.
   public var oneofIndex: Int32 {
-    get {return _storage._oneofIndex ?? 0}
-    set {_uniqueStorage()._oneofIndex = newValue}
+    get {return _oneofIndex ?? 0}
+    set {_oneofIndex = newValue}
   }
   /// Returns true if `oneofIndex` has been explicitly set.
-  public var hasOneofIndex: Bool {return _storage._oneofIndex != nil}
+  public var hasOneofIndex: Bool {return self._oneofIndex != nil}
   /// Clears the value of `oneofIndex`. Subsequent reads from it will return its default value.
-  public mutating func clearOneofIndex() {_uniqueStorage()._oneofIndex = nil}
+  public mutating func clearOneofIndex() {self._oneofIndex = nil}
 
   /// JSON name of this field. The value is set by protocol compiler. If the
   /// user has set a "json_name" option on this field, that option's value
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   public var jsonName: String {
-    get {return _storage._jsonName ?? String()}
-    set {_uniqueStorage()._jsonName = newValue}
+    get {return _jsonName ?? String()}
+    set {_jsonName = newValue}
   }
   /// Returns true if `jsonName` has been explicitly set.
-  public var hasJsonName: Bool {return _storage._jsonName != nil}
+  public var hasJsonName: Bool {return self._jsonName != nil}
   /// Clears the value of `jsonName`. Subsequent reads from it will return its default value.
-  public mutating func clearJsonName() {_uniqueStorage()._jsonName = nil}
+  public mutating func clearJsonName() {self._jsonName = nil}
 
   public var options: Google_Protobuf_FieldOptions {
-    get {return _storage._options ?? Google_Protobuf_FieldOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_FieldOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -588,7 +595,16 @@ public struct Google_Protobuf_FieldDescriptorProto {
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _number: Int32? = nil
+  fileprivate var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
+  fileprivate var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
+  fileprivate var _typeName: String? = nil
+  fileprivate var _extendee: String? = nil
+  fileprivate var _defaultValue: String? = nil
+  fileprivate var _oneofIndex: Int32? = nil
+  fileprivate var _jsonName: String? = nil
+  fileprivate var _options: Google_Protobuf_FieldOptions? = nil
 }
 
 #if swift(>=4.2)
@@ -610,28 +626,29 @@ public struct Google_Protobuf_OneofDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
   public var options: Google_Protobuf_OneofOptions {
-    get {return _storage._options ?? Google_Protobuf_OneofOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_OneofOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_OneofOptions? = nil
 }
 
 /// Describes an enum type.
@@ -641,42 +658,33 @@ public struct Google_Protobuf_EnumDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
-  public var value: [Google_Protobuf_EnumValueDescriptorProto] {
-    get {return _storage._value}
-    set {_uniqueStorage()._value = newValue}
-  }
+  public var value: [Google_Protobuf_EnumValueDescriptorProto] = []
 
   public var options: Google_Protobuf_EnumOptions {
-    get {return _storage._options ?? Google_Protobuf_EnumOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_EnumOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   /// Range of reserved numeric values. Reserved numeric values may not be used
   /// by enum values in the same enum declaration. Reserved ranges may not
   /// overlap.
-  public var reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] {
-    get {return _storage._reservedRange}
-    set {_uniqueStorage()._reservedRange = newValue}
-  }
+  public var reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] = []
 
   /// Reserved enum value names, which may not be reused. A given name may only
   /// be reserved once.
-  public var reservedName: [String] {
-    get {return _storage._reservedName}
-    set {_uniqueStorage()._reservedName = newValue}
-  }
+  public var reservedName: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -721,7 +729,8 @@ public struct Google_Protobuf_EnumDescriptorProto {
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_EnumOptions? = nil
 }
 
 /// Describes a value within an enum.
@@ -731,37 +740,39 @@ public struct Google_Protobuf_EnumValueDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
   public var number: Int32 {
-    get {return _storage._number ?? 0}
-    set {_uniqueStorage()._number = newValue}
+    get {return _number ?? 0}
+    set {_number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  public var hasNumber: Bool {return _storage._number != nil}
+  public var hasNumber: Bool {return self._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  public mutating func clearNumber() {_uniqueStorage()._number = nil}
+  public mutating func clearNumber() {self._number = nil}
 
   public var options: Google_Protobuf_EnumValueOptions {
-    get {return _storage._options ?? Google_Protobuf_EnumValueOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_EnumValueOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _number: Int32? = nil
+  fileprivate var _options: Google_Protobuf_EnumValueOptions? = nil
 }
 
 /// Describes a service.
@@ -771,33 +782,31 @@ public struct Google_Protobuf_ServiceDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
-  public var method: [Google_Protobuf_MethodDescriptorProto] {
-    get {return _storage._method}
-    set {_uniqueStorage()._method = newValue}
-  }
+  public var method: [Google_Protobuf_MethodDescriptorProto] = []
 
   public var options: Google_Protobuf_ServiceOptions {
-    get {return _storage._options ?? Google_Protobuf_ServiceOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_ServiceOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _options: Google_Protobuf_ServiceOptions? = nil
 }
 
 /// Describes a method of a service.
@@ -807,68 +816,73 @@ public struct Google_Protobuf_MethodDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _storage._name ?? String()}
-    set {_uniqueStorage()._name = newValue}
+    get {return _name ?? String()}
+    set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return _storage._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {_uniqueStorage()._name = nil}
+  public mutating func clearName() {self._name = nil}
 
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
   public var inputType: String {
-    get {return _storage._inputType ?? String()}
-    set {_uniqueStorage()._inputType = newValue}
+    get {return _inputType ?? String()}
+    set {_inputType = newValue}
   }
   /// Returns true if `inputType` has been explicitly set.
-  public var hasInputType: Bool {return _storage._inputType != nil}
+  public var hasInputType: Bool {return self._inputType != nil}
   /// Clears the value of `inputType`. Subsequent reads from it will return its default value.
-  public mutating func clearInputType() {_uniqueStorage()._inputType = nil}
+  public mutating func clearInputType() {self._inputType = nil}
 
   public var outputType: String {
-    get {return _storage._outputType ?? String()}
-    set {_uniqueStorage()._outputType = newValue}
+    get {return _outputType ?? String()}
+    set {_outputType = newValue}
   }
   /// Returns true if `outputType` has been explicitly set.
-  public var hasOutputType: Bool {return _storage._outputType != nil}
+  public var hasOutputType: Bool {return self._outputType != nil}
   /// Clears the value of `outputType`. Subsequent reads from it will return its default value.
-  public mutating func clearOutputType() {_uniqueStorage()._outputType = nil}
+  public mutating func clearOutputType() {self._outputType = nil}
 
   public var options: Google_Protobuf_MethodOptions {
-    get {return _storage._options ?? Google_Protobuf_MethodOptions()}
-    set {_uniqueStorage()._options = newValue}
+    get {return _options ?? Google_Protobuf_MethodOptions()}
+    set {_options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return _storage._options != nil}
+  public var hasOptions: Bool {return self._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {_uniqueStorage()._options = nil}
+  public mutating func clearOptions() {self._options = nil}
 
   /// Identifies if client streams multiple client messages
   public var clientStreaming: Bool {
-    get {return _storage._clientStreaming ?? false}
-    set {_uniqueStorage()._clientStreaming = newValue}
+    get {return _clientStreaming ?? false}
+    set {_clientStreaming = newValue}
   }
   /// Returns true if `clientStreaming` has been explicitly set.
-  public var hasClientStreaming: Bool {return _storage._clientStreaming != nil}
+  public var hasClientStreaming: Bool {return self._clientStreaming != nil}
   /// Clears the value of `clientStreaming`. Subsequent reads from it will return its default value.
-  public mutating func clearClientStreaming() {_uniqueStorage()._clientStreaming = nil}
+  public mutating func clearClientStreaming() {self._clientStreaming = nil}
 
   /// Identifies if server streams multiple server messages
   public var serverStreaming: Bool {
-    get {return _storage._serverStreaming ?? false}
-    set {_uniqueStorage()._serverStreaming = newValue}
+    get {return _serverStreaming ?? false}
+    set {_serverStreaming = newValue}
   }
   /// Returns true if `serverStreaming` has been explicitly set.
-  public var hasServerStreaming: Bool {return _storage._serverStreaming != nil}
+  public var hasServerStreaming: Bool {return self._serverStreaming != nil}
   /// Clears the value of `serverStreaming`. Subsequent reads from it will return its default value.
-  public mutating func clearServerStreaming() {_uniqueStorage()._serverStreaming = nil}
+  public mutating func clearServerStreaming() {self._serverStreaming = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _name: String? = nil
+  fileprivate var _inputType: String? = nil
+  fileprivate var _outputType: String? = nil
+  fileprivate var _options: Google_Protobuf_MethodOptions? = nil
+  fileprivate var _clientStreaming: Bool? = nil
+  fileprivate var _serverStreaming: Bool? = nil
 }
 
 public struct Google_Protobuf_FileOptions: SwiftProtobuf.ExtensibleMessage {
@@ -2044,29 +2058,63 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message, SwiftProtobu
     1: .same(proto: "file"),
   ]
 
+  fileprivate class _StorageClass {
+    var _file: [Google_Protobuf_FileDescriptorProto] = []
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _file = source._file
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public var isInitialized: Bool {
-    if !SwiftProtobuf.Internal.areAllInitialized(self.file) {return false}
-    return true
+    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !SwiftProtobuf.Internal.areAllInitialized(_storage._file) {return false}
+      return true
+    }
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeRepeatedMessageField(value: &self.file)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._file)
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.file.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._file.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._file, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_FileDescriptorSet, rhs: Google_Protobuf_FileDescriptorSet) -> Bool {
-    if lhs.file != rhs.file {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._file != rhs_storage._file {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2386,77 +2434,39 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobuf.Message,
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _start: Int32? = nil
-    var _end: Int32? = nil
-    var _options: Google_Protobuf_ExtensionRangeOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _start = source._start
-      _end = source._end
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._start)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._end)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._start)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._end)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._start {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._end {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._start {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._end {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_DescriptorProto.ExtensionRange, rhs: Google_Protobuf_DescriptorProto.ExtensionRange) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._start != rhs_storage._start {return false}
-        if _storage._end != rhs_storage._end {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._start != rhs._start {return false}
+    if lhs._end != rhs._end {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2551,126 +2561,74 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProt
     8: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _number: Int32? = nil
-    var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
-    var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
-    var _typeName: String? = nil
-    var _extendee: String? = nil
-    var _defaultValue: String? = nil
-    var _oneofIndex: Int32? = nil
-    var _jsonName: String? = nil
-    var _options: Google_Protobuf_FieldOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _number = source._number
-      _label = source._label
-      _type = source._type
-      _typeName = source._typeName
-      _extendee = source._extendee
-      _defaultValue = source._defaultValue
-      _oneofIndex = source._oneofIndex
-      _jsonName = source._jsonName
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._extendee)
-        case 3: try decoder.decodeSingularInt32Field(value: &_storage._number)
-        case 4: try decoder.decodeSingularEnumField(value: &_storage._label)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._type)
-        case 6: try decoder.decodeSingularStringField(value: &_storage._typeName)
-        case 7: try decoder.decodeSingularStringField(value: &_storage._defaultValue)
-        case 8: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 9: try decoder.decodeSingularInt32Field(value: &_storage._oneofIndex)
-        case 10: try decoder.decodeSingularStringField(value: &_storage._jsonName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._extendee)
+      case 3: try decoder.decodeSingularInt32Field(value: &self._number)
+      case 4: try decoder.decodeSingularEnumField(value: &self._label)
+      case 5: try decoder.decodeSingularEnumField(value: &self._type)
+      case 6: try decoder.decodeSingularStringField(value: &self._typeName)
+      case 7: try decoder.decodeSingularStringField(value: &self._defaultValue)
+      case 8: try decoder.decodeSingularMessageField(value: &self._options)
+      case 9: try decoder.decodeSingularInt32Field(value: &self._oneofIndex)
+      case 10: try decoder.decodeSingularStringField(value: &self._jsonName)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._extendee {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._number {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._label {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._type {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._typeName {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-      }
-      if let v = _storage._defaultValue {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._oneofIndex {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
-      }
-      if let v = _storage._jsonName {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 10)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._extendee {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._number {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+    }
+    if let v = self._label {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
+    }
+    if let v = self._type {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    }
+    if let v = self._typeName {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    }
+    if let v = self._defaultValue {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }
+    if let v = self._oneofIndex {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
+    }
+    if let v = self._jsonName {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_FieldDescriptorProto, rhs: Google_Protobuf_FieldDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._number != rhs_storage._number {return false}
-        if _storage._label != rhs_storage._label {return false}
-        if _storage._type != rhs_storage._type {return false}
-        if _storage._typeName != rhs_storage._typeName {return false}
-        if _storage._extendee != rhs_storage._extendee {return false}
-        if _storage._defaultValue != rhs_storage._defaultValue {return false}
-        if _storage._oneofIndex != rhs_storage._oneofIndex {return false}
-        if _storage._jsonName != rhs_storage._jsonName {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._number != rhs._number {return false}
+    if lhs._label != rhs._label {return false}
+    if lhs._type != rhs._type {return false}
+    if lhs._typeName != rhs._typeName {return false}
+    if lhs._extendee != rhs._extendee {return false}
+    if lhs._defaultValue != rhs._defaultValue {return false}
+    if lhs._oneofIndex != rhs._oneofIndex {return false}
+    if lhs._jsonName != rhs._jsonName {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2714,70 +2672,34 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message, SwiftProt
     2: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _options: Google_Protobuf_OneofOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_OneofDescriptorProto, rhs: Google_Protobuf_OneofDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2793,92 +2715,50 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message, SwiftProto
     5: .standard(proto: "reserved_name"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _value: [Google_Protobuf_EnumValueDescriptorProto] = []
-    var _options: Google_Protobuf_EnumOptions? = nil
-    var _reservedRange: [Google_Protobuf_EnumDescriptorProto.EnumReservedRange] = []
-    var _reservedName: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _value = source._value
-      _options = source._options
-      _reservedRange = source._reservedRange
-      _reservedName = source._reservedName
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._value) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.value) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._value)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._reservedRange)
-        case 5: try decoder.decodeRepeatedStringField(value: &_storage._reservedName)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.value)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.reservedRange)
+      case 5: try decoder.decodeRepeatedStringField(value: &self.reservedName)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._value.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._value, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._reservedRange.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._reservedRange, fieldNumber: 4)
-      }
-      if !_storage._reservedName.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._reservedName, fieldNumber: 5)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.value.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.value, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.reservedRange.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.reservedRange, fieldNumber: 4)
+    }
+    if !self.reservedName.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.reservedName, fieldNumber: 5)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_EnumDescriptorProto, rhs: Google_Protobuf_EnumDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._value != rhs_storage._value {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._reservedRange != rhs_storage._reservedRange {return false}
-        if _storage._reservedName != rhs_storage._reservedName {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.value != rhs.value {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs.reservedRange != rhs.reservedRange {return false}
+    if lhs.reservedName != rhs.reservedName {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2927,77 +2807,39 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message, Swift
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _number: Int32? = nil
-    var _options: Google_Protobuf_EnumValueOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _number = source._number
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._number)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._number)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._number {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._number {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_EnumValueDescriptorProto, rhs: Google_Protobuf_EnumValueDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._number != rhs_storage._number {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._number != rhs._number {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3011,78 +2853,40 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message, SwiftPr
     3: .same(proto: "options"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _method: [Google_Protobuf_MethodDescriptorProto] = []
-    var _options: Google_Protobuf_ServiceOptions? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _method = source._method
-      _options = source._options
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._method) {return false}
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.method) {return false}
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._method)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._options)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.method)
+      case 3: try decoder.decodeSingularMessageField(value: &self._options)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if !_storage._method.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._method, fieldNumber: 2)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.method.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.method, fieldNumber: 2)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_ServiceDescriptorProto, rhs: Google_Protobuf_ServiceDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._method != rhs_storage._method {return false}
-        if _storage._options != rhs_storage._options {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs.method != rhs.method {return false}
+    if lhs._options != rhs._options {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3099,98 +2903,54 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftPro
     6: .standard(proto: "server_streaming"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String? = nil
-    var _inputType: String? = nil
-    var _outputType: String? = nil
-    var _options: Google_Protobuf_MethodOptions? = nil
-    var _clientStreaming: Bool? = nil
-    var _serverStreaming: Bool? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _inputType = source._inputType
-      _outputType = source._outputType
-      _options = source._options
-      _clientStreaming = source._clientStreaming
-      _serverStreaming = source._serverStreaming
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._options, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._options, !v.isInitialized {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._inputType)
-        case 3: try decoder.decodeSingularStringField(value: &_storage._outputType)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._options)
-        case 5: try decoder.decodeSingularBoolField(value: &_storage._clientStreaming)
-        case 6: try decoder.decodeSingularBoolField(value: &_storage._serverStreaming)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self._name)
+      case 2: try decoder.decodeSingularStringField(value: &self._inputType)
+      case 3: try decoder.decodeSingularStringField(value: &self._outputType)
+      case 4: try decoder.decodeSingularMessageField(value: &self._options)
+      case 5: try decoder.decodeSingularBoolField(value: &self._clientStreaming)
+      case 6: try decoder.decodeSingularBoolField(value: &self._serverStreaming)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._name {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._inputType {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._outputType {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._options {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._clientStreaming {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._serverStreaming {
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
-      }
+    if let v = self._name {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._inputType {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._outputType {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }
+    if let v = self._options {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if let v = self._clientStreaming {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
+    }
+    if let v = self._serverStreaming {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_MethodDescriptorProto, rhs: Google_Protobuf_MethodDescriptorProto) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._inputType != rhs_storage._inputType {return false}
-        if _storage._outputType != rhs_storage._outputType {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._clientStreaming != rhs_storage._clientStreaming {return false}
-        if _storage._serverStreaming != rhs_storage._serverStreaming {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._name != rhs._name {return false}
+    if lhs._inputType != rhs._inputType {return false}
+    if lhs._outputType != rhs._outputType {return false}
+    if lhs._options != rhs._options {return false}
+    if lhs._clientStreaming != rhs._clientStreaming {return false}
+    if lhs._serverStreaming != rhs._serverStreaming {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -104,11 +104,16 @@ public struct Google_Protobuf_Struct {
   // methods supported on all messages.
 
   /// Unordered map of dynamically typed values.
-  public var fields: Dictionary<String,Google_Protobuf_Value> = [:]
+  public var fields: Dictionary<String,Google_Protobuf_Value> {
+    get {return _storage._fields}
+    set {_uniqueStorage()._fields = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `Value` represents a dynamically typed value which can be either
@@ -214,11 +219,16 @@ public struct Google_Protobuf_ListValue {
   // methods supported on all messages.
 
   /// Repeated field of dynamically typed values.
-  public var values: [Google_Protobuf_Value] = []
+  public var values: [Google_Protobuf_Value] {
+    get {return _storage._values}
+    set {_uniqueStorage()._values = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -237,24 +247,56 @@ extension Google_Protobuf_Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     1: .same(proto: "fields"),
   ]
 
+  fileprivate class _StorageClass {
+    var _fields: Dictionary<String,Google_Protobuf_Value> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _fields = source._fields
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &_storage._fields)
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.fields.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._fields.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: _storage._fields, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Struct, rhs: Google_Protobuf_Struct) -> Bool {
-    if lhs.fields != rhs.fields {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._fields != rhs_storage._fields {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -379,24 +421,56 @@ extension Google_Protobuf_ListValue: SwiftProtobuf.Message, SwiftProtobuf._Messa
     1: .same(proto: "values"),
   ]
 
+  fileprivate class _StorageClass {
+    var _values: [Google_Protobuf_Value] = []
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _values = source._values
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeRepeatedMessageField(value: &self.values)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._values)
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.values.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._values.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._values, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_ListValue, rhs: Google_Protobuf_ListValue) -> Bool {
-    if lhs.values != rhs.values {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._values != rhs_storage._values {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -104,16 +104,11 @@ public struct Google_Protobuf_Struct {
   // methods supported on all messages.
 
   /// Unordered map of dynamically typed values.
-  public var fields: Dictionary<String,Google_Protobuf_Value> {
-    get {return _storage._fields}
-    set {_uniqueStorage()._fields = newValue}
-  }
+  public var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `Value` represents a dynamically typed value which can be either
@@ -128,63 +123,60 @@ public struct Google_Protobuf_Value {
   // methods supported on all messages.
 
   /// The kind of value.
-  public var kind: OneOf_Kind? {
-    get {return _storage._kind}
-    set {_uniqueStorage()._kind = newValue}
-  }
+  public var kind: Google_Protobuf_Value.OneOf_Kind? = nil
 
   /// Represents a null value.
   public var nullValue: Google_Protobuf_NullValue {
     get {
-      if case .nullValue(let v)? = _storage._kind {return v}
+      if case .nullValue(let v)? = kind {return v}
       return .nullValue
     }
-    set {_uniqueStorage()._kind = .nullValue(newValue)}
+    set {kind = .nullValue(newValue)}
   }
 
   /// Represents a double value.
   public var numberValue: Double {
     get {
-      if case .numberValue(let v)? = _storage._kind {return v}
+      if case .numberValue(let v)? = kind {return v}
       return 0
     }
-    set {_uniqueStorage()._kind = .numberValue(newValue)}
+    set {kind = .numberValue(newValue)}
   }
 
   /// Represents a string value.
   public var stringValue: String {
     get {
-      if case .stringValue(let v)? = _storage._kind {return v}
+      if case .stringValue(let v)? = kind {return v}
       return String()
     }
-    set {_uniqueStorage()._kind = .stringValue(newValue)}
+    set {kind = .stringValue(newValue)}
   }
 
   /// Represents a boolean value.
   public var boolValue: Bool {
     get {
-      if case .boolValue(let v)? = _storage._kind {return v}
+      if case .boolValue(let v)? = kind {return v}
       return false
     }
-    set {_uniqueStorage()._kind = .boolValue(newValue)}
+    set {kind = .boolValue(newValue)}
   }
 
   /// Represents a structured value.
   public var structValue: Google_Protobuf_Struct {
     get {
-      if case .structValue(let v)? = _storage._kind {return v}
+      if case .structValue(let v)? = kind {return v}
       return Google_Protobuf_Struct()
     }
-    set {_uniqueStorage()._kind = .structValue(newValue)}
+    set {kind = .structValue(newValue)}
   }
 
   /// Represents a repeated `Value`.
   public var listValue: Google_Protobuf_ListValue {
     get {
-      if case .listValue(let v)? = _storage._kind {return v}
+      if case .listValue(let v)? = kind {return v}
       return Google_Protobuf_ListValue()
     }
-    set {_uniqueStorage()._kind = .listValue(newValue)}
+    set {kind = .listValue(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -206,8 +198,6 @@ public struct Google_Protobuf_Value {
   }
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// `ListValue` is a wrapper around a repeated field of values.
@@ -219,16 +209,11 @@ public struct Google_Protobuf_ListValue {
   // methods supported on all messages.
 
   /// Repeated field of dynamically typed values.
-  public var values: [Google_Protobuf_Value] {
-    get {return _storage._values}
-    set {_uniqueStorage()._values = newValue}
-  }
+  public var values: [Google_Protobuf_Value] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -247,56 +232,24 @@ extension Google_Protobuf_Struct: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     1: .same(proto: "fields"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fields: Dictionary<String,Google_Protobuf_Value> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fields = source._fields
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &_storage._fields)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._fields.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: _storage._fields, fieldNumber: 1)
-      }
+    if !self.fields.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Struct, rhs: Google_Protobuf_Struct) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fields != rhs_storage._fields {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.fields != rhs.fields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -313,103 +266,71 @@ extension Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     6: .standard(proto: "list_value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _kind: Google_Protobuf_Value.OneOf_Kind?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _kind = source._kind
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Google_Protobuf_NullValue?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._kind = .nullValue(v)}
-        case 2:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Double?
-          try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._kind = .numberValue(v)}
-        case 3:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._kind = .stringValue(v)}
-        case 4:
-          if _storage._kind != nil {try decoder.handleConflictingOneOf()}
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._kind = .boolValue(v)}
-        case 5:
-          var v: Google_Protobuf_Struct?
-          if let current = _storage._kind {
-            try decoder.handleConflictingOneOf()
-            if case .structValue(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._kind = .structValue(v)}
-        case 6:
-          var v: Google_Protobuf_ListValue?
-          if let current = _storage._kind {
-            try decoder.handleConflictingOneOf()
-            if case .listValue(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._kind = .listValue(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Google_Protobuf_NullValue?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.kind = .nullValue(v)}
+      case 2:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Double?
+        try decoder.decodeSingularDoubleField(value: &v)
+        if let v = v {self.kind = .numberValue(v)}
+      case 3:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.kind = .stringValue(v)}
+      case 4:
+        if self.kind != nil {try decoder.handleConflictingOneOf()}
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {self.kind = .boolValue(v)}
+      case 5:
+        var v: Google_Protobuf_Struct?
+        if let current = self.kind {
+          try decoder.handleConflictingOneOf()
+          if case .structValue(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.kind = .structValue(v)}
+      case 6:
+        var v: Google_Protobuf_ListValue?
+        if let current = self.kind {
+          try decoder.handleConflictingOneOf()
+          if case .listValue(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.kind = .listValue(v)}
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._kind {
-      case .nullValue(let v)?:
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-      case .numberValue(let v)?:
-        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-      case .stringValue(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case .boolValue(let v)?:
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-      case .structValue(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      case .listValue(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      case nil: break
-      }
+    switch self.kind {
+    case .nullValue(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+    case .numberValue(let v)?:
+      try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+    case .stringValue(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case .boolValue(let v)?:
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+    case .structValue(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    case .listValue(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Value, rhs: Google_Protobuf_Value) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._kind != rhs_storage._kind {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.kind != rhs.kind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -421,56 +342,24 @@ extension Google_Protobuf_ListValue: SwiftProtobuf.Message, SwiftProtobuf._Messa
     1: .same(proto: "values"),
   ]
 
-  fileprivate class _StorageClass {
-    var _values: [Google_Protobuf_Value] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _values = source._values
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedMessageField(value: &_storage._values)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.values)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._values.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._values, fieldNumber: 1)
-      }
+    if !self.values.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_ListValue, rhs: Google_Protobuf_ListValue) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._values != rhs_storage._values {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.values != rhs.values {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -100,50 +100,35 @@ public struct Google_Protobuf_Type {
   // methods supported on all messages.
 
   /// The fully qualified message name.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// The list of fields.
-  public var fields: [Google_Protobuf_Field] {
-    get {return _storage._fields}
-    set {_uniqueStorage()._fields = newValue}
-  }
+  public var fields: [Google_Protobuf_Field] = []
 
   /// The list of types appearing in `oneof` definitions in this type.
-  public var oneofs: [String] {
-    get {return _storage._oneofs}
-    set {_uniqueStorage()._oneofs = newValue}
-  }
+  public var oneofs: [String] = []
 
   /// The protocol buffer options.
-  public var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  public var options: [Google_Protobuf_Option] = []
 
   /// The source context.
   public var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  public var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  public var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  public mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  public mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// The source syntax.
-  public var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  public var syntax: Google_Protobuf_Syntax = .proto2
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// A single field of a message type.
@@ -396,44 +381,32 @@ public struct Google_Protobuf_Enum {
   // methods supported on all messages.
 
   /// Enum type name.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// Enum value definitions.
-  public var enumvalue: [Google_Protobuf_EnumValue] {
-    get {return _storage._enumvalue}
-    set {_uniqueStorage()._enumvalue = newValue}
-  }
+  public var enumvalue: [Google_Protobuf_EnumValue] = []
 
   /// Protocol buffer options.
-  public var options: [Google_Protobuf_Option] {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  public var options: [Google_Protobuf_Option] = []
 
   /// The source context.
   public var sourceContext: Google_Protobuf_SourceContext {
-    get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
-    set {_uniqueStorage()._sourceContext = newValue}
+    get {return _sourceContext ?? Google_Protobuf_SourceContext()}
+    set {_sourceContext = newValue}
   }
   /// Returns true if `sourceContext` has been explicitly set.
-  public var hasSourceContext: Bool {return _storage._sourceContext != nil}
+  public var hasSourceContext: Bool {return self._sourceContext != nil}
   /// Clears the value of `sourceContext`. Subsequent reads from it will return its default value.
-  public mutating func clearSourceContext() {_uniqueStorage()._sourceContext = nil}
+  public mutating func clearSourceContext() {self._sourceContext = nil}
 
   /// The source syntax.
-  public var syntax: Google_Protobuf_Syntax {
-    get {return _storage._syntax}
-    set {_uniqueStorage()._syntax = newValue}
-  }
+  public var syntax: Google_Protobuf_Syntax = .proto2
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _sourceContext: Google_Protobuf_SourceContext? = nil
 }
 
 /// Enum value definition.
@@ -467,29 +440,26 @@ public struct Google_Protobuf_Option {
   /// descriptor.proto), this is the short name. For example, `"map_entry"`.
   /// For custom options, it should be the fully-qualified name. For example,
   /// `"google.api.http"`.
-  public var name: String {
-    get {return _storage._name}
-    set {_uniqueStorage()._name = newValue}
-  }
+  public var name: String = String()
 
   /// The option's value packed in an Any message. If the value is a primitive,
   /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
   /// should be used. If the value is an enum, it should be stored as an int32
   /// value using the google.protobuf.Int32Value type.
   public var value: Google_Protobuf_Any {
-    get {return _storage._value ?? Google_Protobuf_Any()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? Google_Protobuf_Any()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  public var hasValue: Bool {return _storage._value != nil}
+  public var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  public mutating func clearValue() {_uniqueStorage()._value = nil}
+  public mutating func clearValue() {self._value = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _value: Google_Protobuf_Any? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -514,91 +484,49 @@ extension Google_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     6: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _fields: [Google_Protobuf_Field] = []
-    var _oneofs: [String] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _fields = source._fields
-      _oneofs = source._oneofs
-      _options = source._options
-      _sourceContext = source._sourceContext
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._fields)
-        case 3: try decoder.decodeRepeatedStringField(value: &_storage._oneofs)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 5: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 6: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.fields)
+      case 3: try decoder.decodeRepeatedStringField(value: &self.oneofs)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 5: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 6: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._fields.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._fields, fieldNumber: 2)
-      }
-      if !_storage._oneofs.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._oneofs, fieldNumber: 3)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 4)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 6)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.fields.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.fields, fieldNumber: 2)
+    }
+    if !self.oneofs.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.oneofs, fieldNumber: 3)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 4)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Type, rhs: Google_Protobuf_Type) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._fields != rhs_storage._fields {return false}
-        if _storage._oneofs != rhs_storage._oneofs {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.fields != rhs.fields {return false}
+    if lhs.oneofs != rhs.oneofs {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -730,84 +658,44 @@ extension Google_Protobuf_Enum: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     5: .same(proto: "syntax"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _enumvalue: [Google_Protobuf_EnumValue] = []
-    var _options: [Google_Protobuf_Option] = []
-    var _sourceContext: Google_Protobuf_SourceContext? = nil
-    var _syntax: Google_Protobuf_Syntax = .proto2
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _enumvalue = source._enumvalue
-      _options = source._options
-      _sourceContext = source._sourceContext
-      _syntax = source._syntax
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._enumvalue)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._options)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._sourceContext)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._syntax)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.enumvalue)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.options)
+      case 4: try decoder.decodeSingularMessageField(value: &self._sourceContext)
+      case 5: try decoder.decodeSingularEnumField(value: &self.syntax)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if !_storage._enumvalue.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._enumvalue, fieldNumber: 2)
-      }
-      if !_storage._options.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._options, fieldNumber: 3)
-      }
-      if let v = _storage._sourceContext {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if _storage._syntax != .proto2 {
-        try visitor.visitSingularEnumField(value: _storage._syntax, fieldNumber: 5)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.enumvalue.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.enumvalue, fieldNumber: 2)
+    }
+    if !self.options.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.options, fieldNumber: 3)
+    }
+    if let v = self._sourceContext {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if self.syntax != .proto2 {
+      try visitor.visitSingularEnumField(value: self.syntax, fieldNumber: 5)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Enum, rhs: Google_Protobuf_Enum) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._enumvalue != rhs_storage._enumvalue {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._sourceContext != rhs_storage._sourceContext {return false}
-        if _storage._syntax != rhs_storage._syntax {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs.enumvalue != rhs.enumvalue {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._sourceContext != rhs._sourceContext {return false}
+    if lhs.syntax != rhs.syntax {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -861,63 +749,29 @@ extension Google_Protobuf_Option: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     2: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _name: String = String()
-    var _value: Google_Protobuf_Any? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _name = source._name
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularStringField(value: &_storage._name)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularStringField(value: &self.name)
+      case 2: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._name.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._name, fieldNumber: 1)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Option, rhs: Google_Protobuf_Option) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._name != rhs_storage._name {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.name != rhs.name {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
@@ -128,20 +128,17 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest {
   /// The .proto files that were explicitly listed on the command-line.  The
   /// code generator should generate code only for these files.  Each file's
   /// descriptor will be included in proto_file, below.
-  public var fileToGenerate: [String] {
-    get {return _storage._fileToGenerate}
-    set {_uniqueStorage()._fileToGenerate = newValue}
-  }
+  public var fileToGenerate: [String] = []
 
   /// The generator parameter passed on the command-line.
   public var parameter: String {
-    get {return _storage._parameter ?? String()}
-    set {_uniqueStorage()._parameter = newValue}
+    get {return _parameter ?? String()}
+    set {_parameter = newValue}
   }
   /// Returns true if `parameter` has been explicitly set.
-  public var hasParameter: Bool {return _storage._parameter != nil}
+  public var hasParameter: Bool {return self._parameter != nil}
   /// Clears the value of `parameter`. Subsequent reads from it will return its default value.
-  public mutating func clearParameter() {_uniqueStorage()._parameter = nil}
+  public mutating func clearParameter() {self._parameter = nil}
 
   /// FileDescriptorProtos for all files in files_to_generate and everything
   /// they import.  The files will appear in topological order, so each file
@@ -157,26 +154,24 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest {
   ///
   /// Type names of fields and extensions in the FileDescriptorProto are always
   /// fully qualified.
-  public var protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] {
-    get {return _storage._protoFile}
-    set {_uniqueStorage()._protoFile = newValue}
-  }
+  public var protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] = []
 
   /// The version number of protocol compiler.
   public var compilerVersion: Google_Protobuf_Compiler_Version {
-    get {return _storage._compilerVersion ?? Google_Protobuf_Compiler_Version()}
-    set {_uniqueStorage()._compilerVersion = newValue}
+    get {return _compilerVersion ?? Google_Protobuf_Compiler_Version()}
+    set {_compilerVersion = newValue}
   }
   /// Returns true if `compilerVersion` has been explicitly set.
-  public var hasCompilerVersion: Bool {return _storage._compilerVersion != nil}
+  public var hasCompilerVersion: Bool {return self._compilerVersion != nil}
   /// Clears the value of `compilerVersion`. Subsequent reads from it will return its default value.
-  public mutating func clearCompilerVersion() {_uniqueStorage()._compilerVersion = nil}
+  public mutating func clearCompilerVersion() {self._compilerVersion = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _parameter: String? = nil
+  fileprivate var _compilerVersion: Google_Protobuf_Compiler_Version? = nil
 }
 
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
@@ -362,84 +357,44 @@ extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, 
     3: .standard(proto: "compiler_version"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fileToGenerate: [String] = []
-    var _parameter: String? = nil
-    var _protoFile: [SwiftProtobuf.Google_Protobuf_FileDescriptorProto] = []
-    var _compilerVersion: Google_Protobuf_Compiler_Version? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fileToGenerate = source._fileToGenerate
-      _parameter = source._parameter
-      _protoFile = source._protoFile
-      _compilerVersion = source._compilerVersion
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._protoFile) {return false}
-      return true
-    }
+    if !SwiftProtobuf.Internal.areAllInitialized(self.protoFile) {return false}
+    return true
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeRepeatedStringField(value: &_storage._fileToGenerate)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._parameter)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._compilerVersion)
-        case 15: try decoder.decodeRepeatedMessageField(value: &_storage._protoFile)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedStringField(value: &self.fileToGenerate)
+      case 2: try decoder.decodeSingularStringField(value: &self._parameter)
+      case 3: try decoder.decodeSingularMessageField(value: &self._compilerVersion)
+      case 15: try decoder.decodeRepeatedMessageField(value: &self.protoFile)
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._fileToGenerate.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._fileToGenerate, fieldNumber: 1)
-      }
-      if let v = _storage._parameter {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._compilerVersion {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._protoFile.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._protoFile, fieldNumber: 15)
-      }
+    if !self.fileToGenerate.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.fileToGenerate, fieldNumber: 1)
+    }
+    if let v = self._parameter {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._compilerVersion {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.protoFile.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.protoFile, fieldNumber: 15)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_Compiler_CodeGeneratorRequest, rhs: Google_Protobuf_Compiler_CodeGeneratorRequest) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fileToGenerate != rhs_storage._fileToGenerate {return false}
-        if _storage._parameter != rhs_storage._parameter {return false}
-        if _storage._protoFile != rhs_storage._protoFile {return false}
-        if _storage._compilerVersion != rhs_storage._compilerVersion {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.fileToGenerate != rhs.fileToGenerate {return false}
+    if lhs._parameter != rhs._parameter {return false}
+    if lhs.protoFile != rhs.protoFile {return false}
+    if lhs._compilerVersion != rhs._compilerVersion {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -502,10 +502,16 @@ fileprivate func hasRecursiveSingularField(descriptor: Descriptor, visited: [Des
   var visited = visited
   visited.append(descriptor)
   return descriptor.fields.contains {
-    // Repeated fields use heap storage already
-    if ($0.type != .message && $0.type != .group) || $0.label == .repeated {
+    // Ignore fields that aren’t messages or groups.
+    if $0.type != .message && $0.type != .group {
       return false
     }
+
+    // Repeated fields already use heap storage (for the array).
+    if $0.label == .repeated {
+      return false
+    }
+
     guard let messageType = $0.messageType else {
       return false
     }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -498,14 +498,6 @@ class MessageGenerator {
   }
 }
 
-fileprivate func hasSingleMessageField(descriptor: Descriptor) -> Bool {
-  let result = descriptor.fields.contains {
-    // Repeated check also rules out maps.
-    ($0.type == .message || $0.type == .group) && $0.label != .repeated
-  }
-  return result
-}
-
 fileprivate func hasRecursiveSingularField(descriptor: Descriptor, visited: [Descriptor] = []) -> Bool {
   var visited = visited
   visited.append(descriptor)

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -516,7 +516,7 @@ fileprivate func hasRecursiveSingularField(descriptor: Descriptor, visited: [Des
     }
 
     // Skip other visited fields.
-    if (visited[1...].contains { $0 === messageType }) {
+    if (visited.contains { $0 === messageType }) {
       return false
     }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -517,9 +517,19 @@ fileprivate func hasRecursiveSingularField(descriptor: Descriptor, visited: [Des
     guard let messageType = $0.messageType else {
       return false
     }
-    return visited.contains {
-      $0 === messageType
-    } || hasRecursiveSingularField(descriptor: messageType, visited: visited)
+
+    // We only care if the message or sub-message recurses to the root message.
+    if messageType === visited[0] {
+      return true
+    }
+
+    // Skip other visited fields.
+    if (visited[1...].contains { $0 === messageType }) {
+      return false
+    }
+
+    // Examine sub-message.
+    return hasRecursiveSingularField(descriptor: messageType, visited: visited)
   }
 }
 

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -54,30 +54,24 @@ struct ProtobufUnittest_TestAny {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var int32Value: Int32 {
-    get {return _storage._int32Value}
-    set {_uniqueStorage()._int32Value = newValue}
-  }
+  var int32Value: Int32 = 0
 
   var anyValue: SwiftProtobuf.Google_Protobuf_Any {
-    get {return _storage._anyValue ?? SwiftProtobuf.Google_Protobuf_Any()}
-    set {_uniqueStorage()._anyValue = newValue}
+    get {return _anyValue ?? SwiftProtobuf.Google_Protobuf_Any()}
+    set {_anyValue = newValue}
   }
   /// Returns true if `anyValue` has been explicitly set.
-  var hasAnyValue: Bool {return _storage._anyValue != nil}
+  var hasAnyValue: Bool {return self._anyValue != nil}
   /// Clears the value of `anyValue`. Subsequent reads from it will return its default value.
-  mutating func clearAnyValue() {_uniqueStorage()._anyValue = nil}
+  mutating func clearAnyValue() {self._anyValue = nil}
 
-  var repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] {
-    get {return _storage._repeatedAnyValue}
-    set {_uniqueStorage()._repeatedAnyValue = newValue}
-  }
+  var repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _anyValue: SwiftProtobuf.Google_Protobuf_Any? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -92,70 +86,34 @@ extension ProtobufUnittest_TestAny: SwiftProtobuf.Message, SwiftProtobuf._Messag
     3: .standard(proto: "repeated_any_value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _int32Value: Int32 = 0
-    var _anyValue: SwiftProtobuf.Google_Protobuf_Any? = nil
-    var _repeatedAnyValue: [SwiftProtobuf.Google_Protobuf_Any] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _int32Value = source._int32Value
-      _anyValue = source._anyValue
-      _repeatedAnyValue = source._repeatedAnyValue
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._int32Value)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._anyValue)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAnyValue)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self.int32Value)
+      case 2: try decoder.decodeSingularMessageField(value: &self._anyValue)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAnyValue)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._int32Value != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._int32Value, fieldNumber: 1)
-      }
-      if let v = _storage._anyValue {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAnyValue.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAnyValue, fieldNumber: 3)
-      }
+    if self.int32Value != 0 {
+      try visitor.visitSingularInt32Field(value: self.int32Value, fieldNumber: 1)
+    }
+    if let v = self._anyValue {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAnyValue.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAnyValue, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestAny, rhs: ProtobufUnittest_TestAny) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._int32Value != rhs_storage._int32Value {return false}
-        if _storage._anyValue != rhs_storage._anyValue {return false}
-        if _storage._repeatedAnyValue != rhs_storage._repeatedAnyValue {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.int32Value != rhs.int32Value {return false}
+    if lhs._anyValue != rhs._anyValue {return false}
+    if lhs.repeatedAnyValue != rhs.repeatedAnyValue {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -206,82 +206,67 @@ struct Conformance_ConformanceRequest {
   /// TODO(haberman): if/when we expand the conformance tests to support proto2,
   /// we will want to include a field that lets the payload/response be a
   /// protobuf_test_messages.proto2.TestAllTypes message instead.
-  var payload: OneOf_Payload? {
-    get {return _storage._payload}
-    set {_uniqueStorage()._payload = newValue}
-  }
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = _storage._payload {return v}
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._payload = .protobufPayload(newValue)}
+    set {payload = .protobufPayload(newValue)}
   }
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = _storage._payload {return v}
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jsonPayload(newValue)}
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Google internal only.  Opensource testees just skip it.
   var jspbPayload: String {
     get {
-      if case .jspbPayload(let v)? = _storage._payload {return v}
+      if case .jspbPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .jspbPayload(newValue)}
+    set {payload = .jspbPayload(newValue)}
   }
 
   var textPayload: String {
     get {
-      if case .textPayload(let v)? = _storage._payload {return v}
+      if case .textPayload(let v)? = payload {return v}
       return String()
     }
-    set {_uniqueStorage()._payload = .textPayload(newValue)}
+    set {payload = .textPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
-  var requestedOutputFormat: Conformance_WireFormat {
-    get {return _storage._requestedOutputFormat}
-    set {_uniqueStorage()._requestedOutputFormat = newValue}
-  }
+  var requestedOutputFormat: Conformance_WireFormat = .unspecified
 
   /// The full name for the test message to use; for the moment, either:
   /// protobuf_test_messages.proto3.TestAllTypesProto3 or
   /// protobuf_test_messages.proto2.TestAllTypesProto2.
-  var messageType: String {
-    get {return _storage._messageType}
-    set {_uniqueStorage()._messageType = newValue}
-  }
+  var messageType: String = String()
 
   /// Each test is given a specific test category. Some category may need
   /// spedific support in testee programs. Refer to the defintion of TestCategory
   /// for more information.
-  var testCategory: Conformance_TestCategory {
-    get {return _storage._testCategory}
-    set {_uniqueStorage()._testCategory = newValue}
-  }
+  var testCategory: Conformance_TestCategory = .unspecifiedTest
 
   /// Specify details for how to encode jspb.
   var jspbEncodingOptions: Conformance_JspbEncodingConfig {
-    get {return _storage._jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
-    set {_uniqueStorage()._jspbEncodingOptions = newValue}
+    get {return _jspbEncodingOptions ?? Conformance_JspbEncodingConfig()}
+    set {_jspbEncodingOptions = newValue}
   }
   /// Returns true if `jspbEncodingOptions` has been explicitly set.
-  var hasJspbEncodingOptions: Bool {return _storage._jspbEncodingOptions != nil}
+  var hasJspbEncodingOptions: Bool {return self._jspbEncodingOptions != nil}
   /// Clears the value of `jspbEncodingOptions`. Subsequent reads from it will return its default value.
-  mutating func clearJspbEncodingOptions() {_uniqueStorage()._jspbEncodingOptions = nil}
+  mutating func clearJspbEncodingOptions() {self._jspbEncodingOptions = nil}
 
   /// This can be used in json and text format. If true, testee should print
   /// unknown fields instead of ignore. This feature is optional.
-  var printUnknownFields: Bool {
-    get {return _storage._printUnknownFields}
-    set {_uniqueStorage()._printUnknownFields = newValue}
-  }
+  var printUnknownFields: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -302,7 +287,7 @@ struct Conformance_ConformanceRequest {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
 }
 
 /// Represents a single test case's output.
@@ -519,123 +504,81 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
     9: .standard(proto: "print_unknown_fields"),
   ]
 
-  fileprivate class _StorageClass {
-    var _payload: Conformance_ConformanceRequest.OneOf_Payload?
-    var _requestedOutputFormat: Conformance_WireFormat = .unspecified
-    var _messageType: String = String()
-    var _testCategory: Conformance_TestCategory = .unspecifiedTest
-    var _jspbEncodingOptions: Conformance_JspbEncodingConfig? = nil
-    var _printUnknownFields: Bool = false
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _payload = source._payload
-      _requestedOutputFormat = source._requestedOutputFormat
-      _messageType = source._messageType
-      _testCategory = source._testCategory
-      _jspbEncodingOptions = source._jspbEncodingOptions
-      _printUnknownFields = source._printUnknownFields
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._payload = .protobufPayload(v)}
-        case 2:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jsonPayload(v)}
-        case 3: try decoder.decodeSingularEnumField(value: &_storage._requestedOutputFormat)
-        case 4: try decoder.decodeSingularStringField(value: &_storage._messageType)
-        case 5: try decoder.decodeSingularEnumField(value: &_storage._testCategory)
-        case 6: try decoder.decodeSingularMessageField(value: &_storage._jspbEncodingOptions)
-        case 7:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .jspbPayload(v)}
-        case 8:
-          if _storage._payload != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._payload = .textPayload(v)}
-        case 9: try decoder.decodeSingularBoolField(value: &_storage._printUnknownFields)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.payload = .protobufPayload(v)}
+      case 2:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jsonPayload(v)}
+      case 3: try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat)
+      case 4: try decoder.decodeSingularStringField(value: &self.messageType)
+      case 5: try decoder.decodeSingularEnumField(value: &self.testCategory)
+      case 6: try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions)
+      case 7:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .jspbPayload(v)}
+      case 8:
+        if self.payload != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.payload = .textPayload(v)}
+      case 9: try decoder.decodeSingularBoolField(value: &self.printUnknownFields)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._payload {
-      case .protobufPayload(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-      case .jsonPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case nil: break
-      default: break
-      }
-      if _storage._requestedOutputFormat != .unspecified {
-        try visitor.visitSingularEnumField(value: _storage._requestedOutputFormat, fieldNumber: 3)
-      }
-      if !_storage._messageType.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._messageType, fieldNumber: 4)
-      }
-      if _storage._testCategory != .unspecifiedTest {
-        try visitor.visitSingularEnumField(value: _storage._testCategory, fieldNumber: 5)
-      }
-      if let v = _storage._jspbEncodingOptions {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }
-      switch _storage._payload {
-      case .jspbPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      case .textPayload(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 8)
-      case nil: break
-      default: break
-      }
-      if _storage._printUnknownFields != false {
-        try visitor.visitSingularBoolField(value: _storage._printUnknownFields, fieldNumber: 9)
-      }
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case nil: break
+    default: break
+    }
+    if self.requestedOutputFormat != .unspecified {
+      try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
+    }
+    if !self.messageType.isEmpty {
+      try visitor.visitSingularStringField(value: self.messageType, fieldNumber: 4)
+    }
+    if self.testCategory != .unspecifiedTest {
+      try visitor.visitSingularEnumField(value: self.testCategory, fieldNumber: 5)
+    }
+    if let v = self._jspbEncodingOptions {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }
+    switch self.payload {
+    case .jspbPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    case .textPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 8)
+    case nil: break
+    default: break
+    }
+    if self.printUnknownFields != false {
+      try visitor.visitSingularBoolField(value: self.printUnknownFields, fieldNumber: 9)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Conformance_ConformanceRequest, rhs: Conformance_ConformanceRequest) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._payload != rhs_storage._payload {return false}
-        if _storage._requestedOutputFormat != rhs_storage._requestedOutputFormat {return false}
-        if _storage._messageType != rhs_storage._messageType {return false}
-        if _storage._testCategory != rhs_storage._testCategory {return false}
-        if _storage._jspbEncodingOptions != rhs_storage._jspbEncodingOptions {return false}
-        if _storage._printUnknownFields != rhs_storage._printUnknownFields {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.payload != rhs.payload {return false}
+    if lhs.requestedOutputFormat != rhs.requestedOutputFormat {return false}
+    if lhs.messageType != rhs.messageType {return false}
+    if lhs.testCategory != rhs.testCategory {return false}
+    if lhs._jspbEncodingOptions != rhs._jspbEncodingOptions {return false}
+    if lhs.printUnknownFields != rhs.printUnknownFields {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -220,19 +220,19 @@ struct ProtobufUnittest_TestSubmessageMaps {
   // methods supported on all messages.
 
   var m: ProtobufUnittest_TestMaps {
-    get {return _storage._m ?? ProtobufUnittest_TestMaps()}
-    set {_uniqueStorage()._m = newValue}
+    get {return _m ?? ProtobufUnittest_TestMaps()}
+    set {_m = newValue}
   }
   /// Returns true if `m` has been explicitly set.
-  var hasM: Bool {return _storage._m != nil}
+  var hasM: Bool {return self._m != nil}
   /// Clears the value of `m`. Subsequent reads from it will return its default value.
-  mutating func clearM() {_uniqueStorage()._m = nil}
+  mutating func clearM() {self._m = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _m: ProtobufUnittest_TestMaps? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -485,56 +485,24 @@ extension ProtobufUnittest_TestSubmessageMaps: SwiftProtobuf.Message, SwiftProto
     1: .same(proto: "m"),
   ]
 
-  fileprivate class _StorageClass {
-    var _m: ProtobufUnittest_TestMaps? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _m = source._m
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._m)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._m)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._m {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._m {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestSubmessageMaps, rhs: ProtobufUnittest_TestSubmessageMaps) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._m != rhs_storage._m {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._m != rhs._m {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -371,10 +371,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> {
-    get {return _storage._type}
-    set {_uniqueStorage()._type = newValue}
-  }
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -404,8 +401,6 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -437,16 +432,11 @@ struct ProtobufUnittest_TestRecursiveMapMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> {
-    get {return _storage._a}
-    set {_uniqueStorage()._a = newValue}
-  }
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -996,56 +986,24 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Messag
     1: .same(proto: "type"),
   ]
 
-  fileprivate class _StorageClass {
-    var _type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _type = source._type
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &_storage._type)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &self.type)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._type.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: _storage._type, fieldNumber: 1)
-      }
+    if !self.type.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: self.type, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_MessageContainingEnumCalledType, rhs: ProtobufUnittest_MessageContainingEnumCalledType) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._type != rhs_storage._type {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.type != rhs.type {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1092,56 +1050,24 @@ extension ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message, Swift
     1: .same(proto: "a"),
   ]
 
-  fileprivate class _StorageClass {
-    var _a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _a = source._a
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &_storage._a)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &self.a)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !_storage._a.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: _storage._a, fieldNumber: 1)
-      }
+    if !self.a.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: self.a, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRecursiveMapMessage, rhs: ProtobufUnittest_TestRecursiveMapMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._a != rhs_storage._a {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.a != rhs.a {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -207,19 +207,19 @@ struct ProtobufUnittest_TestMapSubmessage {
   // methods supported on all messages.
 
   var testMap: ProtobufUnittest_TestMap {
-    get {return _storage._testMap ?? ProtobufUnittest_TestMap()}
-    set {_uniqueStorage()._testMap = newValue}
+    get {return _testMap ?? ProtobufUnittest_TestMap()}
+    set {_testMap = newValue}
   }
   /// Returns true if `testMap` has been explicitly set.
-  var hasTestMap: Bool {return _storage._testMap != nil}
+  var hasTestMap: Bool {return self._testMap != nil}
   /// Clears the value of `testMap`. Subsequent reads from it will return its default value.
-  mutating func clearTestMap() {_uniqueStorage()._testMap = nil}
+  mutating func clearTestMap() {self._testMap = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _testMap: ProtobufUnittest_TestMap? = nil
 }
 
 struct ProtobufUnittest_TestMessageMap {
@@ -371,7 +371,10 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> {
+    get {return _storage._type}
+    set {_uniqueStorage()._type = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -401,6 +404,8 @@ struct ProtobufUnittest_MessageContainingEnumCalledType {
   }
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -432,11 +437,16 @@ struct ProtobufUnittest_TestRecursiveMapMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> {
+    get {return _storage._a}
+    set {_uniqueStorage()._a = newValue}
+  }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -662,56 +672,24 @@ extension ProtobufUnittest_TestMapSubmessage: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "test_map"),
   ]
 
-  fileprivate class _StorageClass {
-    var _testMap: ProtobufUnittest_TestMap? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _testMap = source._testMap
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._testMap)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._testMap)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._testMap {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._testMap {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMapSubmessage, rhs: ProtobufUnittest_TestMapSubmessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._testMap != rhs_storage._testMap {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._testMap != rhs._testMap {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1018,24 +996,56 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Messag
     1: .same(proto: "type"),
   ]
 
+  fileprivate class _StorageClass {
+    var _type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _type = source._type
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &self.type)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: &_storage._type)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.type.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: self.type, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._type.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_MessageContainingEnumCalledType>.self, value: _storage._type, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_MessageContainingEnumCalledType, rhs: ProtobufUnittest_MessageContainingEnumCalledType) -> Bool {
-    if lhs.type != rhs.type {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._type != rhs_storage._type {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -1082,24 +1092,56 @@ extension ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message, Swift
     1: .same(proto: "a"),
   ]
 
+  fileprivate class _StorageClass {
+    var _a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _a = source._a
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      switch fieldNumber {
-      case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &self.a)
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        switch fieldNumber {
+        case 1: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: &_storage._a)
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.a.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: self.a, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if !_storage._a.isEmpty {
+        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufUnittest_TestRecursiveMapMessage>.self, value: _storage._a, fieldNumber: 1)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRecursiveMapMessage, rhs: ProtobufUnittest_TestRecursiveMapMessage) -> Bool {
-    if lhs.a != rhs.a {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._a != rhs_storage._a {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1410,22 +1410,22 @@ struct ProtobufUnittest_TestGroup {
   // methods supported on all messages.
 
   var optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestGroup.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestGroup.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
   var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
-    get {return _storage._optionalForeignEnum ?? .foreignFoo}
-    set {_uniqueStorage()._optionalForeignEnum = newValue}
+    get {return _optionalForeignEnum ?? .foreignFoo}
+    set {_optionalForeignEnum = newValue}
   }
   /// Returns true if `optionalForeignEnum` has been explicitly set.
-  var hasOptionalForeignEnum: Bool {return _storage._optionalForeignEnum != nil}
+  var hasOptionalForeignEnum: Bool {return self._optionalForeignEnum != nil}
   /// Clears the value of `optionalForeignEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalForeignEnum() {_uniqueStorage()._optionalForeignEnum = nil}
+  mutating func clearOptionalForeignEnum() {self._optionalForeignEnum = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1452,7 +1452,8 @@ struct ProtobufUnittest_TestGroup {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup? = nil
+  fileprivate var _optionalForeignEnum: ProtobufUnittest_ForeignEnum? = nil
 }
 
 struct ProtobufUnittest_TestGroupExtension: SwiftProtobuf.ExtensibleMessage {
@@ -1820,33 +1821,31 @@ struct ProtobufUnittest_TestRequiredForeign {
   // methods supported on all messages.
 
   var optionalMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestRequired()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestRequired] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestRequired] = []
 
   var dummy: Int32 {
-    get {return _storage._dummy ?? 0}
-    set {_uniqueStorage()._dummy = newValue}
+    get {return _dummy ?? 0}
+    set {_dummy = newValue}
   }
   /// Returns true if `dummy` has been explicitly set.
-  var hasDummy: Bool {return _storage._dummy != nil}
+  var hasDummy: Bool {return self._dummy != nil}
   /// Clears the value of `dummy`. Subsequent reads from it will return its default value.
-  mutating func clearDummy() {_uniqueStorage()._dummy = nil}
+  mutating func clearDummy() {self._dummy = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestRequired? = nil
+  fileprivate var _dummy: Int32? = nil
 }
 
 struct ProtobufUnittest_TestRequiredMessage {
@@ -1855,33 +1854,31 @@ struct ProtobufUnittest_TestRequiredMessage {
   // methods supported on all messages.
 
   var optionalMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestRequired()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestRequired] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestRequired] = []
 
   var requiredMessage: ProtobufUnittest_TestRequired {
-    get {return _storage._requiredMessage ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._requiredMessage = newValue}
+    get {return _requiredMessage ?? ProtobufUnittest_TestRequired()}
+    set {_requiredMessage = newValue}
   }
   /// Returns true if `requiredMessage` has been explicitly set.
-  var hasRequiredMessage: Bool {return _storage._requiredMessage != nil}
+  var hasRequiredMessage: Bool {return self._requiredMessage != nil}
   /// Clears the value of `requiredMessage`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredMessage() {_uniqueStorage()._requiredMessage = nil}
+  mutating func clearRequiredMessage() {self._requiredMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestRequired? = nil
+  fileprivate var _requiredMessage: ProtobufUnittest_TestRequired? = nil
 }
 
 /// Test that we can use NestedMessage from outside TestAllTypes.
@@ -1891,19 +1888,19 @@ struct ProtobufUnittest_TestForeignNested {
   // methods supported on all messages.
 
   var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return _storage._foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {_uniqueStorage()._foreignNested = newValue}
+    get {return _foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {_foreignNested = newValue}
   }
   /// Returns true if `foreignNested` has been explicitly set.
-  var hasForeignNested: Bool {return _storage._foreignNested != nil}
+  var hasForeignNested: Bool {return self._foreignNested != nil}
   /// Clears the value of `foreignNested`. Subsequent reads from it will return its default value.
-  mutating func clearForeignNested() {_uniqueStorage()._foreignNested = nil}
+  mutating func clearForeignNested() {self._foreignNested = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
 }
 
 /// TestEmptyMessage is used to test unknown field support.
@@ -2126,13 +2123,13 @@ struct ProtobufUnittest_TestIsInitialized {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestIsInitialized.SubMessage {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestIsInitialized.SubMessage()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestIsInitialized.SubMessage()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2142,13 +2139,13 @@ struct ProtobufUnittest_TestIsInitialized {
     // methods supported on all messages.
 
     var subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup {
-      get {return _storage._subGroup ?? ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup()}
-      set {_uniqueStorage()._subGroup = newValue}
+      get {return _subGroup ?? ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup()}
+      set {_subGroup = newValue}
     }
     /// Returns true if `subGroup` has been explicitly set.
-    var hasSubGroup: Bool {return _storage._subGroup != nil}
+    var hasSubGroup: Bool {return self._subGroup != nil}
     /// Clears the value of `subGroup`. Subsequent reads from it will return its default value.
-    mutating func clearSubGroup() {_uniqueStorage()._subGroup = nil}
+    mutating func clearSubGroup() {self._subGroup = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2175,12 +2172,12 @@ struct ProtobufUnittest_TestIsInitialized {
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup? = nil
   }
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestIsInitialized.SubMessage? = nil
 }
 
 /// Test that groups have disjoint field numbers from their siblings and
@@ -2194,31 +2191,31 @@ struct ProtobufUnittest_TestDupFieldNumber {
 
   /// NO_PROTO1
   var a: Int32 {
-    get {return _storage._a ?? 0}
-    set {_uniqueStorage()._a = newValue}
+    get {return _a ?? 0}
+    set {_a = newValue}
   }
   /// Returns true if `a` has been explicitly set.
-  var hasA: Bool {return _storage._a != nil}
+  var hasA: Bool {return self._a != nil}
   /// Clears the value of `a`. Subsequent reads from it will return its default value.
-  mutating func clearA() {_uniqueStorage()._a = nil}
+  mutating func clearA() {self._a = nil}
 
   var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
-    get {return _storage._foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
-    set {_uniqueStorage()._foo = newValue}
+    get {return _foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
+    set {_foo = newValue}
   }
   /// Returns true if `foo` has been explicitly set.
-  var hasFoo: Bool {return _storage._foo != nil}
+  var hasFoo: Bool {return self._foo != nil}
   /// Clears the value of `foo`. Subsequent reads from it will return its default value.
-  mutating func clearFoo() {_uniqueStorage()._foo = nil}
+  mutating func clearFoo() {self._foo = nil}
 
   var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
-    get {return _storage._bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
-    set {_uniqueStorage()._bar = newValue}
+    get {return _bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
+    set {_bar = newValue}
   }
   /// Returns true if `bar` has been explicitly set.
-  var hasBar: Bool {return _storage._bar != nil}
+  var hasBar: Bool {return self._bar != nil}
   /// Clears the value of `bar`. Subsequent reads from it will return its default value.
-  mutating func clearBar() {_uniqueStorage()._bar = nil}
+  mutating func clearBar() {self._bar = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2266,7 +2263,9 @@ struct ProtobufUnittest_TestDupFieldNumber {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _a: Int32? = nil
+  fileprivate var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
+  fileprivate var _bar: ProtobufUnittest_TestDupFieldNumber.Bar? = nil
 }
 
 /// Additional messages for testing lazy fields.
@@ -2276,19 +2275,19 @@ struct ProtobufUnittest_TestEagerMessage {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 }
 
 struct ProtobufUnittest_TestLazyMessage {
@@ -2297,19 +2296,19 @@ struct ProtobufUnittest_TestLazyMessage {
   // methods supported on all messages.
 
   var subMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._subMessage = newValue}
+    get {return _subMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_subMessage = newValue}
   }
   /// Returns true if `subMessage` has been explicitly set.
-  var hasSubMessage: Bool {return _storage._subMessage != nil}
+  var hasSubMessage: Bool {return self._subMessage != nil}
   /// Clears the value of `subMessage`. Subsequent reads from it will return its default value.
-  mutating func clearSubMessage() {_uniqueStorage()._subMessage = nil}
+  mutating func clearSubMessage() {self._subMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 }
 
 /// Needed for a Python test.
@@ -2319,13 +2318,13 @@ struct ProtobufUnittest_TestNestedMessageHasBits {
   // methods supported on all messages.
 
   var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2345,7 +2344,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
 }
 
 /// Test message with CamelCase field names.  This violates Protocol Buffer
@@ -2356,94 +2355,81 @@ struct ProtobufUnittest_TestCamelCaseFieldNames {
   // methods supported on all messages.
 
   var primitiveField: Int32 {
-    get {return _storage._primitiveField ?? 0}
-    set {_uniqueStorage()._primitiveField = newValue}
+    get {return _primitiveField ?? 0}
+    set {_primitiveField = newValue}
   }
   /// Returns true if `primitiveField` has been explicitly set.
-  var hasPrimitiveField: Bool {return _storage._primitiveField != nil}
+  var hasPrimitiveField: Bool {return self._primitiveField != nil}
   /// Clears the value of `primitiveField`. Subsequent reads from it will return its default value.
-  mutating func clearPrimitiveField() {_uniqueStorage()._primitiveField = nil}
+  mutating func clearPrimitiveField() {self._primitiveField = nil}
 
   var stringField: String {
-    get {return _storage._stringField ?? String()}
-    set {_uniqueStorage()._stringField = newValue}
+    get {return _stringField ?? String()}
+    set {_stringField = newValue}
   }
   /// Returns true if `stringField` has been explicitly set.
-  var hasStringField: Bool {return _storage._stringField != nil}
+  var hasStringField: Bool {return self._stringField != nil}
   /// Clears the value of `stringField`. Subsequent reads from it will return its default value.
-  mutating func clearStringField() {_uniqueStorage()._stringField = nil}
+  mutating func clearStringField() {self._stringField = nil}
 
   var enumField: ProtobufUnittest_ForeignEnum {
-    get {return _storage._enumField ?? .foreignFoo}
-    set {_uniqueStorage()._enumField = newValue}
+    get {return _enumField ?? .foreignFoo}
+    set {_enumField = newValue}
   }
   /// Returns true if `enumField` has been explicitly set.
-  var hasEnumField: Bool {return _storage._enumField != nil}
+  var hasEnumField: Bool {return self._enumField != nil}
   /// Clears the value of `enumField`. Subsequent reads from it will return its default value.
-  mutating func clearEnumField() {_uniqueStorage()._enumField = nil}
+  mutating func clearEnumField() {self._enumField = nil}
 
   var messageField: ProtobufUnittest_ForeignMessage {
-    get {return _storage._messageField ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._messageField = newValue}
+    get {return _messageField ?? ProtobufUnittest_ForeignMessage()}
+    set {_messageField = newValue}
   }
   /// Returns true if `messageField` has been explicitly set.
-  var hasMessageField: Bool {return _storage._messageField != nil}
+  var hasMessageField: Bool {return self._messageField != nil}
   /// Clears the value of `messageField`. Subsequent reads from it will return its default value.
-  mutating func clearMessageField() {_uniqueStorage()._messageField = nil}
+  mutating func clearMessageField() {self._messageField = nil}
 
   var stringPieceField: String {
-    get {return _storage._stringPieceField ?? String()}
-    set {_uniqueStorage()._stringPieceField = newValue}
+    get {return _stringPieceField ?? String()}
+    set {_stringPieceField = newValue}
   }
   /// Returns true if `stringPieceField` has been explicitly set.
-  var hasStringPieceField: Bool {return _storage._stringPieceField != nil}
+  var hasStringPieceField: Bool {return self._stringPieceField != nil}
   /// Clears the value of `stringPieceField`. Subsequent reads from it will return its default value.
-  mutating func clearStringPieceField() {_uniqueStorage()._stringPieceField = nil}
+  mutating func clearStringPieceField() {self._stringPieceField = nil}
 
   var cordField: String {
-    get {return _storage._cordField ?? String()}
-    set {_uniqueStorage()._cordField = newValue}
+    get {return _cordField ?? String()}
+    set {_cordField = newValue}
   }
   /// Returns true if `cordField` has been explicitly set.
-  var hasCordField: Bool {return _storage._cordField != nil}
+  var hasCordField: Bool {return self._cordField != nil}
   /// Clears the value of `cordField`. Subsequent reads from it will return its default value.
-  mutating func clearCordField() {_uniqueStorage()._cordField = nil}
+  mutating func clearCordField() {self._cordField = nil}
 
-  var repeatedPrimitiveField: [Int32] {
-    get {return _storage._repeatedPrimitiveField}
-    set {_uniqueStorage()._repeatedPrimitiveField = newValue}
-  }
+  var repeatedPrimitiveField: [Int32] = []
 
-  var repeatedStringField: [String] {
-    get {return _storage._repeatedStringField}
-    set {_uniqueStorage()._repeatedStringField = newValue}
-  }
+  var repeatedStringField: [String] = []
 
-  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
-    get {return _storage._repeatedEnumField}
-    set {_uniqueStorage()._repeatedEnumField = newValue}
-  }
+  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] = []
 
-  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
-    get {return _storage._repeatedMessageField}
-    set {_uniqueStorage()._repeatedMessageField = newValue}
-  }
+  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] = []
 
-  var repeatedStringPieceField: [String] {
-    get {return _storage._repeatedStringPieceField}
-    set {_uniqueStorage()._repeatedStringPieceField = newValue}
-  }
+  var repeatedStringPieceField: [String] = []
 
-  var repeatedCordField: [String] {
-    get {return _storage._repeatedCordField}
-    set {_uniqueStorage()._repeatedCordField = newValue}
-  }
+  var repeatedCordField: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _primitiveField: Int32? = nil
+  fileprivate var _stringField: String? = nil
+  fileprivate var _enumField: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _messageField: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _stringPieceField: String? = nil
+  fileprivate var _cordField: String? = nil
 }
 
 /// We list fields out of order, to ensure that we're using field number and not
@@ -2454,40 +2440,40 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var myString: String {
-    get {return _storage._myString ?? String()}
-    set {_uniqueStorage()._myString = newValue}
+    get {return _myString ?? String()}
+    set {_myString = newValue}
   }
   /// Returns true if `myString` has been explicitly set.
-  var hasMyString: Bool {return _storage._myString != nil}
+  var hasMyString: Bool {return self._myString != nil}
   /// Clears the value of `myString`. Subsequent reads from it will return its default value.
-  mutating func clearMyString() {_uniqueStorage()._myString = nil}
+  mutating func clearMyString() {self._myString = nil}
 
   var myInt: Int64 {
-    get {return _storage._myInt ?? 0}
-    set {_uniqueStorage()._myInt = newValue}
+    get {return _myInt ?? 0}
+    set {_myInt = newValue}
   }
   /// Returns true if `myInt` has been explicitly set.
-  var hasMyInt: Bool {return _storage._myInt != nil}
+  var hasMyInt: Bool {return self._myInt != nil}
   /// Clears the value of `myInt`. Subsequent reads from it will return its default value.
-  mutating func clearMyInt() {_uniqueStorage()._myInt = nil}
+  mutating func clearMyInt() {self._myInt = nil}
 
   var myFloat: Float {
-    get {return _storage._myFloat ?? 0}
-    set {_uniqueStorage()._myFloat = newValue}
+    get {return _myFloat ?? 0}
+    set {_myFloat = newValue}
   }
   /// Returns true if `myFloat` has been explicitly set.
-  var hasMyFloat: Bool {return _storage._myFloat != nil}
+  var hasMyFloat: Bool {return self._myFloat != nil}
   /// Clears the value of `myFloat`. Subsequent reads from it will return its default value.
-  mutating func clearMyFloat() {_uniqueStorage()._myFloat = nil}
+  mutating func clearMyFloat() {self._myFloat = nil}
 
   var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -2528,7 +2514,10 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _myString: String? = nil
+  fileprivate var _myInt: Int64? = nil
+  fileprivate var _myFloat: Float? = nil
+  fileprivate var _optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage? = nil
 }
 
 struct ProtobufUnittest_TestExtensionOrderings1 {
@@ -3061,41 +3050,38 @@ struct ProtobufUnittest_TestOneof {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOneof.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {return v}
+      if case .fooGroup(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof.FooGroup()
     }
-    set {_uniqueStorage()._foo = .fooGroup(newValue)}
+    set {foo = .fooGroup(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3139,8 +3125,6 @@ struct ProtobufUnittest_TestOneof {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtobufUnittest_TestOneofBackwardsCompatible {
@@ -3149,40 +3133,40 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible {
   // methods supported on all messages.
 
   var fooInt: Int32 {
-    get {return _storage._fooInt ?? 0}
-    set {_uniqueStorage()._fooInt = newValue}
+    get {return _fooInt ?? 0}
+    set {_fooInt = newValue}
   }
   /// Returns true if `fooInt` has been explicitly set.
-  var hasFooInt: Bool {return _storage._fooInt != nil}
+  var hasFooInt: Bool {return self._fooInt != nil}
   /// Clears the value of `fooInt`. Subsequent reads from it will return its default value.
-  mutating func clearFooInt() {_uniqueStorage()._fooInt = nil}
+  mutating func clearFooInt() {self._fooInt = nil}
 
   var fooString: String {
-    get {return _storage._fooString ?? String()}
-    set {_uniqueStorage()._fooString = newValue}
+    get {return _fooString ?? String()}
+    set {_fooString = newValue}
   }
   /// Returns true if `fooString` has been explicitly set.
-  var hasFooString: Bool {return _storage._fooString != nil}
+  var hasFooString: Bool {return self._fooString != nil}
   /// Clears the value of `fooString`. Subsequent reads from it will return its default value.
-  mutating func clearFooString() {_uniqueStorage()._fooString = nil}
+  mutating func clearFooString() {self._fooString = nil}
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
-    get {return _storage._fooMessage ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._fooMessage = newValue}
+    get {return _fooMessage ?? ProtobufUnittest_TestAllTypes()}
+    set {_fooMessage = newValue}
   }
   /// Returns true if `fooMessage` has been explicitly set.
-  var hasFooMessage: Bool {return _storage._fooMessage != nil}
+  var hasFooMessage: Bool {return self._fooMessage != nil}
   /// Clears the value of `fooMessage`. Subsequent reads from it will return its default value.
-  mutating func clearFooMessage() {_uniqueStorage()._fooMessage = nil}
+  mutating func clearFooMessage() {self._fooMessage = nil}
 
   var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
-    get {return _storage._fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
-    set {_uniqueStorage()._fooGroup = newValue}
+    get {return _fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
+    set {_fooGroup = newValue}
   }
   /// Returns true if `fooGroup` has been explicitly set.
-  var hasFooGroup: Bool {return _storage._fooGroup != nil}
+  var hasFooGroup: Bool {return self._fooGroup != nil}
   /// Clears the value of `fooGroup`. Subsequent reads from it will return its default value.
-  mutating func clearFooGroup() {_uniqueStorage()._fooGroup = nil}
+  mutating func clearFooGroup() {self._fooGroup = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3219,7 +3203,10 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _fooInt: Int32? = nil
+  fileprivate var _fooString: String? = nil
+  fileprivate var _fooMessage: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup? = nil
 }
 
 struct ProtobufUnittest_TestOneof2 {
@@ -3499,33 +3486,30 @@ struct ProtobufUnittest_TestRequiredOneof {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3558,8 +3542,6 @@ struct ProtobufUnittest_TestRequiredOneof {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct ProtobufUnittest_TestPackedTypes {
@@ -3673,59 +3655,53 @@ struct ProtobufUnittest_TestDynamicExtensions {
   // methods supported on all messages.
 
   var scalarExtension: UInt32 {
-    get {return _storage._scalarExtension ?? 0}
-    set {_uniqueStorage()._scalarExtension = newValue}
+    get {return _scalarExtension ?? 0}
+    set {_scalarExtension = newValue}
   }
   /// Returns true if `scalarExtension` has been explicitly set.
-  var hasScalarExtension: Bool {return _storage._scalarExtension != nil}
+  var hasScalarExtension: Bool {return self._scalarExtension != nil}
   /// Clears the value of `scalarExtension`. Subsequent reads from it will return its default value.
-  mutating func clearScalarExtension() {_uniqueStorage()._scalarExtension = nil}
+  mutating func clearScalarExtension() {self._scalarExtension = nil}
 
   var enumExtension: ProtobufUnittest_ForeignEnum {
-    get {return _storage._enumExtension ?? .foreignFoo}
-    set {_uniqueStorage()._enumExtension = newValue}
+    get {return _enumExtension ?? .foreignFoo}
+    set {_enumExtension = newValue}
   }
   /// Returns true if `enumExtension` has been explicitly set.
-  var hasEnumExtension: Bool {return _storage._enumExtension != nil}
+  var hasEnumExtension: Bool {return self._enumExtension != nil}
   /// Clears the value of `enumExtension`. Subsequent reads from it will return its default value.
-  mutating func clearEnumExtension() {_uniqueStorage()._enumExtension = nil}
+  mutating func clearEnumExtension() {self._enumExtension = nil}
 
   var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
-    get {return _storage._dynamicEnumExtension ?? .dynamicFoo}
-    set {_uniqueStorage()._dynamicEnumExtension = newValue}
+    get {return _dynamicEnumExtension ?? .dynamicFoo}
+    set {_dynamicEnumExtension = newValue}
   }
   /// Returns true if `dynamicEnumExtension` has been explicitly set.
-  var hasDynamicEnumExtension: Bool {return _storage._dynamicEnumExtension != nil}
+  var hasDynamicEnumExtension: Bool {return self._dynamicEnumExtension != nil}
   /// Clears the value of `dynamicEnumExtension`. Subsequent reads from it will return its default value.
-  mutating func clearDynamicEnumExtension() {_uniqueStorage()._dynamicEnumExtension = nil}
+  mutating func clearDynamicEnumExtension() {self._dynamicEnumExtension = nil}
 
   var messageExtension: ProtobufUnittest_ForeignMessage {
-    get {return _storage._messageExtension ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._messageExtension = newValue}
+    get {return _messageExtension ?? ProtobufUnittest_ForeignMessage()}
+    set {_messageExtension = newValue}
   }
   /// Returns true if `messageExtension` has been explicitly set.
-  var hasMessageExtension: Bool {return _storage._messageExtension != nil}
+  var hasMessageExtension: Bool {return self._messageExtension != nil}
   /// Clears the value of `messageExtension`. Subsequent reads from it will return its default value.
-  mutating func clearMessageExtension() {_uniqueStorage()._messageExtension = nil}
+  mutating func clearMessageExtension() {self._messageExtension = nil}
 
   var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
-    get {return _storage._dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
-    set {_uniqueStorage()._dynamicMessageExtension = newValue}
+    get {return _dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
+    set {_dynamicMessageExtension = newValue}
   }
   /// Returns true if `dynamicMessageExtension` has been explicitly set.
-  var hasDynamicMessageExtension: Bool {return _storage._dynamicMessageExtension != nil}
+  var hasDynamicMessageExtension: Bool {return self._dynamicMessageExtension != nil}
   /// Clears the value of `dynamicMessageExtension`. Subsequent reads from it will return its default value.
-  mutating func clearDynamicMessageExtension() {_uniqueStorage()._dynamicMessageExtension = nil}
+  mutating func clearDynamicMessageExtension() {self._dynamicMessageExtension = nil}
 
-  var repeatedExtension: [String] {
-    get {return _storage._repeatedExtension}
-    set {_uniqueStorage()._repeatedExtension = newValue}
-  }
+  var repeatedExtension: [String] = []
 
-  var packedExtension: [Int32] {
-    get {return _storage._packedExtension}
-    set {_uniqueStorage()._packedExtension = newValue}
-  }
+  var packedExtension: [Int32] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3781,7 +3757,11 @@ struct ProtobufUnittest_TestDynamicExtensions {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _scalarExtension: UInt32? = nil
+  fileprivate var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType? = nil
+  fileprivate var _messageExtension: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType? = nil
 }
 
 #if swift(>=4.2)
@@ -3828,41 +3808,35 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var requiredAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._requiredAllTypes = newValue}
+    get {return _requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
+    set {_requiredAllTypes = newValue}
   }
   /// Returns true if `requiredAllTypes` has been explicitly set.
-  var hasRequiredAllTypes: Bool {return _storage._requiredAllTypes != nil}
+  var hasRequiredAllTypes: Bool {return self._requiredAllTypes != nil}
   /// Clears the value of `requiredAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredAllTypes() {_uniqueStorage()._requiredAllTypes = nil}
+  mutating func clearRequiredAllTypes() {self._requiredAllTypes = nil}
 
   var optionalAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._optionalAllTypes = newValue}
+    get {return _optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
+    set {_optionalAllTypes = newValue}
   }
   /// Returns true if `optionalAllTypes` has been explicitly set.
-  var hasOptionalAllTypes: Bool {return _storage._optionalAllTypes != nil}
+  var hasOptionalAllTypes: Bool {return self._optionalAllTypes != nil}
   /// Clears the value of `optionalAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalAllTypes() {_uniqueStorage()._optionalAllTypes = nil}
+  mutating func clearOptionalAllTypes() {self._optionalAllTypes = nil}
 
-  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
-    get {return _storage._repeatedAllTypes}
-    set {_uniqueStorage()._repeatedAllTypes = newValue}
-  }
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] = []
 
   var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
-    get {return _storage._repeatedGroup}
-    set {_uniqueStorage()._repeatedGroup = newValue}
-  }
+  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3898,19 +3872,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypes {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypes()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypes? = nil
     }
 
     struct Group2 {
@@ -3919,19 +3893,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypes {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypes()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypes? = nil
     }
 
     init() {}
@@ -3943,19 +3917,19 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
-      get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
-      set {_uniqueStorage()._optionalGroupAllTypes = newValue}
+      get {return _optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
+      set {_optionalGroupAllTypes = newValue}
     }
     /// Returns true if `optionalGroupAllTypes` has been explicitly set.
-    var hasOptionalGroupAllTypes: Bool {return _storage._optionalGroupAllTypes != nil}
+    var hasOptionalGroupAllTypes: Bool {return self._optionalGroupAllTypes != nil}
     /// Clears the value of `optionalGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearOptionalGroupAllTypes() {_uniqueStorage()._optionalGroupAllTypes = nil}
+    mutating func clearOptionalGroupAllTypes() {self._optionalGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
   }
 
   struct RepeatedGroup {
@@ -3964,25 +3938,27 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
-      get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
-      set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
+      get {return _repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
+      set {_repeatedGroupAllTypes = newValue}
     }
     /// Returns true if `repeatedGroupAllTypes` has been explicitly set.
-    var hasRepeatedGroupAllTypes: Bool {return _storage._repeatedGroupAllTypes != nil}
+    var hasRepeatedGroupAllTypes: Bool {return self._repeatedGroupAllTypes != nil}
     /// Clears the value of `repeatedGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearRepeatedGroupAllTypes() {_uniqueStorage()._repeatedGroupAllTypes = nil}
+    mutating func clearRepeatedGroupAllTypes() {self._repeatedGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
   }
 
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _requiredAllTypes: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _optionalAllTypes: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestCommentInjectionMessage {
@@ -4145,118 +4121,106 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var fixed32: Int32 {
-    get {return _storage._fixed32 ?? 0}
-    set {_uniqueStorage()._fixed32 = newValue}
+    get {return _fixed32 ?? 0}
+    set {_fixed32 = newValue}
   }
   /// Returns true if `fixed32` has been explicitly set.
-  var hasFixed32: Bool {return _storage._fixed32 != nil}
+  var hasFixed32: Bool {return self._fixed32 != nil}
   /// Clears the value of `fixed32`. Subsequent reads from it will return its default value.
-  mutating func clearFixed32() {_uniqueStorage()._fixed32 = nil}
+  mutating func clearFixed32() {self._fixed32 = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
-  var packedInt32: [Int32] {
-    get {return _storage._packedInt32}
-    set {_uniqueStorage()._packedInt32 = newValue}
-  }
+  var packedInt32: [Int32] = []
 
   var optionalEnum: ProtobufUnittest_ForeignEnum {
-    get {return _storage._optionalEnum ?? .foreignFoo}
-    set {_uniqueStorage()._optionalEnum = newValue}
+    get {return _optionalEnum ?? .foreignFoo}
+    set {_optionalEnum = newValue}
   }
   /// Returns true if `optionalEnum` has been explicitly set.
-  var hasOptionalEnum: Bool {return _storage._optionalEnum != nil}
+  var hasOptionalEnum: Bool {return self._optionalEnum != nil}
   /// Clears the value of `optionalEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalEnum() {_uniqueStorage()._optionalEnum = nil}
+  mutating func clearOptionalEnum() {self._optionalEnum = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
-    set {_uniqueStorage()._optionalBytes = newValue}
+    get {return _optionalBytes ?? SwiftProtobuf.Internal.emptyData}
+    set {_optionalBytes = newValue}
   }
   /// Returns true if `optionalBytes` has been explicitly set.
-  var hasOptionalBytes: Bool {return _storage._optionalBytes != nil}
+  var hasOptionalBytes: Bool {return self._optionalBytes != nil}
   /// Clears the value of `optionalBytes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBytes() {_uniqueStorage()._optionalBytes = nil}
+  mutating func clearOptionalBytes() {self._optionalBytes = nil}
 
   var optionalMessage: ProtobufUnittest_ForeignMessage {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_ForeignMessage()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
   var optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var stringStringMap: Dictionary<String,String> {
-    get {return _storage._stringStringMap}
-    set {_uniqueStorage()._stringStringMap = newValue}
-  }
+  var stringStringMap: Dictionary<String,String> = [:]
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
+      if case .oneofTestAllTypes(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
+    set {oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -4292,7 +4256,13 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _fixed32: Int32? = nil
+  fileprivate var _optionalEnum: ProtobufUnittest_ForeignEnum? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _optionalBytes: Data? = nil
+  fileprivate var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestExtensionInsideTable: SwiftProtobuf.ExtensibleMessage {
@@ -8128,63 +8098,29 @@ extension ProtobufUnittest_TestGroup: SwiftProtobuf.Message, SwiftProtobuf._Mess
     22: .standard(proto: "optional_foreign_enum"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroup: ProtobufUnittest_TestGroup.OptionalGroup? = nil
-    var _optionalForeignEnum: ProtobufUnittest_ForeignEnum? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroup = source._optionalGroup
-      _optionalForeignEnum = source._optionalForeignEnum
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 16: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 22: try decoder.decodeSingularEnumField(value: &_storage._optionalForeignEnum)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 16: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 22: try decoder.decodeSingularEnumField(value: &self._optionalForeignEnum)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 16)
-      }
-      if let v = _storage._optionalForeignEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 22)
-      }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 16)
+    }
+    if let v = self._optionalForeignEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 22)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestGroup, rhs: ProtobufUnittest_TestGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._optionalForeignEnum != rhs_storage._optionalForeignEnum {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs._optionalForeignEnum != rhs._optionalForeignEnum {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8630,78 +8566,40 @@ extension ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message, SwiftProt
     3: .same(proto: "dummy"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestRequired? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
-    var _dummy: Int32? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-      _dummy = source._dummy
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      return true
-    }
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        case 3: try decoder.decodeSingularInt32Field(value: &_storage._dummy)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      case 3: try decoder.decodeSingularInt32Field(value: &self._dummy)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
-      if let v = _storage._dummy {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
+    }
+    if let v = self._dummy {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredForeign, rhs: ProtobufUnittest_TestRequiredForeign) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        if _storage._dummy != rhs_storage._dummy {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
+    if lhs._dummy != rhs._dummy {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8715,80 +8613,42 @@ extension ProtobufUnittest_TestRequiredMessage: SwiftProtobuf.Message, SwiftProt
     3: .standard(proto: "required_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestRequired? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
-    var _requiredMessage: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-      _requiredMessage = source._requiredMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredMessage == nil {return false}
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      if let v = _storage._requiredMessage, !v.isInitialized {return false}
-      return true
-    }
+    if self._requiredMessage == nil {return false}
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    if let v = self._requiredMessage, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._requiredMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      case 3: try decoder.decodeSingularMessageField(value: &self._requiredMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
-      if let v = _storage._requiredMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
+    }
+    if let v = self._requiredMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredMessage, rhs: ProtobufUnittest_TestRequiredMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        if _storage._requiredMessage != rhs_storage._requiredMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
+    if lhs._requiredMessage != rhs._requiredMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -8800,56 +8660,24 @@ extension ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "foreign_nested"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foreignNested = source._foreignNested
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._foreignNested)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._foreignNested)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._foreignNested {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._foreignNested {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestForeignNested, rhs: ProtobufUnittest_TestForeignNested) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foreignNested != rhs_storage._foreignNested {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._foreignNested != rhs._foreignNested {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9312,63 +9140,29 @@ extension ProtobufUnittest_TestIsInitialized: SwiftProtobuf.Message, SwiftProtob
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestIsInitialized.SubMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._subMessage, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestIsInitialized, rhs: ProtobufUnittest_TestIsInitialized) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9380,63 +9174,29 @@ extension ProtobufUnittest_TestIsInitialized.SubMessage: SwiftProtobuf.Message, 
     1: .unique(proto: "SubGroup", json: "subgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subGroup: ProtobufUnittest_TestIsInitialized.SubMessage.SubGroup? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subGroup = source._subGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subGroup, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._subGroup, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularGroupField(value: &_storage._subGroup)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularGroupField(value: &self._subGroup)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestIsInitialized.SubMessage, rhs: ProtobufUnittest_TestIsInitialized.SubMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subGroup != rhs_storage._subGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subGroup != rhs._subGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9484,70 +9244,34 @@ extension ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message, SwiftProto
     3: .unique(proto: "Bar", json: "bar"),
   ]
 
-  fileprivate class _StorageClass {
-    var _a: Int32? = nil
-    var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
-    var _bar: ProtobufUnittest_TestDupFieldNumber.Bar? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _a = source._a
-      _foo = source._foo
-      _bar = source._bar
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._a)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._foo)
-        case 3: try decoder.decodeSingularGroupField(value: &_storage._bar)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._a)
+      case 2: try decoder.decodeSingularGroupField(value: &self._foo)
+      case 3: try decoder.decodeSingularGroupField(value: &self._bar)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._a {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._foo {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._bar {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-      }
+    if let v = self._a {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._foo {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
+    }
+    if let v = self._bar {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestDupFieldNumber, rhs: ProtobufUnittest_TestDupFieldNumber) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._a != rhs_storage._a {return false}
-        if _storage._foo != rhs_storage._foo {return false}
-        if _storage._bar != rhs_storage._bar {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._a != rhs._a {return false}
+    if lhs._foo != rhs._foo {return false}
+    if lhs._bar != rhs._bar {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9617,56 +9341,24 @@ extension ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message, SwiftProtobu
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestEagerMessage, rhs: ProtobufUnittest_TestEagerMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9678,56 +9370,24 @@ extension ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message, SwiftProtobuf
     1: .standard(proto: "sub_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _subMessage: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _subMessage = source._subMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._subMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._subMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._subMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._subMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestLazyMessage, rhs: ProtobufUnittest_TestLazyMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._subMessage != rhs_storage._subMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._subMessage != rhs._subMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9739,56 +9399,24 @@ extension ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message, Swif
     1: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestNestedMessageHasBits, rhs: ProtobufUnittest_TestNestedMessageHasBits) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9846,133 +9474,79 @@ extension ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message, Swift
     12: .same(proto: "RepeatedCordField"),
   ]
 
-  fileprivate class _StorageClass {
-    var _primitiveField: Int32? = nil
-    var _stringField: String? = nil
-    var _enumField: ProtobufUnittest_ForeignEnum? = nil
-    var _messageField: ProtobufUnittest_ForeignMessage? = nil
-    var _stringPieceField: String? = nil
-    var _cordField: String? = nil
-    var _repeatedPrimitiveField: [Int32] = []
-    var _repeatedStringField: [String] = []
-    var _repeatedEnumField: [ProtobufUnittest_ForeignEnum] = []
-    var _repeatedMessageField: [ProtobufUnittest_ForeignMessage] = []
-    var _repeatedStringPieceField: [String] = []
-    var _repeatedCordField: [String] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _primitiveField = source._primitiveField
-      _stringField = source._stringField
-      _enumField = source._enumField
-      _messageField = source._messageField
-      _stringPieceField = source._stringPieceField
-      _cordField = source._cordField
-      _repeatedPrimitiveField = source._repeatedPrimitiveField
-      _repeatedStringField = source._repeatedStringField
-      _repeatedEnumField = source._repeatedEnumField
-      _repeatedMessageField = source._repeatedMessageField
-      _repeatedStringPieceField = source._repeatedStringPieceField
-      _repeatedCordField = source._repeatedCordField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._primitiveField)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._stringField)
-        case 3: try decoder.decodeSingularEnumField(value: &_storage._enumField)
-        case 4: try decoder.decodeSingularMessageField(value: &_storage._messageField)
-        case 5: try decoder.decodeSingularStringField(value: &_storage._stringPieceField)
-        case 6: try decoder.decodeSingularStringField(value: &_storage._cordField)
-        case 7: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedPrimitiveField)
-        case 8: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringField)
-        case 9: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnumField)
-        case 10: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessageField)
-        case 11: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPieceField)
-        case 12: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCordField)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._primitiveField)
+      case 2: try decoder.decodeSingularStringField(value: &self._stringField)
+      case 3: try decoder.decodeSingularEnumField(value: &self._enumField)
+      case 4: try decoder.decodeSingularMessageField(value: &self._messageField)
+      case 5: try decoder.decodeSingularStringField(value: &self._stringPieceField)
+      case 6: try decoder.decodeSingularStringField(value: &self._cordField)
+      case 7: try decoder.decodeRepeatedInt32Field(value: &self.repeatedPrimitiveField)
+      case 8: try decoder.decodeRepeatedStringField(value: &self.repeatedStringField)
+      case 9: try decoder.decodeRepeatedEnumField(value: &self.repeatedEnumField)
+      case 10: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessageField)
+      case 11: try decoder.decodeRepeatedStringField(value: &self.repeatedStringPieceField)
+      case 12: try decoder.decodeRepeatedStringField(value: &self.repeatedCordField)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._primitiveField {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._stringField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._enumField {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._messageField {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._stringPieceField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._cordField {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-      }
-      if !_storage._repeatedPrimitiveField.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedPrimitiveField, fieldNumber: 7)
-      }
-      if !_storage._repeatedStringField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedStringField, fieldNumber: 8)
-      }
-      if !_storage._repeatedEnumField.isEmpty {
-        try visitor.visitRepeatedEnumField(value: _storage._repeatedEnumField, fieldNumber: 9)
-      }
-      if !_storage._repeatedMessageField.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessageField, fieldNumber: 10)
-      }
-      if !_storage._repeatedStringPieceField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedStringPieceField, fieldNumber: 11)
-      }
-      if !_storage._repeatedCordField.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedCordField, fieldNumber: 12)
-      }
+    if let v = self._primitiveField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._stringField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._enumField {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
+    }
+    if let v = self._messageField {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
+    if let v = self._stringPieceField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    }
+    if let v = self._cordField {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    }
+    if !self.repeatedPrimitiveField.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedPrimitiveField, fieldNumber: 7)
+    }
+    if !self.repeatedStringField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedStringField, fieldNumber: 8)
+    }
+    if !self.repeatedEnumField.isEmpty {
+      try visitor.visitRepeatedEnumField(value: self.repeatedEnumField, fieldNumber: 9)
+    }
+    if !self.repeatedMessageField.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessageField, fieldNumber: 10)
+    }
+    if !self.repeatedStringPieceField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedStringPieceField, fieldNumber: 11)
+    }
+    if !self.repeatedCordField.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedCordField, fieldNumber: 12)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestCamelCaseFieldNames, rhs: ProtobufUnittest_TestCamelCaseFieldNames) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._primitiveField != rhs_storage._primitiveField {return false}
-        if _storage._stringField != rhs_storage._stringField {return false}
-        if _storage._enumField != rhs_storage._enumField {return false}
-        if _storage._messageField != rhs_storage._messageField {return false}
-        if _storage._stringPieceField != rhs_storage._stringPieceField {return false}
-        if _storage._cordField != rhs_storage._cordField {return false}
-        if _storage._repeatedPrimitiveField != rhs_storage._repeatedPrimitiveField {return false}
-        if _storage._repeatedStringField != rhs_storage._repeatedStringField {return false}
-        if _storage._repeatedEnumField != rhs_storage._repeatedEnumField {return false}
-        if _storage._repeatedMessageField != rhs_storage._repeatedMessageField {return false}
-        if _storage._repeatedStringPieceField != rhs_storage._repeatedStringPieceField {return false}
-        if _storage._repeatedCordField != rhs_storage._repeatedCordField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._primitiveField != rhs._primitiveField {return false}
+    if lhs._stringField != rhs._stringField {return false}
+    if lhs._enumField != rhs._enumField {return false}
+    if lhs._messageField != rhs._messageField {return false}
+    if lhs._stringPieceField != rhs._stringPieceField {return false}
+    if lhs._cordField != rhs._cordField {return false}
+    if lhs.repeatedPrimitiveField != rhs.repeatedPrimitiveField {return false}
+    if lhs.repeatedStringField != rhs.repeatedStringField {return false}
+    if lhs.repeatedEnumField != rhs.repeatedEnumField {return false}
+    if lhs.repeatedMessageField != rhs.repeatedMessageField {return false}
+    if lhs.repeatedStringPieceField != rhs.repeatedStringPieceField {return false}
+    if lhs.repeatedCordField != rhs.repeatedCordField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -9987,86 +9561,48 @@ extension ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProto
     200: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _myString: String? = nil
-    var _myInt: Int64? = nil
-    var _myFloat: Float? = nil
-    var _optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _myString = source._myString
-      _myInt = source._myInt
-      _myFloat = source._myFloat
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
-        case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
-        case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-        case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        case 2..<11, 12..<101:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt64Field(value: &self._myInt)
+      case 11: try decoder.decodeSingularStringField(value: &self._myString)
+      case 101: try decoder.decodeSingularFloatField(value: &self._myFloat)
+      case 200: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      case 2..<11, 12..<101:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._myInt {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 11)
-      if let v = _storage._myString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 101)
-      if let v = _storage._myFloat {
-        try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
-      }
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
-      }
+    if let v = self._myInt {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 11)
+    if let v = self._myString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 101)
+    if let v = self._myFloat {
+      try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
+    }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestFieldOrderings, rhs: ProtobufUnittest_TestFieldOrderings) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._myString != rhs_storage._myString {return false}
-        if _storage._myInt != rhs_storage._myInt {return false}
-        if _storage._myFloat != rhs_storage._myFloat {return false}
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._myString != rhs._myString {return false}
+    if lhs._myInt != rhs._myInt {return false}
+    if lhs._myFloat != rhs._myFloat {return false}
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -10763,89 +10299,57 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._Mess
     4: .unique(proto: "FooGroup", json: "foogroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        case 3:
-          var v: ProtobufUnittest_TestAllTypes?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        case 4:
-          var v: ProtobufUnittest_TestOneof.FooGroup?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooGroup(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._foo = .fooGroup(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      case 3:
+        var v: ProtobufUnittest_TestAllTypes?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      case 4:
+        var v: ProtobufUnittest_TestOneof.FooGroup?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooGroup(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.foo = .fooGroup(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._foo {
-      case .fooInt(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .fooString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case .fooMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      case .fooGroup(let v)?:
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      case nil: break
-      }
+    switch self.foo {
+    case .fooInt(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .fooString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .fooMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    case .fooGroup(let v)?:
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneof, rhs: ProtobufUnittest_TestOneof) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -10895,77 +10399,39 @@ extension ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message, 
     4: .unique(proto: "FooGroup", json: "foogroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _fooInt: Int32? = nil
-    var _fooString: String? = nil
-    var _fooMessage: ProtobufUnittest_TestAllTypes? = nil
-    var _fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _fooInt = source._fooInt
-      _fooString = source._fooString
-      _fooMessage = source._fooMessage
-      _fooGroup = source._fooGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._fooInt)
-        case 2: try decoder.decodeSingularStringField(value: &_storage._fooString)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._fooMessage)
-        case 4: try decoder.decodeSingularGroupField(value: &_storage._fooGroup)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._fooInt)
+      case 2: try decoder.decodeSingularStringField(value: &self._fooString)
+      case 3: try decoder.decodeSingularMessageField(value: &self._fooMessage)
+      case 4: try decoder.decodeSingularGroupField(value: &self._fooGroup)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._fooInt {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._fooString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._fooMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._fooGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      }
+    if let v = self._fooInt {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._fooString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    if let v = self._fooMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if let v = self._fooGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneofBackwardsCompatible, rhs: ProtobufUnittest_TestOneofBackwardsCompatible) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._fooInt != rhs_storage._fooInt {return false}
-        if _storage._fooString != rhs_storage._fooString {return false}
-        if _storage._fooMessage != rhs_storage._fooMessage {return false}
-        if _storage._fooGroup != rhs_storage._fooGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._fooInt != rhs._fooInt {return false}
+    if lhs._fooString != rhs._fooString {return false}
+    if lhs._fooMessage != rhs._fooMessage {return false}
+    if lhs._fooGroup != rhs._fooGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11302,86 +10768,52 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
     3: .standard(proto: "foo_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if case .fooMessage(let v)? = _storage._foo, !v.isInitialized {return false}
-      return true
-    }
+    if case .fooMessage(let v)? = self.foo, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        case 3:
-          var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      case 3:
+        var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._foo {
-      case .fooInt(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .fooString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      case .fooMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      case nil: break
-      }
+    switch self.foo {
+    case .fooInt(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .fooString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .fooMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestRequiredOneof, rhs: ProtobufUnittest_TestRequiredOneof) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11705,98 +11137,54 @@ extension ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message, SwiftPr
     2006: .standard(proto: "packed_extension"),
   ]
 
-  fileprivate class _StorageClass {
-    var _scalarExtension: UInt32? = nil
-    var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
-    var _dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType? = nil
-    var _messageExtension: ProtobufUnittest_ForeignMessage? = nil
-    var _dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType? = nil
-    var _repeatedExtension: [String] = []
-    var _packedExtension: [Int32] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _scalarExtension = source._scalarExtension
-      _enumExtension = source._enumExtension
-      _dynamicEnumExtension = source._dynamicEnumExtension
-      _messageExtension = source._messageExtension
-      _dynamicMessageExtension = source._dynamicMessageExtension
-      _repeatedExtension = source._repeatedExtension
-      _packedExtension = source._packedExtension
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 2000: try decoder.decodeSingularFixed32Field(value: &_storage._scalarExtension)
-        case 2001: try decoder.decodeSingularEnumField(value: &_storage._enumExtension)
-        case 2002: try decoder.decodeSingularEnumField(value: &_storage._dynamicEnumExtension)
-        case 2003: try decoder.decodeSingularMessageField(value: &_storage._messageExtension)
-        case 2004: try decoder.decodeSingularMessageField(value: &_storage._dynamicMessageExtension)
-        case 2005: try decoder.decodeRepeatedStringField(value: &_storage._repeatedExtension)
-        case 2006: try decoder.decodeRepeatedSInt32Field(value: &_storage._packedExtension)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 2000: try decoder.decodeSingularFixed32Field(value: &self._scalarExtension)
+      case 2001: try decoder.decodeSingularEnumField(value: &self._enumExtension)
+      case 2002: try decoder.decodeSingularEnumField(value: &self._dynamicEnumExtension)
+      case 2003: try decoder.decodeSingularMessageField(value: &self._messageExtension)
+      case 2004: try decoder.decodeSingularMessageField(value: &self._dynamicMessageExtension)
+      case 2005: try decoder.decodeRepeatedStringField(value: &self.repeatedExtension)
+      case 2006: try decoder.decodeRepeatedSInt32Field(value: &self.packedExtension)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._scalarExtension {
-        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 2000)
-      }
-      if let v = _storage._enumExtension {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 2001)
-      }
-      if let v = _storage._dynamicEnumExtension {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 2002)
-      }
-      if let v = _storage._messageExtension {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2003)
-      }
-      if let v = _storage._dynamicMessageExtension {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2004)
-      }
-      if !_storage._repeatedExtension.isEmpty {
-        try visitor.visitRepeatedStringField(value: _storage._repeatedExtension, fieldNumber: 2005)
-      }
-      if !_storage._packedExtension.isEmpty {
-        try visitor.visitPackedSInt32Field(value: _storage._packedExtension, fieldNumber: 2006)
-      }
+    if let v = self._scalarExtension {
+      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 2000)
+    }
+    if let v = self._enumExtension {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 2001)
+    }
+    if let v = self._dynamicEnumExtension {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 2002)
+    }
+    if let v = self._messageExtension {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2003)
+    }
+    if let v = self._dynamicMessageExtension {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2004)
+    }
+    if !self.repeatedExtension.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.repeatedExtension, fieldNumber: 2005)
+    }
+    if !self.packedExtension.isEmpty {
+      try visitor.visitPackedSInt32Field(value: self.packedExtension, fieldNumber: 2006)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestDynamicExtensions, rhs: ProtobufUnittest_TestDynamicExtensions) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._scalarExtension != rhs_storage._scalarExtension {return false}
-        if _storage._enumExtension != rhs_storage._enumExtension {return false}
-        if _storage._dynamicEnumExtension != rhs_storage._dynamicEnumExtension {return false}
-        if _storage._messageExtension != rhs_storage._messageExtension {return false}
-        if _storage._dynamicMessageExtension != rhs_storage._dynamicMessageExtension {return false}
-        if _storage._repeatedExtension != rhs_storage._repeatedExtension {return false}
-        if _storage._packedExtension != rhs_storage._packedExtension {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._scalarExtension != rhs._scalarExtension {return false}
+    if lhs._enumExtension != rhs._enumExtension {return false}
+    if lhs._dynamicEnumExtension != rhs._dynamicEnumExtension {return false}
+    if lhs._messageExtension != rhs._messageExtension {return false}
+    if lhs._dynamicMessageExtension != rhs._dynamicMessageExtension {return false}
+    if lhs.repeatedExtension != rhs.repeatedExtension {return false}
+    if lhs.packedExtension != rhs.packedExtension {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -11908,95 +11296,53 @@ extension ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobu
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _requiredAllTypes: ProtobufUnittest_TestAllTypes? = nil
-    var _optionalAllTypes: ProtobufUnittest_TestAllTypes? = nil
-    var _repeatedAllTypes: [ProtobufUnittest_TestAllTypes] = []
-    var _optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup? = nil
-    var _repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _requiredAllTypes = source._requiredAllTypes
-      _optionalAllTypes = source._optionalAllTypes
-      _repeatedAllTypes = source._repeatedAllTypes
-      _optionalGroup = source._optionalGroup
-      _repeatedGroup = source._repeatedGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredAllTypes == nil {return false}
-      return true
-    }
+    if self._requiredAllTypes == nil {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._requiredAllTypes)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._optionalAllTypes)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
-        case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._requiredAllTypes)
+      case 2: try decoder.decodeSingularMessageField(value: &self._optionalAllTypes)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAllTypes)
+      case 10: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 20: try decoder.decodeRepeatedGroupField(value: &self.repeatedGroup)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._requiredAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._optionalAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAllTypes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAllTypes, fieldNumber: 3)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
-      }
-      if !_storage._repeatedGroup.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._repeatedGroup, fieldNumber: 20)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._requiredAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._optionalAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAllTypes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAllTypes, fieldNumber: 3)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
+    }
+    if !self.repeatedGroup.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.repeatedGroup, fieldNumber: 20)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge, rhs: ProtobufUnittest_TestParsingMerge) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._requiredAllTypes != rhs_storage._requiredAllTypes {return false}
-        if _storage._optionalAllTypes != rhs_storage._optionalAllTypes {return false}
-        if _storage._repeatedAllTypes != rhs_storage._repeatedAllTypes {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._repeatedGroup != rhs_storage._repeatedGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._requiredAllTypes != rhs._requiredAllTypes {return false}
+    if lhs._optionalAllTypes != rhs._optionalAllTypes {return false}
+    if lhs.repeatedAllTypes != rhs.repeatedAllTypes {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.repeatedGroup != rhs.repeatedGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -12074,56 +11420,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1: Swif
     11: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1, rhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12135,56 +11449,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2: Swif
     21: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2, rhs: ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12196,56 +11478,24 @@ extension ProtobufUnittest_TestParsingMerge.OptionalGroup: SwiftProtobuf.Message
     11: .standard(proto: "optional_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroupAllTypes = source._optionalGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._optionalGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._optionalGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._optionalGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.OptionalGroup, rhs: ProtobufUnittest_TestParsingMerge.OptionalGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroupAllTypes != rhs_storage._optionalGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroupAllTypes != rhs._optionalGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12257,56 +11507,24 @@ extension ProtobufUnittest_TestParsingMerge.RepeatedGroup: SwiftProtobuf.Message
     21: .standard(proto: "repeated_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _repeatedGroupAllTypes = source._repeatedGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._repeatedGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._repeatedGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._repeatedGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._repeatedGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMerge.RepeatedGroup, rhs: ProtobufUnittest_TestParsingMerge.RepeatedGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._repeatedGroupAllTypes != rhs_storage._repeatedGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._repeatedGroupAllTypes != rhs._repeatedGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12533,164 +11751,112 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
     536870014: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _fixed32: Int32? = nil
-    var _repeatedInt32: [Int32] = []
-    var _packedInt32: [Int32] = []
-    var _optionalEnum: ProtobufUnittest_ForeignEnum? = nil
-    var _optionalString: String? = nil
-    var _optionalBytes: Data? = nil
-    var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
-    var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
-    var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _fixed32 = source._fixed32
-      _repeatedInt32 = source._repeatedInt32
-      _packedInt32 = source._packedInt32
-      _optionalEnum = source._optionalEnum
-      _optionalString = source._optionalString
-      _optionalBytes = source._optionalBytes
-      _optionalMessage = source._optionalMessage
-      _optionalGroup = source._optionalGroup
-      _stringStringMap = source._stringStringMap
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 536870000: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 536870001: try decoder.decodeSingularInt32Field(value: &_storage._fixed32)
-        case 536870002: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        case 536870003: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
-        case 536870004: try decoder.decodeSingularEnumField(value: &_storage._optionalEnum)
-        case 536870005: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 536870006: try decoder.decodeSingularBytesField(value: &_storage._optionalBytes)
-        case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-        case 536870011:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 536870012:
-          var v: ProtobufUnittest_TestAllTypes?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofTestAllTypes(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofTestAllTypes(v)}
-        case 536870013:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 536870014:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 536860000..<536870000:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 536870000: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 536870001: try decoder.decodeSingularInt32Field(value: &self._fixed32)
+      case 536870002: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      case 536870003: try decoder.decodeRepeatedInt32Field(value: &self.packedInt32)
+      case 536870004: try decoder.decodeSingularEnumField(value: &self._optionalEnum)
+      case 536870005: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 536870006: try decoder.decodeSingularBytesField(value: &self._optionalBytes)
+      case 536870007: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 536870008: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap)
+      case 536870011:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 536870012:
+        var v: ProtobufUnittest_TestAllTypes?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofTestAllTypes(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofTestAllTypes(v)}
+      case 536870013:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 536870014:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 536860000..<536870000:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
-      }
-      if let v = _storage._fixed32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 536870002)
-      }
-      if !_storage._packedInt32.isEmpty {
-        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 536870003)
-      }
-      if let v = _storage._optionalEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
-      }
-      if let v = _storage._optionalBytes {
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
-      }
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
-      }
-      if !_storage._stringStringMap.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
-      }
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-      case .oneofTestAllTypes(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      case nil: break
-      }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
+    }
+    if let v = self._fixed32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 536870002)
+    }
+    if !self.packedInt32.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.packedInt32, fieldNumber: 536870003)
+    }
+    if let v = self._optionalEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
+    }
+    if let v = self._optionalBytes {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
+    }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
+    }
+    if !self.stringStringMap.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.stringStringMap, fieldNumber: 536870010)
+    }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+    case .oneofTestAllTypes(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers, rhs: ProtobufUnittest_TestHugeFieldNumbers) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._fixed32 != rhs_storage._fixed32 {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
-        if _storage._optionalEnum != rhs_storage._optionalEnum {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._optionalBytes != rhs_storage._optionalBytes {return false}
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._stringStringMap != rhs_storage._stringStringMap {return false}
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._fixed32 != rhs._fixed32 {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
+    if lhs.packedInt32 != rhs.packedInt32 {return false}
+    if lhs._optionalEnum != rhs._optionalEnum {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._optionalBytes != rhs._optionalBytes {return false}
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.stringStringMap != rhs.stringStringMap {return false}
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -387,36 +387,33 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var bar: ProtobufUnittest_ComplexOptionType1 {
-    get {return _storage._bar ?? ProtobufUnittest_ComplexOptionType1()}
-    set {_uniqueStorage()._bar = newValue}
+    get {return _bar ?? ProtobufUnittest_ComplexOptionType1()}
+    set {_bar = newValue}
   }
   /// Returns true if `bar` has been explicitly set.
-  var hasBar: Bool {return _storage._bar != nil}
+  var hasBar: Bool {return self._bar != nil}
   /// Clears the value of `bar`. Subsequent reads from it will return its default value.
-  mutating func clearBar() {_uniqueStorage()._bar = nil}
+  mutating func clearBar() {self._bar = nil}
 
   var baz: Int32 {
-    get {return _storage._baz ?? 0}
-    set {_uniqueStorage()._baz = newValue}
+    get {return _baz ?? 0}
+    set {_baz = newValue}
   }
   /// Returns true if `baz` has been explicitly set.
-  var hasBaz: Bool {return _storage._baz != nil}
+  var hasBaz: Bool {return self._baz != nil}
   /// Clears the value of `baz`. Subsequent reads from it will return its default value.
-  mutating func clearBaz() {_uniqueStorage()._baz = nil}
+  mutating func clearBaz() {self._baz = nil}
 
   var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return _storage._fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {_uniqueStorage()._fred = newValue}
+    get {return _fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {_fred = newValue}
   }
   /// Returns true if `fred` has been explicitly set.
-  var hasFred: Bool {return _storage._fred != nil}
+  var hasFred: Bool {return self._fred != nil}
   /// Clears the value of `fred`. Subsequent reads from it will return its default value.
-  mutating func clearFred() {_uniqueStorage()._fred = nil}
+  mutating func clearFred() {self._fred = nil}
 
-  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
-    get {return _storage._barney}
-    set {_uniqueStorage()._barney = newValue}
-  }
+  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -444,7 +441,9 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _bar: ProtobufUnittest_ComplexOptionType1? = nil
+  fileprivate var _baz: Int32? = nil
+  fileprivate var _fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4? = nil
 }
 
 struct ProtobufUnittest_ComplexOptionType3 {
@@ -453,22 +452,22 @@ struct ProtobufUnittest_ComplexOptionType3 {
   // methods supported on all messages.
 
   var qux: Int32 {
-    get {return _storage._qux ?? 0}
-    set {_uniqueStorage()._qux = newValue}
+    get {return _qux ?? 0}
+    set {_qux = newValue}
   }
   /// Returns true if `qux` has been explicitly set.
-  var hasQux: Bool {return _storage._qux != nil}
+  var hasQux: Bool {return self._qux != nil}
   /// Clears the value of `qux`. Subsequent reads from it will return its default value.
-  mutating func clearQux() {_uniqueStorage()._qux = nil}
+  mutating func clearQux() {self._qux = nil}
 
   var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
-    get {return _storage._complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
-    set {_uniqueStorage()._complexOptionType5 = newValue}
+    get {return _complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
+    set {_complexOptionType5 = newValue}
   }
   /// Returns true if `complexOptionType5` has been explicitly set.
-  var hasComplexOptionType5: Bool {return _storage._complexOptionType5 != nil}
+  var hasComplexOptionType5: Bool {return self._complexOptionType5 != nil}
   /// Clears the value of `complexOptionType5`. Subsequent reads from it will return its default value.
-  mutating func clearComplexOptionType5() {_uniqueStorage()._complexOptionType5 = nil}
+  mutating func clearComplexOptionType5() {self._complexOptionType5 = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -495,7 +494,8 @@ struct ProtobufUnittest_ComplexOptionType3 {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _qux: Int32? = nil
+  fileprivate var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
 }
 
 struct ProtobufUnittest_ComplexOpt6 {
@@ -2202,88 +2202,48 @@ extension ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProto
     4: .same(proto: "barney"),
   ]
 
-  fileprivate class _StorageClass {
-    var _bar: ProtobufUnittest_ComplexOptionType1? = nil
-    var _baz: Int32? = nil
-    var _fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4? = nil
-    var _barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _bar = source._bar
-      _baz = source._baz
-      _fred = source._fred
-      _barney = source._barney
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._bar, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._bar, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._bar)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._baz)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._fred)
-        case 4: try decoder.decodeRepeatedMessageField(value: &_storage._barney)
-        case 100..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._bar)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._baz)
+      case 3: try decoder.decodeSingularMessageField(value: &self._fred)
+      case 4: try decoder.decodeRepeatedMessageField(value: &self.barney)
+      case 100..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._bar {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._baz {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._fred {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if !_storage._barney.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._barney, fieldNumber: 4)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 100, end: 536870912)
+    if let v = self._bar {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._baz {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._fred {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
+    if !self.barney.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.barney, fieldNumber: 4)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 100, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_ComplexOptionType2, rhs: ProtobufUnittest_ComplexOptionType2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._bar != rhs_storage._bar {return false}
-        if _storage._baz != rhs_storage._baz {return false}
-        if _storage._fred != rhs_storage._fred {return false}
-        if _storage._barney != rhs_storage._barney {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._bar != rhs._bar {return false}
+    if lhs._baz != rhs._baz {return false}
+    if lhs._fred != rhs._fred {return false}
+    if lhs.barney != rhs.barney {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -2326,63 +2286,29 @@ extension ProtobufUnittest_ComplexOptionType3: SwiftProtobuf.Message, SwiftProto
     2: .unique(proto: "ComplexOptionType5", json: "complexoptiontype5"),
   ]
 
-  fileprivate class _StorageClass {
-    var _qux: Int32? = nil
-    var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _qux = source._qux
-      _complexOptionType5 = source._complexOptionType5
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._qux)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._complexOptionType5)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._qux)
+      case 2: try decoder.decodeSingularGroupField(value: &self._complexOptionType5)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._qux {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._complexOptionType5 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
+    if let v = self._qux {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._complexOptionType5 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_ComplexOptionType3, rhs: ProtobufUnittest_ComplexOptionType3) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._qux != rhs_storage._qux {return false}
-        if _storage._complexOptionType5 != rhs_storage._complexOptionType5 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._qux != rhs._qux {return false}
+    if lhs._complexOptionType5 != rhs._complexOptionType5 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
@@ -63,24 +63,21 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize {
   /// Test that embedding a message which has optimize_for = CODE_SIZE into
   /// one optimized for speed works.
   var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -94,71 +91,35 @@ extension ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message, Swi
     2: .standard(proto: "repeated_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
-    var _repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage, !v.isInitialized {return false}
-      if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedMessage) {return false}
-      return true
-    }
+    if let v = self._optionalMessage, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.repeatedMessage) {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestEmbedOptimizedForSize, rhs: ProtobufUnittest_TestEmbedOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1051,41 +1051,35 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
-    get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-    set {_uniqueStorage()._requiredAllTypes = newValue}
+    get {return _requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+    set {_requiredAllTypes = newValue}
   }
   /// Returns true if `requiredAllTypes` has been explicitly set.
-  var hasRequiredAllTypes: Bool {return _storage._requiredAllTypes != nil}
+  var hasRequiredAllTypes: Bool {return self._requiredAllTypes != nil}
   /// Clears the value of `requiredAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearRequiredAllTypes() {_uniqueStorage()._requiredAllTypes = nil}
+  mutating func clearRequiredAllTypes() {self._requiredAllTypes = nil}
 
   var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
-    get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-    set {_uniqueStorage()._optionalAllTypes = newValue}
+    get {return _optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+    set {_optionalAllTypes = newValue}
   }
   /// Returns true if `optionalAllTypes` has been explicitly set.
-  var hasOptionalAllTypes: Bool {return _storage._optionalAllTypes != nil}
+  var hasOptionalAllTypes: Bool {return self._optionalAllTypes != nil}
   /// Clears the value of `optionalAllTypes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalAllTypes() {_uniqueStorage()._optionalAllTypes = nil}
+  mutating func clearOptionalAllTypes() {self._optionalAllTypes = nil}
 
-  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
-    get {return _storage._repeatedAllTypes}
-    set {_uniqueStorage()._repeatedAllTypes = newValue}
-  }
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] = []
 
   var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
-    get {return _storage._repeatedGroup}
-    set {_uniqueStorage()._repeatedGroup = newValue}
-  }
+  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1116,19 +1110,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypesLite {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypesLite()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypesLite? = nil
     }
 
     struct Group2 {
@@ -1137,19 +1131,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
       // methods supported on all messages.
 
       var field1: ProtobufUnittest_TestAllTypesLite {
-        get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
-        set {_uniqueStorage()._field1 = newValue}
+        get {return _field1 ?? ProtobufUnittest_TestAllTypesLite()}
+        set {_field1 = newValue}
       }
       /// Returns true if `field1` has been explicitly set.
-      var hasField1: Bool {return _storage._field1 != nil}
+      var hasField1: Bool {return self._field1 != nil}
       /// Clears the value of `field1`. Subsequent reads from it will return its default value.
-      mutating func clearField1() {_uniqueStorage()._field1 = nil}
+      mutating func clearField1() {self._field1 = nil}
 
       var unknownFields = SwiftProtobuf.UnknownStorage()
 
       init() {}
 
-      fileprivate var _storage = _StorageClass.defaultInstance
+      fileprivate var _field1: ProtobufUnittest_TestAllTypesLite? = nil
     }
 
     init() {}
@@ -1161,19 +1155,19 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
-      get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-      set {_uniqueStorage()._optionalGroupAllTypes = newValue}
+      get {return _optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+      set {_optionalGroupAllTypes = newValue}
     }
     /// Returns true if `optionalGroupAllTypes` has been explicitly set.
-    var hasOptionalGroupAllTypes: Bool {return _storage._optionalGroupAllTypes != nil}
+    var hasOptionalGroupAllTypes: Bool {return self._optionalGroupAllTypes != nil}
     /// Clears the value of `optionalGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearOptionalGroupAllTypes() {_uniqueStorage()._optionalGroupAllTypes = nil}
+    mutating func clearOptionalGroupAllTypes() {self._optionalGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
   }
 
   struct RepeatedGroup {
@@ -1182,25 +1176,27 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.ExtensibleMessage {
     // methods supported on all messages.
 
     var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
-      get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
-      set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
+      get {return _repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
+      set {_repeatedGroupAllTypes = newValue}
     }
     /// Returns true if `repeatedGroupAllTypes` has been explicitly set.
-    var hasRepeatedGroupAllTypes: Bool {return _storage._repeatedGroupAllTypes != nil}
+    var hasRepeatedGroupAllTypes: Bool {return self._repeatedGroupAllTypes != nil}
     /// Clears the value of `repeatedGroupAllTypes`. Subsequent reads from it will return its default value.
-    mutating func clearRepeatedGroupAllTypes() {_uniqueStorage()._repeatedGroupAllTypes = nil}
+    mutating func clearRepeatedGroupAllTypes() {self._repeatedGroupAllTypes = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
   }
 
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _requiredAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
+  fileprivate var _optionalAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup? = nil
 }
 
 /// TestEmptyMessageLite is used to test unknown fields support in lite mode.
@@ -1296,118 +1292,106 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
   // methods supported on all messages.
 
   var optionalInt32: Int32 {
-    get {return _storage._optionalInt32 ?? 0}
-    set {_uniqueStorage()._optionalInt32 = newValue}
+    get {return _optionalInt32 ?? 0}
+    set {_optionalInt32 = newValue}
   }
   /// Returns true if `optionalInt32` has been explicitly set.
-  var hasOptionalInt32: Bool {return _storage._optionalInt32 != nil}
+  var hasOptionalInt32: Bool {return self._optionalInt32 != nil}
   /// Clears the value of `optionalInt32`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalInt32() {_uniqueStorage()._optionalInt32 = nil}
+  mutating func clearOptionalInt32() {self._optionalInt32 = nil}
 
   var fixed32: Int32 {
-    get {return _storage._fixed32 ?? 0}
-    set {_uniqueStorage()._fixed32 = newValue}
+    get {return _fixed32 ?? 0}
+    set {_fixed32 = newValue}
   }
   /// Returns true if `fixed32` has been explicitly set.
-  var hasFixed32: Bool {return _storage._fixed32 != nil}
+  var hasFixed32: Bool {return self._fixed32 != nil}
   /// Clears the value of `fixed32`. Subsequent reads from it will return its default value.
-  mutating func clearFixed32() {_uniqueStorage()._fixed32 = nil}
+  mutating func clearFixed32() {self._fixed32 = nil}
 
-  var repeatedInt32: [Int32] {
-    get {return _storage._repeatedInt32}
-    set {_uniqueStorage()._repeatedInt32 = newValue}
-  }
+  var repeatedInt32: [Int32] = []
 
-  var packedInt32: [Int32] {
-    get {return _storage._packedInt32}
-    set {_uniqueStorage()._packedInt32 = newValue}
-  }
+  var packedInt32: [Int32] = []
 
   var optionalEnum: ProtobufUnittest_ForeignEnumLite {
-    get {return _storage._optionalEnum ?? .foreignLiteFoo}
-    set {_uniqueStorage()._optionalEnum = newValue}
+    get {return _optionalEnum ?? .foreignLiteFoo}
+    set {_optionalEnum = newValue}
   }
   /// Returns true if `optionalEnum` has been explicitly set.
-  var hasOptionalEnum: Bool {return _storage._optionalEnum != nil}
+  var hasOptionalEnum: Bool {return self._optionalEnum != nil}
   /// Clears the value of `optionalEnum`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalEnum() {_uniqueStorage()._optionalEnum = nil}
+  mutating func clearOptionalEnum() {self._optionalEnum = nil}
 
   var optionalString: String {
-    get {return _storage._optionalString ?? String()}
-    set {_uniqueStorage()._optionalString = newValue}
+    get {return _optionalString ?? String()}
+    set {_optionalString = newValue}
   }
   /// Returns true if `optionalString` has been explicitly set.
-  var hasOptionalString: Bool {return _storage._optionalString != nil}
+  var hasOptionalString: Bool {return self._optionalString != nil}
   /// Clears the value of `optionalString`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalString() {_uniqueStorage()._optionalString = nil}
+  mutating func clearOptionalString() {self._optionalString = nil}
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
-    set {_uniqueStorage()._optionalBytes = newValue}
+    get {return _optionalBytes ?? SwiftProtobuf.Internal.emptyData}
+    set {_optionalBytes = newValue}
   }
   /// Returns true if `optionalBytes` has been explicitly set.
-  var hasOptionalBytes: Bool {return _storage._optionalBytes != nil}
+  var hasOptionalBytes: Bool {return self._optionalBytes != nil}
   /// Clears the value of `optionalBytes`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalBytes() {_uniqueStorage()._optionalBytes = nil}
+  mutating func clearOptionalBytes() {self._optionalBytes = nil}
 
   var optionalMessage: ProtobufUnittest_ForeignMessageLite {
-    get {return _storage._optionalMessage ?? ProtobufUnittest_ForeignMessageLite()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? ProtobufUnittest_ForeignMessageLite()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
   var optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup {
-    get {return _storage._optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup()}
-    set {_uniqueStorage()._optionalGroup = newValue}
+    get {return _optionalGroup ?? ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup()}
+    set {_optionalGroup = newValue}
   }
   /// Returns true if `optionalGroup` has been explicitly set.
-  var hasOptionalGroup: Bool {return _storage._optionalGroup != nil}
+  var hasOptionalGroup: Bool {return self._optionalGroup != nil}
   /// Clears the value of `optionalGroup`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalGroup() {_uniqueStorage()._optionalGroup = nil}
+  mutating func clearOptionalGroup() {self._optionalGroup = nil}
 
-  var stringStringMap: Dictionary<String,String> {
-    get {return _storage._stringStringMap}
-    set {_uniqueStorage()._stringStringMap = newValue}
-  }
+  var stringStringMap: Dictionary<String,String> = [:]
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
+      if case .oneofTestAllTypes(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
+    set {oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1443,7 +1427,13 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalInt32: Int32? = nil
+  fileprivate var _fixed32: Int32? = nil
+  fileprivate var _optionalEnum: ProtobufUnittest_ForeignEnumLite? = nil
+  fileprivate var _optionalString: String? = nil
+  fileprivate var _optionalBytes: Data? = nil
+  fileprivate var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
+  fileprivate var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
 }
 
 struct ProtobufUnittest_TestOneofParsingLite {
@@ -1451,81 +1441,78 @@ struct ProtobufUnittest_TestOneofParsingLite {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField? = nil
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._oneofField {return v}
+      if case .oneofInt32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofInt32(newValue)}
+    set {oneofField = .oneofInt32(newValue)}
   }
 
   var oneofSubmessage: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofSubmessage(let v)? = _storage._oneofField {return v}
+      if case .oneofSubmessage(let v)? = oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {_uniqueStorage()._oneofField = .oneofSubmessage(newValue)}
+    set {oneofField = .oneofSubmessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return Data([100, 101, 102, 97, 117, 108, 116, 32, 98, 121, 116, 101, 115])
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var oneofStringCord: String {
     get {
-      if case .oneofStringCord(let v)? = _storage._oneofField {return v}
+      if case .oneofStringCord(let v)? = oneofField {return v}
       return "default Cord"
     }
-    set {_uniqueStorage()._oneofField = .oneofStringCord(newValue)}
+    set {oneofField = .oneofStringCord(newValue)}
   }
 
   var oneofBytesCord: Data {
     get {
-      if case .oneofBytesCord(let v)? = _storage._oneofField {return v}
+      if case .oneofBytesCord(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytesCord(newValue)}
+    set {oneofField = .oneofBytesCord(newValue)}
   }
 
   var oneofStringStringPiece: String {
     get {
-      if case .oneofStringStringPiece(let v)? = _storage._oneofField {return v}
+      if case .oneofStringStringPiece(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofStringStringPiece(newValue)}
+    set {oneofField = .oneofStringStringPiece(newValue)}
   }
 
   var oneofBytesStringPiece: Data {
     get {
-      if case .oneofBytesStringPiece(let v)? = _storage._oneofField {return v}
+      if case .oneofBytesStringPiece(let v)? = oneofField {return v}
       return Data([100, 101, 102, 97, 117, 108, 116, 32, 83, 116, 114, 105, 110, 103, 80, 105, 101, 99, 101])
     }
-    set {_uniqueStorage()._oneofField = .oneofBytesStringPiece(newValue)}
+    set {oneofField = .oneofBytesStringPiece(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_V2EnumLite {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {return v}
+      if case .oneofEnum(let v)? = oneofField {return v}
       return .v2First
     }
-    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
+    set {oneofField = .oneofEnum(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1543,8 +1530,6 @@ struct ProtobufUnittest_TestOneofParsingLite {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// The following four messages are set up to test for wire compatibility between
@@ -4756,95 +4741,53 @@ extension ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftPro
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  fileprivate class _StorageClass {
-    var _requiredAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-    var _optionalAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-    var _repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] = []
-    var _optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup? = nil
-    var _repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _requiredAllTypes = source._requiredAllTypes
-      _optionalAllTypes = source._optionalAllTypes
-      _repeatedAllTypes = source._repeatedAllTypes
-      _optionalGroup = source._optionalGroup
-      _repeatedGroup = source._repeatedGroup
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._requiredAllTypes == nil {return false}
-      return true
-    }
+    if self._requiredAllTypes == nil {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._requiredAllTypes)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._optionalAllTypes)
-        case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
-        case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._requiredAllTypes)
+      case 2: try decoder.decodeSingularMessageField(value: &self._optionalAllTypes)
+      case 3: try decoder.decodeRepeatedMessageField(value: &self.repeatedAllTypes)
+      case 10: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 20: try decoder.decodeRepeatedGroupField(value: &self.repeatedGroup)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._requiredAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._optionalAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if !_storage._repeatedAllTypes.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedAllTypes, fieldNumber: 3)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
-      }
-      if !_storage._repeatedGroup.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._repeatedGroup, fieldNumber: 20)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._requiredAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    if let v = self._optionalAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }
+    if !self.repeatedAllTypes.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedAllTypes, fieldNumber: 3)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 10)
+    }
+    if !self.repeatedGroup.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.repeatedGroup, fieldNumber: 20)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite, rhs: ProtobufUnittest_TestParsingMergeLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._requiredAllTypes != rhs_storage._requiredAllTypes {return false}
-        if _storage._optionalAllTypes != rhs_storage._optionalAllTypes {return false}
-        if _storage._repeatedAllTypes != rhs_storage._repeatedAllTypes {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._repeatedGroup != rhs_storage._repeatedGroup {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._requiredAllTypes != rhs._requiredAllTypes {return false}
+    if lhs._optionalAllTypes != rhs._optionalAllTypes {return false}
+    if lhs.repeatedAllTypes != rhs.repeatedAllTypes {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.repeatedGroup != rhs.repeatedGroup {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -4922,56 +4865,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1: 
     11: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -4983,56 +4894,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2: 
     21: .same(proto: "field1"),
   ]
 
-  fileprivate class _StorageClass {
-    var _field1: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _field1 = source._field1
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._field1)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._field1)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._field1 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._field1 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._field1 != rhs_storage._field1 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._field1 != rhs._field1 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5044,56 +4923,24 @@ extension ProtobufUnittest_TestParsingMergeLite.OptionalGroup: SwiftProtobuf.Mes
     11: .standard(proto: "optional_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalGroupAllTypes = source._optionalGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 11: try decoder.decodeSingularMessageField(value: &_storage._optionalGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 11: try decoder.decodeSingularMessageField(value: &self._optionalGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+    if let v = self._optionalGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.OptionalGroup, rhs: ProtobufUnittest_TestParsingMergeLite.OptionalGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalGroupAllTypes != rhs_storage._optionalGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalGroupAllTypes != rhs._optionalGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5105,56 +4952,24 @@ extension ProtobufUnittest_TestParsingMergeLite.RepeatedGroup: SwiftProtobuf.Mes
     21: .standard(proto: "repeated_group_all_types"),
   ]
 
-  fileprivate class _StorageClass {
-    var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _repeatedGroupAllTypes = source._repeatedGroupAllTypes
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 21: try decoder.decodeSingularMessageField(value: &_storage._repeatedGroupAllTypes)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 21: try decoder.decodeSingularMessageField(value: &self._repeatedGroupAllTypes)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._repeatedGroupAllTypes {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
-      }
+    if let v = self._repeatedGroupAllTypes {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 21)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestParsingMergeLite.RepeatedGroup, rhs: ProtobufUnittest_TestParsingMergeLite.RepeatedGroup) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._repeatedGroupAllTypes != rhs_storage._repeatedGroupAllTypes {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._repeatedGroupAllTypes != rhs._repeatedGroupAllTypes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -5307,164 +5122,112 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
     536870014: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalInt32: Int32? = nil
-    var _fixed32: Int32? = nil
-    var _repeatedInt32: [Int32] = []
-    var _packedInt32: [Int32] = []
-    var _optionalEnum: ProtobufUnittest_ForeignEnumLite? = nil
-    var _optionalString: String? = nil
-    var _optionalBytes: Data? = nil
-    var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
-    var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
-    var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalInt32 = source._optionalInt32
-      _fixed32 = source._fixed32
-      _repeatedInt32 = source._repeatedInt32
-      _packedInt32 = source._packedInt32
-      _optionalEnum = source._optionalEnum
-      _optionalString = source._optionalString
-      _optionalBytes = source._optionalBytes
-      _optionalMessage = source._optionalMessage
-      _optionalGroup = source._optionalGroup
-      _stringStringMap = source._stringStringMap
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 536870000: try decoder.decodeSingularInt32Field(value: &_storage._optionalInt32)
-        case 536870001: try decoder.decodeSingularInt32Field(value: &_storage._fixed32)
-        case 536870002: try decoder.decodeRepeatedInt32Field(value: &_storage._repeatedInt32)
-        case 536870003: try decoder.decodeRepeatedInt32Field(value: &_storage._packedInt32)
-        case 536870004: try decoder.decodeSingularEnumField(value: &_storage._optionalEnum)
-        case 536870005: try decoder.decodeSingularStringField(value: &_storage._optionalString)
-        case 536870006: try decoder.decodeSingularBytesField(value: &_storage._optionalBytes)
-        case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
-        case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-        case 536870011:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 536870012:
-          var v: ProtobufUnittest_TestAllTypesLite?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofTestAllTypes(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofTestAllTypes(v)}
-        case 536870013:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 536870014:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 536860000..<536870000:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 536870000: try decoder.decodeSingularInt32Field(value: &self._optionalInt32)
+      case 536870001: try decoder.decodeSingularInt32Field(value: &self._fixed32)
+      case 536870002: try decoder.decodeRepeatedInt32Field(value: &self.repeatedInt32)
+      case 536870003: try decoder.decodeRepeatedInt32Field(value: &self.packedInt32)
+      case 536870004: try decoder.decodeSingularEnumField(value: &self._optionalEnum)
+      case 536870005: try decoder.decodeSingularStringField(value: &self._optionalString)
+      case 536870006: try decoder.decodeSingularBytesField(value: &self._optionalBytes)
+      case 536870007: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 536870008: try decoder.decodeSingularGroupField(value: &self._optionalGroup)
+      case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap)
+      case 536870011:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 536870012:
+        var v: ProtobufUnittest_TestAllTypesLite?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofTestAllTypes(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofTestAllTypes(v)}
+      case 536870013:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 536870014:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 536860000..<536870000:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
-      if let v = _storage._optionalInt32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
-      }
-      if let v = _storage._fixed32 {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
-      }
-      if !_storage._repeatedInt32.isEmpty {
-        try visitor.visitRepeatedInt32Field(value: _storage._repeatedInt32, fieldNumber: 536870002)
-      }
-      if !_storage._packedInt32.isEmpty {
-        try visitor.visitPackedInt32Field(value: _storage._packedInt32, fieldNumber: 536870003)
-      }
-      if let v = _storage._optionalEnum {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
-      }
-      if let v = _storage._optionalString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
-      }
-      if let v = _storage._optionalBytes {
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
-      }
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
-      }
-      if let v = _storage._optionalGroup {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
-      }
-      if !_storage._stringStringMap.isEmpty {
-        try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
-      }
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-      case .oneofTestAllTypes(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      case nil: break
-      }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 536860000, end: 536870000)
+    if let v = self._optionalInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870000)
+    }
+    if let v = self._fixed32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 536870001)
+    }
+    if !self.repeatedInt32.isEmpty {
+      try visitor.visitRepeatedInt32Field(value: self.repeatedInt32, fieldNumber: 536870002)
+    }
+    if !self.packedInt32.isEmpty {
+      try visitor.visitPackedInt32Field(value: self.packedInt32, fieldNumber: 536870003)
+    }
+    if let v = self._optionalEnum {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 536870004)
+    }
+    if let v = self._optionalString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870005)
+    }
+    if let v = self._optionalBytes {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870006)
+    }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870007)
+    }
+    if let v = self._optionalGroup {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 536870008)
+    }
+    if !self.stringStringMap.isEmpty {
+      try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.stringStringMap, fieldNumber: 536870010)
+    }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+    case .oneofTestAllTypes(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite, rhs: ProtobufUnittest_TestHugeFieldNumbersLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalInt32 != rhs_storage._optionalInt32 {return false}
-        if _storage._fixed32 != rhs_storage._fixed32 {return false}
-        if _storage._repeatedInt32 != rhs_storage._repeatedInt32 {return false}
-        if _storage._packedInt32 != rhs_storage._packedInt32 {return false}
-        if _storage._optionalEnum != rhs_storage._optionalEnum {return false}
-        if _storage._optionalString != rhs_storage._optionalString {return false}
-        if _storage._optionalBytes != rhs_storage._optionalBytes {return false}
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._optionalGroup != rhs_storage._optionalGroup {return false}
-        if _storage._stringStringMap != rhs_storage._stringStringMap {return false}
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalInt32 != rhs._optionalInt32 {return false}
+    if lhs._fixed32 != rhs._fixed32 {return false}
+    if lhs.repeatedInt32 != rhs.repeatedInt32 {return false}
+    if lhs.packedInt32 != rhs.packedInt32 {return false}
+    if lhs._optionalEnum != rhs._optionalEnum {return false}
+    if lhs._optionalString != rhs._optionalString {return false}
+    if lhs._optionalBytes != rhs._optionalBytes {return false}
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs._optionalGroup != rhs._optionalGroup {return false}
+    if lhs.stringStringMap != rhs.stringStringMap {return false}
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -5514,121 +5277,89 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
     9: .standard(proto: "oneof_enum"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofInt32(v)}
-        case 2:
-          var v: ProtobufUnittest_TestAllTypesLite?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofSubmessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofSubmessage(v)}
-        case 3:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 4:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        case 5:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofStringCord(v)}
-        case 6:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytesCord(v)}
-        case 7:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofStringStringPiece(v)}
-        case 8:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytesStringPiece(v)}
-        case 9:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_V2EnumLite?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofInt32(v)}
+      case 2:
+        var v: ProtobufUnittest_TestAllTypesLite?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofSubmessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofSubmessage(v)}
+      case 3:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 4:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      case 5:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofStringCord(v)}
+      case 6:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytesCord(v)}
+      case 7:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofStringStringPiece(v)}
+      case 8:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytesStringPiece(v)}
+      case 9:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_V2EnumLite?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.oneofField = .oneofEnum(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._oneofField {
-      case .oneofInt32(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      case .oneofSubmessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
-      case .oneofStringCord(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-      case .oneofBytesCord(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 6)
-      case .oneofStringStringPiece(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-      case .oneofBytesStringPiece(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 8)
-      case .oneofEnum(let v)?:
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 9)
-      case nil: break
-      }
+    switch self.oneofField {
+    case .oneofInt32(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .oneofSubmessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
+    case .oneofStringCord(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    case .oneofBytesCord(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 6)
+    case .oneofStringStringPiece(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+    case .oneofBytesStringPiece(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 8)
+    case .oneofEnum(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 9)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneofParsingLite, rhs: ProtobufUnittest_TestOneofParsingLite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
@@ -59,29 +59,30 @@ struct ProtobufUnittest_TestLiteImportsNonlite {
   // methods supported on all messages.
 
   var message: ProtobufUnittest_TestAllTypes {
-    get {return _storage._message ?? ProtobufUnittest_TestAllTypes()}
-    set {_uniqueStorage()._message = newValue}
+    get {return _message ?? ProtobufUnittest_TestAllTypes()}
+    set {_message = newValue}
   }
   /// Returns true if `message` has been explicitly set.
-  var hasMessage: Bool {return _storage._message != nil}
+  var hasMessage: Bool {return self._message != nil}
   /// Clears the value of `message`. Subsequent reads from it will return its default value.
-  mutating func clearMessage() {_uniqueStorage()._message = nil}
+  mutating func clearMessage() {self._message = nil}
 
   /// Verifies that transitive required fields generates valid code.
   var messageWithRequired: ProtobufUnittest_TestRequired {
-    get {return _storage._messageWithRequired ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._messageWithRequired = newValue}
+    get {return _messageWithRequired ?? ProtobufUnittest_TestRequired()}
+    set {_messageWithRequired = newValue}
   }
   /// Returns true if `messageWithRequired` has been explicitly set.
-  var hasMessageWithRequired: Bool {return _storage._messageWithRequired != nil}
+  var hasMessageWithRequired: Bool {return self._messageWithRequired != nil}
   /// Clears the value of `messageWithRequired`. Subsequent reads from it will return its default value.
-  mutating func clearMessageWithRequired() {_uniqueStorage()._messageWithRequired = nil}
+  mutating func clearMessageWithRequired() {self._messageWithRequired = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _message: ProtobufUnittest_TestAllTypes? = nil
+  fileprivate var _messageWithRequired: ProtobufUnittest_TestRequired? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -95,70 +96,34 @@ extension ProtobufUnittest_TestLiteImportsNonlite: SwiftProtobuf.Message, SwiftP
     2: .standard(proto: "message_with_required"),
   ]
 
-  fileprivate class _StorageClass {
-    var _message: ProtobufUnittest_TestAllTypes? = nil
-    var _messageWithRequired: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _message = source._message
-      _messageWithRequired = source._messageWithRequired
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageWithRequired, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageWithRequired, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._message)
-        case 2: try decoder.decodeSingularMessageField(value: &_storage._messageWithRequired)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._message)
+      case 2: try decoder.decodeSingularMessageField(value: &self._messageWithRequired)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._message {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._messageWithRequired {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+    if let v = self._message {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if let v = self._messageWithRequired {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestLiteImportsNonlite, rhs: ProtobufUnittest_TestLiteImportsNonlite) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._message != rhs_storage._message {return false}
-        if _storage._messageWithRequired != rhs_storage._messageWithRequired {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._message != rhs._message {return false}
+    if lhs._messageWithRequired != rhs._messageWithRequired {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -62,19 +62,19 @@ struct ProtobufUnittest_TestMessageSetContainer {
   // methods supported on all messages.
 
   var messageSet: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._messageSet = newValue}
+    get {return _messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_messageSet = newValue}
   }
   /// Returns true if `messageSet` has been explicitly set.
-  var hasMessageSet: Bool {return _storage._messageSet != nil}
+  var hasMessageSet: Bool {return self._messageSet != nil}
   /// Clears the value of `messageSet`. Subsequent reads from it will return its default value.
-  mutating func clearMessageSet() {_uniqueStorage()._messageSet = nil}
+  mutating func clearMessageSet() {self._messageSet = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 }
 
 struct ProtobufUnittest_TestMessageSetExtension1 {
@@ -83,37 +83,39 @@ struct ProtobufUnittest_TestMessageSetExtension1 {
   // methods supported on all messages.
 
   var i: Int32 {
-    get {return _storage._i ?? 0}
-    set {_uniqueStorage()._i = newValue}
+    get {return _i ?? 0}
+    set {_i = newValue}
   }
   /// Returns true if `i` has been explicitly set.
-  var hasI: Bool {return _storage._i != nil}
+  var hasI: Bool {return self._i != nil}
   /// Clears the value of `i`. Subsequent reads from it will return its default value.
-  mutating func clearI() {_uniqueStorage()._i = nil}
+  mutating func clearI() {self._i = nil}
 
   var recursive: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._recursive ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._recursive = newValue}
+    get {return _recursive ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_recursive = newValue}
   }
   /// Returns true if `recursive` has been explicitly set.
-  var hasRecursive: Bool {return _storage._recursive != nil}
+  var hasRecursive: Bool {return self._recursive != nil}
   /// Clears the value of `recursive`. Subsequent reads from it will return its default value.
-  mutating func clearRecursive() {_uniqueStorage()._recursive = nil}
+  mutating func clearRecursive() {self._recursive = nil}
 
   var testAliasing: String {
-    get {return _storage._testAliasing ?? String()}
-    set {_uniqueStorage()._testAliasing = newValue}
+    get {return _testAliasing ?? String()}
+    set {_testAliasing = newValue}
   }
   /// Returns true if `testAliasing` has been explicitly set.
-  var hasTestAliasing: Bool {return _storage._testAliasing != nil}
+  var hasTestAliasing: Bool {return self._testAliasing != nil}
   /// Clears the value of `testAliasing`. Subsequent reads from it will return its default value.
-  mutating func clearTestAliasing() {_uniqueStorage()._testAliasing = nil}
+  mutating func clearTestAliasing() {self._testAliasing = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _i: Int32? = nil
+  fileprivate var _recursive: Proto2WireformatUnittest_TestMessageSet? = nil
+  fileprivate var _testAliasing: String? = nil
 }
 
 struct ProtobufUnittest_TestMessageSetExtension2 {
@@ -254,63 +256,29 @@ extension ProtobufUnittest_TestMessageSetContainer: SwiftProtobuf.Message, Swift
     1: .standard(proto: "message_set"),
   ]
 
-  fileprivate class _StorageClass {
-    var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _messageSet = source._messageSet
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageSet, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._messageSet)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._messageSet)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._messageSet {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMessageSetContainer, rhs: ProtobufUnittest_TestMessageSetContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._messageSet != rhs_storage._messageSet {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._messageSet != rhs._messageSet {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -324,77 +292,39 @@ extension ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message, Swif
     17: .standard(proto: "test_aliasing"),
   ]
 
-  fileprivate class _StorageClass {
-    var _i: Int32? = nil
-    var _recursive: Proto2WireformatUnittest_TestMessageSet? = nil
-    var _testAliasing: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _i = source._i
-      _recursive = source._recursive
-      _testAliasing = source._testAliasing
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._recursive, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._recursive, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 15: try decoder.decodeSingularInt32Field(value: &_storage._i)
-        case 16: try decoder.decodeSingularMessageField(value: &_storage._recursive)
-        case 17: try decoder.decodeSingularStringField(value: &_storage._testAliasing)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 15: try decoder.decodeSingularInt32Field(value: &self._i)
+      case 16: try decoder.decodeSingularMessageField(value: &self._recursive)
+      case 17: try decoder.decodeSingularStringField(value: &self._testAliasing)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._i {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 15)
-      }
-      if let v = _storage._recursive {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-      }
-      if let v = _storage._testAliasing {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 17)
-      }
+    if let v = self._i {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 15)
+    }
+    if let v = self._recursive {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+    }
+    if let v = self._testAliasing {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 17)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestMessageSetExtension1, rhs: ProtobufUnittest_TestMessageSetExtension1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._i != rhs_storage._i {return false}
-        if _storage._recursive != rhs_storage._recursive {return false}
-        if _storage._testAliasing != rhs_storage._testAliasing {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._i != rhs._i {return false}
+    if lhs._recursive != rhs._recursive {return false}
+    if lhs._testAliasing != rhs._testAliasing {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -74,19 +74,19 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer {
   // methods supported on all messages.
 
   var messageSet: Proto2WireformatUnittest_TestMessageSet {
-    get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
-    set {_uniqueStorage()._messageSet = newValue}
+    get {return _messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
+    set {_messageSet = newValue}
   }
   /// Returns true if `messageSet` has been explicitly set.
-  var hasMessageSet: Bool {return _storage._messageSet != nil}
+  var hasMessageSet: Bool {return self._messageSet != nil}
   /// Clears the value of `messageSet`. Subsequent reads from it will return its default value.
-  mutating func clearMessageSet() {_uniqueStorage()._messageSet = nil}
+  mutating func clearMessageSet() {self._messageSet = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -124,63 +124,29 @@ extension Proto2WireformatUnittest_TestMessageSetWireFormatContainer: SwiftProto
     1: .standard(proto: "message_set"),
   ]
 
-  fileprivate class _StorageClass {
-    var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _messageSet = source._messageSet
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._messageSet, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._messageSet)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._messageSet)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._messageSet {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._messageSet {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Proto2WireformatUnittest_TestMessageSetWireFormatContainer, rhs: Proto2WireformatUnittest_TestMessageSetWireFormatContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._messageSet != rhs_storage._messageSet {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._messageSet != rhs._messageSet {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -843,19 +843,19 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage {
   // methods supported on all messages.
 
   var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
-    get {return _storage._arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
-    set {_uniqueStorage()._arenaMessage = newValue}
+    get {return _arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
+    set {_arenaMessage = newValue}
   }
   /// Returns true if `arenaMessage` has been explicitly set.
-  var hasArenaMessage: Bool {return _storage._arenaMessage != nil}
+  var hasArenaMessage: Bool {return self._arenaMessage != nil}
   /// Clears the value of `arenaMessage`. Subsequent reads from it will return its default value.
-  mutating func clearArenaMessage() {_uniqueStorage()._arenaMessage = nil}
+  mutating func clearArenaMessage() {self._arenaMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
 }
 
 struct ProtobufUnittestNoArena_OneString {
@@ -1695,56 +1695,24 @@ extension ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, Swi
     1: .standard(proto: "arena_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _arenaMessage = source._arenaMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._arenaMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._arenaMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._arenaMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._arenaMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittestNoArena_TestNoArenaMessage, rhs: ProtobufUnittestNoArena_TestNoArenaMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._arenaMessage != rhs_storage._arenaMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._arenaMessage != rhs._arenaMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -468,19 +468,19 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required {
   // methods supported on all messages.
 
   var proto2: ProtobufUnittest_TestRequired {
-    get {return _storage._proto2 ?? ProtobufUnittest_TestRequired()}
-    set {_uniqueStorage()._proto2 = newValue}
+    get {return _proto2 ?? ProtobufUnittest_TestRequired()}
+    set {_proto2 = newValue}
   }
   /// Returns true if `proto2` has been explicitly set.
-  var hasProto2: Bool {return _storage._proto2 != nil}
+  var hasProto2: Bool {return self._proto2 != nil}
   /// Clears the value of `proto2`. Subsequent reads from it will return its default value.
-  mutating func clearProto2() {_uniqueStorage()._proto2 = nil}
+  mutating func clearProto2() {self._proto2 = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _proto2: ProtobufUnittest_TestRequired? = nil
 }
 
 /// Define these after TestAllTypes to make sure the compiler can handle
@@ -1014,63 +1014,29 @@ extension Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Messag
     1: .same(proto: "proto2"),
   ]
 
-  fileprivate class _StorageClass {
-    var _proto2: ProtobufUnittest_TestRequired? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _proto2 = source._proto2
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._proto2, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._proto2, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._proto2)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._proto2)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._proto2 {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._proto2 {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Proto2NofieldpresenceUnittest_TestProto2Required, rhs: Proto2NofieldpresenceUnittest_TestProto2Required) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._proto2 != rhs_storage._proto2 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._proto2 != rhs._proto2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -61,42 +61,39 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var i: Int32 {
-    get {return _storage._i ?? 0}
-    set {_uniqueStorage()._i = newValue}
+    get {return _i ?? 0}
+    set {_i = newValue}
   }
   /// Returns true if `i` has been explicitly set.
-  var hasI: Bool {return _storage._i != nil}
+  var hasI: Bool {return self._i != nil}
   /// Clears the value of `i`. Subsequent reads from it will return its default value.
-  mutating func clearI() {_uniqueStorage()._i = nil}
+  mutating func clearI() {self._i = nil}
 
   var msg: ProtobufUnittest_ForeignMessage {
-    get {return _storage._msg ?? ProtobufUnittest_ForeignMessage()}
-    set {_uniqueStorage()._msg = newValue}
+    get {return _msg ?? ProtobufUnittest_ForeignMessage()}
+    set {_msg = newValue}
   }
   /// Returns true if `msg` has been explicitly set.
-  var hasMsg: Bool {return _storage._msg != nil}
+  var hasMsg: Bool {return self._msg != nil}
   /// Clears the value of `msg`. Subsequent reads from it will return its default value.
-  mutating func clearMsg() {_uniqueStorage()._msg = nil}
+  mutating func clearMsg() {self._msg = nil}
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo? = nil
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v)? = _storage._foo {return v}
+      if case .integerField(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .integerField(newValue)}
+    set {foo = .integerField(newValue)}
   }
 
   var stringField: String {
     get {
-      if case .stringField(let v)? = _storage._foo {return v}
+      if case .stringField(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .stringField(newValue)}
+    set {foo = .stringField(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -109,7 +106,8 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _i: Int32? = nil
+  fileprivate var _msg: ProtobufUnittest_ForeignMessage? = nil
 }
 
 struct ProtobufUnittest_TestRequiredOptimizedForSize {
@@ -139,19 +137,19 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize {
   // methods supported on all messages.
 
   var o: ProtobufUnittest_TestRequiredOptimizedForSize {
-    get {return _storage._o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
-    set {_uniqueStorage()._o = newValue}
+    get {return _o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
+    set {_o = newValue}
   }
   /// Returns true if `o` has been explicitly set.
-  var hasO: Bool {return _storage._o != nil}
+  var hasO: Bool {return self._o != nil}
   /// Clears the value of `o`. Subsequent reads from it will return its default value.
-  mutating func clearO() {_uniqueStorage()._o = nil}
+  mutating func clearO() {self._o = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
 }
 
 // MARK: - Extension support defined in unittest_optimize_for.proto.
@@ -226,91 +224,55 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftPro
     3: .standard(proto: "string_field"),
   ]
 
-  fileprivate class _StorageClass {
-    var _i: Int32? = nil
-    var _msg: ProtobufUnittest_ForeignMessage? = nil
-    var _foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _i = source._i
-      _msg = source._msg
-      _foo = source._foo
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._i)
-        case 2:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .integerField(v)}
-        case 3:
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .stringField(v)}
-        case 19: try decoder.decodeSingularMessageField(value: &_storage._msg)
-        case 1000..<536870912:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._i)
+      case 2:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .integerField(v)}
+      case 3:
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .stringField(v)}
+      case 19: try decoder.decodeSingularMessageField(value: &self._msg)
+      case 1000..<536870912:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._i {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      switch _storage._foo {
-      case .integerField(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      case .stringField(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      case nil: break
-      }
-      if let v = _storage._msg {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
+    if let v = self._i {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
     }
+    switch self.foo {
+    case .integerField(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    case .stringField(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    case nil: break
+    }
+    if let v = self._msg {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 1000, end: 536870912)
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOptimizedForSize, rhs: ProtobufUnittest_TestOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._i != rhs_storage._i {return false}
-        if _storage._msg != rhs_storage._msg {return false}
-        if _storage._foo != rhs_storage._foo {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._i != rhs._i {return false}
+    if lhs._msg != rhs._msg {return false}
+    if lhs.foo != rhs.foo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true
@@ -357,63 +319,29 @@ extension ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, 
     1: .same(proto: "o"),
   ]
 
-  fileprivate class _StorageClass {
-    var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _o = source._o
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._o, !v.isInitialized {return false}
-      return true
-    }
+    if let v = self._o, !v.isInitialized {return false}
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._o)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._o)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._o {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+    if let v = self._o {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOptionalOptimizedForSize, rhs: ProtobufUnittest_TestOptionalOptimizedForSize) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._o != rhs_storage._o {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._o != rhs._o {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -41,77 +41,74 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   // methods supported on all messages.
 
   var myString: String {
-    get {return _storage._myString ?? String()}
-    set {_uniqueStorage()._myString = newValue}
+    get {return _myString ?? String()}
+    set {_myString = newValue}
   }
   /// Returns true if `myString` has been explicitly set.
-  var hasMyString: Bool {return _storage._myString != nil}
+  var hasMyString: Bool {return self._myString != nil}
   /// Clears the value of `myString`. Subsequent reads from it will return its default value.
-  mutating func clearMyString() {_uniqueStorage()._myString = nil}
+  mutating func clearMyString() {self._myString = nil}
 
   var myInt: Int64 {
-    get {return _storage._myInt ?? 0}
-    set {_uniqueStorage()._myInt = newValue}
+    get {return _myInt ?? 0}
+    set {_myInt = newValue}
   }
   /// Returns true if `myInt` has been explicitly set.
-  var hasMyInt: Bool {return _storage._myInt != nil}
+  var hasMyInt: Bool {return self._myInt != nil}
   /// Clears the value of `myInt`. Subsequent reads from it will return its default value.
-  mutating func clearMyInt() {_uniqueStorage()._myInt = nil}
+  mutating func clearMyInt() {self._myInt = nil}
 
   var myFloat: Float {
-    get {return _storage._myFloat ?? 0}
-    set {_uniqueStorage()._myFloat = newValue}
+    get {return _myFloat ?? 0}
+    set {_myFloat = newValue}
   }
   /// Returns true if `myFloat` has been explicitly set.
-  var hasMyFloat: Bool {return _storage._myFloat != nil}
+  var hasMyFloat: Bool {return self._myFloat != nil}
   /// Clears the value of `myFloat`. Subsequent reads from it will return its default value.
-  mutating func clearMyFloat() {_uniqueStorage()._myFloat = nil}
+  mutating func clearMyFloat() {self._myFloat = nil}
 
-  var options: OneOf_Options? {
-    get {return _storage._options}
-    set {_uniqueStorage()._options = newValue}
-  }
+  var options: Swift_Protobuf_TestFieldOrderings.OneOf_Options? = nil
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._options {return v}
+      if case .oneofInt64(let v)? = options {return v}
       return 0
     }
-    set {_uniqueStorage()._options = .oneofInt64(newValue)}
+    set {options = .oneofInt64(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._options {return v}
+      if case .oneofBool(let v)? = options {return v}
       return false
     }
-    set {_uniqueStorage()._options = .oneofBool(newValue)}
+    set {options = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._options {return v}
+      if case .oneofString(let v)? = options {return v}
       return String()
     }
-    set {_uniqueStorage()._options = .oneofString(newValue)}
+    set {options = .oneofString(newValue)}
   }
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._options {return v}
+      if case .oneofInt32(let v)? = options {return v}
       return 0
     }
-    set {_uniqueStorage()._options = .oneofInt32(newValue)}
+    set {options = .oneofInt32(newValue)}
   }
 
   var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
-    get {return _storage._optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
-    set {_uniqueStorage()._optionalNestedMessage = newValue}
+    get {return _optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
+    set {_optionalNestedMessage = newValue}
   }
   /// Returns true if `optionalNestedMessage` has been explicitly set.
-  var hasOptionalNestedMessage: Bool {return _storage._optionalNestedMessage != nil}
+  var hasOptionalNestedMessage: Bool {return self._optionalNestedMessage != nil}
   /// Clears the value of `optionalNestedMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalNestedMessage() {_uniqueStorage()._optionalNestedMessage = nil}
+  mutating func clearOptionalNestedMessage() {self._optionalNestedMessage = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -156,7 +153,10 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
   init() {}
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _myString: String? = nil
+  fileprivate var _myInt: Int64? = nil
+  fileprivate var _myFloat: Float? = nil
+  fileprivate var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
 }
 
 /// These checks how the traverse() generated for a oneof
@@ -356,123 +356,83 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobu
     200: .standard(proto: "optional_nested_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _myString: String? = nil
-    var _myInt: Int64? = nil
-    var _myFloat: Float? = nil
-    var _options: Swift_Protobuf_TestFieldOrderings.OneOf_Options?
-    var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _myString = source._myString
-      _myInt = source._myInt
-      _myFloat = source._myFloat
-      _options = source._options
-      _optionalNestedMessage = source._optionalNestedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
-        case 9:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._options = .oneofBool(v)}
-        case 10:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._options = .oneofInt32(v)}
-        case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
-        case 60:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: Int64?
-          try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._options = .oneofInt64(v)}
-        case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-        case 150:
-          if _storage._options != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._options = .oneofString(v)}
-        case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-        case 2..<9, 12..<56:
-          try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt64Field(value: &self._myInt)
+      case 9:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {self.options = .oneofBool(v)}
+      case 10:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.options = .oneofInt32(v)}
+      case 11: try decoder.decodeSingularStringField(value: &self._myString)
+      case 60:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: Int64?
+        try decoder.decodeSingularInt64Field(value: &v)
+        if let v = v {self.options = .oneofInt64(v)}
+      case 101: try decoder.decodeSingularFloatField(value: &self._myFloat)
+      case 150:
+        if self.options != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.options = .oneofString(v)}
+      case 200: try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage)
+      case 2..<9, 12..<56:
+        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._myInt {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
-      switch _storage._options {
-      case .oneofBool(let v)?:
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-      case .oneofInt32(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-      case nil: break
-      default: break
-      }
-      if let v = _storage._myString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-      }
-      try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
-      if case .oneofInt64(let v)? = _storage._options {
-        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-      }
-      if let v = _storage._myFloat {
-        try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
-      }
-      if case .oneofString(let v)? = _storage._options {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-      }
-      if let v = _storage._optionalNestedMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
-      }
+    if let v = self._myInt {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
+    switch self.options {
+    case .oneofBool(let v)?:
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+    case .oneofInt32(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+    case nil: break
+    default: break
+    }
+    if let v = self._myString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+    }
+    try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
+    if case .oneofInt64(let v)? = self.options {
+      try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+    }
+    if let v = self._myFloat {
+      try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
+    }
+    if case .oneofString(let v)? = self.options {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+    }
+    if let v = self._optionalNestedMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Swift_Protobuf_TestFieldOrderings, rhs: Swift_Protobuf_TestFieldOrderings) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._myString != rhs_storage._myString {return false}
-        if _storage._myInt != rhs_storage._myInt {return false}
-        if _storage._myFloat != rhs_storage._myFloat {return false}
-        if _storage._options != rhs_storage._options {return false}
-        if _storage._optionalNestedMessage != rhs_storage._optionalNestedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._myString != rhs._myString {return false}
+    if lhs._myInt != rhs._myInt {return false}
+    if lhs._myFloat != rhs._myFloat {return false}
+    if lhs.options != rhs.options {return false}
+    if lhs._optionalNestedMessage != rhs._optionalNestedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
     return true

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -141,27 +141,24 @@ struct SwiftTestNestingGroupsMessage {
   // methods supported on all messages.
 
   var outerA: Int32 {
-    get {return _storage._outerA ?? 0}
-    set {_uniqueStorage()._outerA = newValue}
+    get {return _outerA ?? 0}
+    set {_outerA = newValue}
   }
   /// Returns true if `outerA` has been explicitly set.
-  var hasOuterA: Bool {return _storage._outerA != nil}
+  var hasOuterA: Bool {return self._outerA != nil}
   /// Clears the value of `outerA`. Subsequent reads from it will return its default value.
-  mutating func clearOuterA() {_uniqueStorage()._outerA = nil}
+  mutating func clearOuterA() {self._outerA = nil}
 
   var subGroup1: SwiftTestNestingGroupsMessage.SubGroup1 {
-    get {return _storage._subGroup1 ?? SwiftTestNestingGroupsMessage.SubGroup1()}
-    set {_uniqueStorage()._subGroup1 = newValue}
+    get {return _subGroup1 ?? SwiftTestNestingGroupsMessage.SubGroup1()}
+    set {_subGroup1 = newValue}
   }
   /// Returns true if `subGroup1` has been explicitly set.
-  var hasSubGroup1: Bool {return _storage._subGroup1 != nil}
+  var hasSubGroup1: Bool {return self._subGroup1 != nil}
   /// Clears the value of `subGroup1`. Subsequent reads from it will return its default value.
-  mutating func clearSubGroup1() {_uniqueStorage()._subGroup1 = nil}
+  mutating func clearSubGroup1() {self._subGroup1 = nil}
 
-  var subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] {
-    get {return _storage._subGroup3}
-    set {_uniqueStorage()._subGroup3 = newValue}
-  }
+  var subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -171,22 +168,22 @@ struct SwiftTestNestingGroupsMessage {
     // methods supported on all messages.
 
     var sub1A: Int32 {
-      get {return _storage._sub1A ?? 0}
-      set {_uniqueStorage()._sub1A = newValue}
+      get {return _sub1A ?? 0}
+      set {_sub1A = newValue}
     }
     /// Returns true if `sub1A` has been explicitly set.
-    var hasSub1A: Bool {return _storage._sub1A != nil}
+    var hasSub1A: Bool {return self._sub1A != nil}
     /// Clears the value of `sub1A`. Subsequent reads from it will return its default value.
-    mutating func clearSub1A() {_uniqueStorage()._sub1A = nil}
+    mutating func clearSub1A() {self._sub1A = nil}
 
     var subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2 {
-      get {return _storage._subGroup2 ?? SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2()}
-      set {_uniqueStorage()._subGroup2 = newValue}
+      get {return _subGroup2 ?? SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2()}
+      set {_subGroup2 = newValue}
     }
     /// Returns true if `subGroup2` has been explicitly set.
-    var hasSubGroup2: Bool {return _storage._subGroup2 != nil}
+    var hasSubGroup2: Bool {return self._subGroup2 != nil}
     /// Clears the value of `subGroup2`. Subsequent reads from it will return its default value.
-    mutating func clearSubGroup2() {_uniqueStorage()._subGroup2 = nil}
+    mutating func clearSubGroup2() {self._subGroup2 = nil}
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -213,7 +210,8 @@ struct SwiftTestNestingGroupsMessage {
 
     init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _sub1A: Int32? = nil
+    fileprivate var _subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2? = nil
   }
 
   struct SubGroup3 {
@@ -262,7 +260,8 @@ struct SwiftTestNestingGroupsMessage {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _outerA: Int32? = nil
+  fileprivate var _subGroup1: SwiftTestNestingGroupsMessage.SubGroup1? = nil
 }
 
 // MARK: - Extension support defined in unittest_swift_groups.proto.
@@ -455,70 +454,34 @@ extension SwiftTestNestingGroupsMessage: SwiftProtobuf.Message, SwiftProtobuf._M
     3: .unique(proto: "SubGroup3", json: "subgroup3"),
   ]
 
-  fileprivate class _StorageClass {
-    var _outerA: Int32? = nil
-    var _subGroup1: SwiftTestNestingGroupsMessage.SubGroup1? = nil
-    var _subGroup3: [SwiftTestNestingGroupsMessage.SubGroup3] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _outerA = source._outerA
-      _subGroup1 = source._subGroup1
-      _subGroup3 = source._subGroup3
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._outerA)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._subGroup1)
-        case 3: try decoder.decodeRepeatedGroupField(value: &_storage._subGroup3)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._outerA)
+      case 2: try decoder.decodeSingularGroupField(value: &self._subGroup1)
+      case 3: try decoder.decodeRepeatedGroupField(value: &self.subGroup3)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._outerA {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._subGroup1 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
-      if !_storage._subGroup3.isEmpty {
-        try visitor.visitRepeatedGroupField(value: _storage._subGroup3, fieldNumber: 3)
-      }
+    if let v = self._outerA {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._subGroup1 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
+    }
+    if !self.subGroup3.isEmpty {
+      try visitor.visitRepeatedGroupField(value: self.subGroup3, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftTestNestingGroupsMessage, rhs: SwiftTestNestingGroupsMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._outerA != rhs_storage._outerA {return false}
-        if _storage._subGroup1 != rhs_storage._subGroup1 {return false}
-        if _storage._subGroup3 != rhs_storage._subGroup3 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._outerA != rhs._outerA {return false}
+    if lhs._subGroup1 != rhs._subGroup1 {return false}
+    if lhs.subGroup3 != rhs.subGroup3 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -531,63 +494,29 @@ extension SwiftTestNestingGroupsMessage.SubGroup1: SwiftProtobuf.Message, SwiftP
     2: .unique(proto: "SubGroup2", json: "subgroup2"),
   ]
 
-  fileprivate class _StorageClass {
-    var _sub1A: Int32? = nil
-    var _subGroup2: SwiftTestNestingGroupsMessage.SubGroup1.SubGroup2? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _sub1A = source._sub1A
-      _subGroup2 = source._subGroup2
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._sub1A)
-        case 2: try decoder.decodeSingularGroupField(value: &_storage._subGroup2)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._sub1A)
+      case 2: try decoder.decodeSingularGroupField(value: &self._subGroup2)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._sub1A {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._subGroup2 {
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
-      }
+    if let v = self._sub1A {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._subGroup2 {
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftTestNestingGroupsMessage.SubGroup1, rhs: SwiftTestNestingGroupsMessage.SubGroup1) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._sub1A != rhs_storage._sub1A {return false}
-        if _storage._subGroup2 != rhs_storage._subGroup2 {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._sub1A != rhs._sub1A {return false}
+    if lhs._subGroup2 != rhs._subGroup2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -96,41 +96,38 @@ struct ProtobufUnittest_OneOfContainer {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var option: OneOf_Option? {
-    get {return _storage._option}
-    set {_uniqueStorage()._option = newValue}
-  }
+  var option: ProtobufUnittest_OneOfContainer.OneOf_Option? = nil
 
   var option1: ProtobufUnittest_OneOfOptionMessage1 {
     get {
-      if case .option1(let v)? = _storage._option {return v}
+      if case .option1(let v)? = option {return v}
       return ProtobufUnittest_OneOfOptionMessage1()
     }
-    set {_uniqueStorage()._option = .option1(newValue)}
+    set {option = .option1(newValue)}
   }
 
   var option2: ProtobufUnittest_OneOfOptionMessage2 {
     get {
-      if case .option2(let v)? = _storage._option {return v}
+      if case .option2(let v)? = option {return v}
       return ProtobufUnittest_OneOfOptionMessage2()
     }
-    set {_uniqueStorage()._option = .option2(newValue)}
+    set {option = .option2(newValue)}
   }
 
   var option3: ProtobufUnittest_OneOfContainer.Option3 {
     get {
-      if case .option3(let v)? = _storage._option {return v}
+      if case .option3(let v)? = option {return v}
       return ProtobufUnittest_OneOfContainer.Option3()
     }
-    set {_uniqueStorage()._option = .option3(newValue)}
+    set {option = .option3(newValue)}
   }
 
   var option4: Int32 {
     get {
-      if case .option4(let v)? = _storage._option {return v}
+      if case .option4(let v)? = option {return v}
       return 0
     }
-    set {_uniqueStorage()._option = .option4(newValue)}
+    set {option = .option4(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -174,8 +171,6 @@ struct ProtobufUnittest_OneOfContainer {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -259,104 +254,70 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
     6: .same(proto: "option4"),
   ]
 
-  fileprivate class _StorageClass {
-    var _option: ProtobufUnittest_OneOfContainer.OneOf_Option?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _option = source._option
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public var isInitialized: Bool {
-    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._option {
-      case .option1(let v)?: if !v.isInitialized {return false}
-      case .option2(let v)?: if !v.isInitialized {return false}
-      case .option3(let v)?: if !v.isInitialized {return false}
-      default: break
-      }
-      return true
+    switch self.option {
+    case .option1(let v)?: if !v.isInitialized {return false}
+    case .option2(let v)?: if !v.isInitialized {return false}
+    case .option3(let v)?: if !v.isInitialized {return false}
+    default: break
     }
+    return true
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1:
-          var v: ProtobufUnittest_OneOfOptionMessage1?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option1(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._option = .option1(v)}
-        case 2:
-          var v: ProtobufUnittest_OneOfOptionMessage2?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option2(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._option = .option2(v)}
-        case 3:
-          var v: ProtobufUnittest_OneOfContainer.Option3?
-          if let current = _storage._option {
-            try decoder.handleConflictingOneOf()
-            if case .option3(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._option = .option3(v)}
-        case 6:
-          if _storage._option != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._option = .option4(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1:
+        var v: ProtobufUnittest_OneOfOptionMessage1?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option1(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.option = .option1(v)}
+      case 2:
+        var v: ProtobufUnittest_OneOfOptionMessage2?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option2(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.option = .option2(v)}
+      case 3:
+        var v: ProtobufUnittest_OneOfContainer.Option3?
+        if let current = self.option {
+          try decoder.handleConflictingOneOf()
+          if case .option3(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.option = .option3(v)}
+      case 6:
+        if self.option != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.option = .option4(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._option {
-      case .option1(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      case .option2(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      case .option3(let v)?:
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-      case .option4(let v)?:
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-      case nil: break
-      }
+    switch self.option {
+    case .option1(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    case .option2(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    case .option3(let v)?:
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
+    case .option4(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_OneOfContainer, rhs: ProtobufUnittest_OneOfContainer) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._option != rhs_storage._option {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.option != rhs.option {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
@@ -42,41 +42,38 @@ struct SwiftUnittest_TestMessage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: SwiftUnittest_TestMessage.OneOf_OneofField? = nil
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {return v}
+      if case .oneofUint32(let v)? = oneofField {return v}
       return 0
     }
-    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
+    set {oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: SwiftUnittest_TestMessage.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
+      if case .oneofNestedMessage(let v)? = oneofField {return v}
       return SwiftUnittest_TestMessage.NestedMessage()
     }
-    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
+    set {oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {return v}
+      if case .oneofString(let v)? = oneofField {return v}
       return String()
     }
-    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
+    set {oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {return v}
+      if case .oneofBytes(let v)? = oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
+    set {oneofField = .oneofBytes(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -130,8 +127,6 @@ struct SwiftUnittest_TestMessage {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct SwiftUnittest_TestParsingMerge {
@@ -140,18 +135,15 @@ struct SwiftUnittest_TestParsingMerge {
   // methods supported on all messages.
 
   var optionalMessage: SwiftUnittest_TestMessage {
-    get {return _storage._optionalMessage ?? SwiftUnittest_TestMessage()}
-    set {_uniqueStorage()._optionalMessage = newValue}
+    get {return _optionalMessage ?? SwiftUnittest_TestMessage()}
+    set {_optionalMessage = newValue}
   }
   /// Returns true if `optionalMessage` has been explicitly set.
-  var hasOptionalMessage: Bool {return _storage._optionalMessage != nil}
+  var hasOptionalMessage: Bool {return self._optionalMessage != nil}
   /// Clears the value of `optionalMessage`. Subsequent reads from it will return its default value.
-  mutating func clearOptionalMessage() {_uniqueStorage()._optionalMessage = nil}
+  mutating func clearOptionalMessage() {self._optionalMessage = nil}
 
-  var repeatedMessage: [SwiftUnittest_TestMessage] {
-    get {return _storage._repeatedMessage}
-    set {_uniqueStorage()._repeatedMessage = newValue}
-  }
+  var repeatedMessage: [SwiftUnittest_TestMessage] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -171,7 +163,7 @@ struct SwiftUnittest_TestParsingMerge {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _optionalMessage: SwiftUnittest_TestMessage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -187,86 +179,54 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
     114: .standard(proto: "oneof_bytes"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: SwiftUnittest_TestMessage.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 111:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
-        case 112:
-          var v: SwiftUnittest_TestMessage.NestedMessage?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .oneofNestedMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
-        case 113:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
-        case 114:
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 111:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {self.oneofField = .oneofUint32(v)}
+      case 112:
+        var v: SwiftUnittest_TestMessage.NestedMessage?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .oneofNestedMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .oneofNestedMessage(v)}
+      case 113:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.oneofField = .oneofString(v)}
+      case 114:
+        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.oneofField = .oneofBytes(v)}
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      switch _storage._oneofField {
-      case .oneofUint32(let v)?:
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-      case .oneofNestedMessage(let v)?:
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-      case .oneofString(let v)?:
-        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-      case .oneofBytes(let v)?:
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      case nil: break
-      }
+    switch self.oneofField {
+    case .oneofUint32(let v)?:
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+    case .oneofNestedMessage(let v)?:
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+    case .oneofString(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+    case .oneofBytes(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftUnittest_TestMessage, rhs: SwiftUnittest_TestMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -320,63 +280,29 @@ extension SwiftUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf._
     2: .standard(proto: "repeated_message"),
   ]
 
-  fileprivate class _StorageClass {
-    var _optionalMessage: SwiftUnittest_TestMessage? = nil
-    var _repeatedMessage: [SwiftUnittest_TestMessage] = []
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _optionalMessage = source._optionalMessage
-      _repeatedMessage = source._repeatedMessage
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
-        case 2: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._optionalMessage)
+      case 2: try decoder.decodeRepeatedMessageField(value: &self.repeatedMessage)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._optionalMessage {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if !_storage._repeatedMessage.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._repeatedMessage, fieldNumber: 2)
-      }
+    if let v = self._optionalMessage {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.repeatedMessage.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.repeatedMessage, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SwiftUnittest_TestParsingMerge, rhs: SwiftUnittest_TestParsingMerge) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._optionalMessage != rhs_storage._optionalMessage {return false}
-        if _storage._repeatedMessage != rhs_storage._repeatedMessage {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._optionalMessage != rhs._optionalMessage {return false}
+    if lhs.repeatedMessage != rhs.repeatedMessage {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -772,38 +772,40 @@ struct ProtobufUnittest_Msg2NamesUsesStorage {
   // methods supported on all messages.
 
   var isInitialized_p: Int32 {
-    get {return _storage._isInitialized_p ?? 0}
-    set {_uniqueStorage()._isInitialized_p = newValue}
+    get {return _isInitialized_p ?? 0}
+    set {_isInitialized_p = newValue}
   }
   /// Returns true if `isInitialized_p` has been explicitly set.
-  var hasIsInitialized_p: Bool {return _storage._isInitialized_p != nil}
+  var hasIsInitialized_p: Bool {return self._isInitialized_p != nil}
   /// Clears the value of `isInitialized_p`. Subsequent reads from it will return its default value.
-  mutating func clearIsInitialized_p() {_uniqueStorage()._isInitialized_p = nil}
+  mutating func clearIsInitialized_p() {self._isInitialized_p = nil}
 
   var debugDescription_p: Int32 {
-    get {return _storage._debugDescription_p ?? 0}
-    set {_uniqueStorage()._debugDescription_p = newValue}
+    get {return _debugDescription_p ?? 0}
+    set {_debugDescription_p = newValue}
   }
   /// Returns true if `debugDescription_p` has been explicitly set.
-  var hasDebugDescription_p: Bool {return _storage._debugDescription_p != nil}
+  var hasDebugDescription_p: Bool {return self._debugDescription_p != nil}
   /// Clears the value of `debugDescription_p`. Subsequent reads from it will return its default value.
-  mutating func clearDebugDescription_p() {_uniqueStorage()._debugDescription_p = nil}
+  mutating func clearDebugDescription_p() {self._debugDescription_p = nil}
 
   /// Recursive class, forces _StorageClass
   var value: ProtobufUnittest_Msg2UsesStorage {
-    get {return _storage._value ?? ProtobufUnittest_Msg2UsesStorage()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? ProtobufUnittest_Msg2UsesStorage()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  var hasValue: Bool {return _storage._value != nil}
+  var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  mutating func clearValue() {_uniqueStorage()._value = nil}
+  mutating func clearValue() {self._value = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _isInitialized_p: Int32? = nil
+  fileprivate var _debugDescription_p: Int32? = nil
+  fileprivate var _value: ProtobufUnittest_Msg2UsesStorage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -1690,70 +1692,34 @@ extension ProtobufUnittest_Msg2NamesUsesStorage: SwiftProtobuf.Message, SwiftPro
     3: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _isInitialized_p: Int32? = nil
-    var _debugDescription_p: Int32? = nil
-    var _value: ProtobufUnittest_Msg2UsesStorage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _isInitialized_p = source._isInitialized_p
-      _debugDescription_p = source._debugDescription_p
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._isInitialized_p)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._debugDescription_p)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self._isInitialized_p)
+      case 2: try decoder.decodeSingularInt32Field(value: &self._debugDescription_p)
+      case 3: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._isInitialized_p {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._debugDescription_p {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if let v = self._isInitialized_p {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }
+    if let v = self._debugDescription_p {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_Msg2NamesUsesStorage, rhs: ProtobufUnittest_Msg2NamesUsesStorage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._isInitialized_p != rhs_storage._isInitialized_p {return false}
-        if _storage._debugDescription_p != rhs_storage._debugDescription_p {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs._isInitialized_p != rhs._isInitialized_p {return false}
+    if lhs._debugDescription_p != rhs._debugDescription_p {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -598,31 +598,25 @@ struct ProtobufUnittest_Msg3NamesUsesStorage {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var isInitialized_p: Int32 {
-    get {return _storage._isInitialized_p}
-    set {_uniqueStorage()._isInitialized_p = newValue}
-  }
+  var isInitialized_p: Int32 = 0
 
-  var debugDescription_p: Int32 {
-    get {return _storage._debugDescription_p}
-    set {_uniqueStorage()._debugDescription_p = newValue}
-  }
+  var debugDescription_p: Int32 = 0
 
   /// Recursive class, forces _StorageClass
   var value: ProtobufUnittest_Msg3UsesStorage {
-    get {return _storage._value ?? ProtobufUnittest_Msg3UsesStorage()}
-    set {_uniqueStorage()._value = newValue}
+    get {return _value ?? ProtobufUnittest_Msg3UsesStorage()}
+    set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  var hasValue: Bool {return _storage._value != nil}
+  var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  mutating func clearValue() {_uniqueStorage()._value = nil}
+  mutating func clearValue() {self._value = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _value: ProtobufUnittest_Msg3UsesStorage? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -1389,70 +1383,34 @@ extension ProtobufUnittest_Msg3NamesUsesStorage: SwiftProtobuf.Message, SwiftPro
     3: .same(proto: "value"),
   ]
 
-  fileprivate class _StorageClass {
-    var _isInitialized_p: Int32 = 0
-    var _debugDescription_p: Int32 = 0
-    var _value: ProtobufUnittest_Msg3UsesStorage? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _isInitialized_p = source._isInitialized_p
-      _debugDescription_p = source._debugDescription_p
-      _value = source._value
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        switch fieldNumber {
-        case 1: try decoder.decodeSingularInt32Field(value: &_storage._isInitialized_p)
-        case 2: try decoder.decodeSingularInt32Field(value: &_storage._debugDescription_p)
-        case 3: try decoder.decodeSingularMessageField(value: &_storage._value)
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularInt32Field(value: &self.isInitialized_p)
+      case 2: try decoder.decodeSingularInt32Field(value: &self.debugDescription_p)
+      case 3: try decoder.decodeSingularMessageField(value: &self._value)
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._isInitialized_p != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._isInitialized_p, fieldNumber: 1)
-      }
-      if _storage._debugDescription_p != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._debugDescription_p, fieldNumber: 2)
-      }
-      if let v = _storage._value {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+    if self.isInitialized_p != 0 {
+      try visitor.visitSingularInt32Field(value: self.isInitialized_p, fieldNumber: 1)
+    }
+    if self.debugDescription_p != 0 {
+      try visitor.visitSingularInt32Field(value: self.debugDescription_p, fieldNumber: 2)
+    }
+    if let v = self._value {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_Msg3NamesUsesStorage, rhs: ProtobufUnittest_Msg3NamesUsesStorage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._isInitialized_p != rhs_storage._isInitialized_p {return false}
-        if _storage._debugDescription_p != rhs_storage._debugDescription_p {return false}
-        if _storage._value != rhs_storage._value {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.isInitialized_p != rhs.isInitialized_p {return false}
+    if lhs.debugDescription_p != rhs.debugDescription_p {return false}
+    if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
Hi there—long time reader, first-time PR.

I think this addresses the issues raised in #733 and broken out into #735 by analyzing if a proto has a message field with a transitive recursion.

I broke this out into two major commits: one that [introduces the change to `protoc-gen-swift`](https://github.com/apple/swift-protobuf/pull/900/commits/9aedf6b836aeb928896bf61cb3d3f66d166efb03), and a [second commit](https://github.com/apple/swift-protobuf/pull/900/commits/a9b7ee23f52f70e0679e1d47f396bb888dc1cac1) with the updated generated Swift files. There’s a third commit that undoes a change I needed to build + run the tests on my machine using XCode 11 / Swift 5.1.

Following the instructions in the Makefile, all tests including conformance tests, passed.

Is this the right idea?