### PR TITLE
Revert "Drop Swift 4.0 support (#905)"

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -298,6 +298,18 @@ struct Conformance_ConformanceRequest {
     /// Google internal only.  Opensource testees just skip it.
     case jspbPayload(String)
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -432,6 +444,22 @@ struct Conformance_ConformanceResponse {
     /// If the input was successfully parsed and the requested output was
     /// TEXT_FORMAT, serialize to TEXT_FORMAT and set it in this field.
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -198,6 +198,20 @@ struct Google_Protobuf_Value {
     case structValue(Google_Protobuf_Struct)
     /// Represents a repeated `Value`.
     case listValue(Google_Protobuf_ListValue)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
+      switch (lhs, rhs) {
+      case (.nullValue(let l), .nullValue(let r)): return l == r
+      case (.numberValue(let l), .numberValue(let r)): return l == r
+      case (.stringValue(let l), .stringValue(let r)): return l == r
+      case (.boolValue(let l), .boolValue(let r)): return l == r
+      case (.structValue(let l), .structValue(let r)): return l == r
+      case (.listValue(let l), .listValue(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto2.pb.swift
@@ -909,6 +909,23 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField, rhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -980,6 +980,23 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1111,6 +1111,18 @@ struct ProtobufUnittest_TestAllTypes {
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1290,6 +1302,14 @@ struct ProtobufUnittest_TestDeprecatedFields {
 
   enum OneOf_OneofFields: Equatable {
     case deprecatedInt32InOneof(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestDeprecatedFields.OneOf_OneofFields, rhs: ProtobufUnittest_TestDeprecatedFields.OneOf_OneofFields) -> Bool {
+      switch (lhs, rhs) {
+      case (.deprecatedInt32InOneof(let l), .deprecatedInt32InOneof(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -3105,6 +3125,18 @@ struct ProtobufUnittest_TestOneof {
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct FooGroup {
@@ -3387,6 +3419,23 @@ struct ProtobufUnittest_TestOneof2 {
     case fooMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case fooGroup(ProtobufUnittest_TestOneof2.FooGroup)
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooCord(let l), .fooCord(let r)): return l == r
+      case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
+      case (.fooBytes(let l), .fooBytes(let r)): return l == r
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum OneOf_Bar: Equatable {
@@ -3396,6 +3445,20 @@ struct ProtobufUnittest_TestOneof2 {
     case barStringPiece(String)
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+      switch (lhs, rhs) {
+      case (.barInt(let l), .barInt(let r)): return l == r
+      case (.barString(let l), .barString(let r)): return l == r
+      case (.barCord(let l), .barCord(let r)): return l == r
+      case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
+      case (.barBytes(let l), .barBytes(let r)): return l == r
+      case (.barEnum(let l), .barEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -3534,6 +3597,17 @@ struct ProtobufUnittest_TestRequiredOneof {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {
@@ -4266,6 +4340,18 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypes)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct OptionalGroup {

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -150,6 +150,14 @@ struct ProtobufUnittest_TestMessageWithCustomOptions {
 
   enum OneOf_AnOneof: Equatable {
     case oneofField(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofField(let l), .oneofField(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   enum AnEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -769,6 +769,19 @@ struct ProtobufUnittest_TestAllTypesLite {
     case oneofString(String)
     case oneofBytes(Data)
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1417,6 +1430,18 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypesLite)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct OptionalGroup {
@@ -1540,6 +1565,23 @@ struct ProtobufUnittest_TestOneofParsingLite {
     case oneofStringStringPiece(String)
     case oneofBytesStringPiece(Data)
     case oneofEnum(ProtobufUnittest_V2EnumLite)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField, rhs: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofSubmessage(let l), .oneofSubmessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofStringCord(let l), .oneofStringCord(let r)): return l == r
+      case (.oneofBytesCord(let l), .oneofBytesCord(let r)): return l == r
+      case (.oneofStringStringPiece(let l), .oneofStringStringPiece(let r)): return l == r
+      case (.oneofBytesStringPiece(let l), .oneofBytesStringPiece(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -699,6 +699,19 @@ struct ProtobufUnittestNoArena_TestAllTypes {
     case oneofString(String)
     case oneofBytes(Data)
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -399,6 +399,18 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes {
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -104,6 +104,16 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   enum OneOf_Foo: Equatable {
     case integerField(Int32)
     case stringField(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.integerField(let l), .integerField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -178,6 +178,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage {
   enum OneOf_O: Equatable {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -219,6 +229,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra {
   enum OneOf_O: Equatable {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -130,6 +130,16 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage {
   enum OneOf_O: Equatable {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -415,6 +415,18 @@ struct Proto3Unittest_TestAllTypes {
     case oneofNestedMessage(Proto3Unittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3Unittest_TestAllTypes.OneOf_OneofField, rhs: Proto3Unittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -645,6 +657,14 @@ struct Proto3Unittest_TestOneof2 {
 
   enum OneOf_Foo: Equatable {
     case fooEnum(Proto3Unittest_TestOneof2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3Unittest_TestOneof2.OneOf_Foo, rhs: Proto3Unittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -415,6 +415,18 @@ struct Proto3ArenaUnittest_TestAllTypes {
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -406,6 +406,18 @@ struct Proto3ArenaLiteUnittest_TestAllTypes {
     case oneofNestedMessage(Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -406,6 +406,18 @@ struct Proto3LiteUnittest_TestAllTypes {
     case oneofNestedMessage(Proto3LiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -485,6 +485,32 @@ struct ProtobufUnittest_OneofWellKnownTypes {
     case boolField(SwiftProtobuf.Google_Protobuf_BoolValue)
     case stringField(SwiftProtobuf.Google_Protobuf_StringValue)
     case bytesField(SwiftProtobuf.Google_Protobuf_BytesValue)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.anyField(let l), .anyField(let r)): return l == r
+      case (.apiField(let l), .apiField(let r)): return l == r
+      case (.durationField(let l), .durationField(let r)): return l == r
+      case (.emptyField(let l), .emptyField(let r)): return l == r
+      case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
+      case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
+      case (.structField(let l), .structField(let r)): return l == r
+      case (.timestampField(let l), .timestampField(let r)): return l == r
+      case (.typeField(let l), .typeField(let r)): return l == r
+      case (.doubleField(let l), .doubleField(let r)): return l == r
+      case (.floatField(let l), .floatField(let r)): return l == r
+      case (.int64Field(let l), .int64Field(let r)): return l == r
+      case (.uint64Field(let l), .uint64Field(let r)): return l == r
+      case (.int32Field(let l), .int32Field(let r)): return l == r
+      case (.uint32Field(let l), .uint32Field(let r)): return l == r
+      case (.boolField(let l), .boolField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.bytesField(let l), .bytesField(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -139,6 +139,18 @@ struct SDTTopLevelMessage {
     case field4(SDTTopLevelMessage.SubEnum)
     case field5(SDTTopLevelMessage.SubMessage)
     case field6(SDTTopLevelMessage2)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: SDTTopLevelMessage.OneOf_O, rhs: SDTTopLevelMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.field3(let l), .field3(let r)): return l == r
+      case (.field4(let l), .field4(let r)): return l == r
+      case (.field5(let l), .field5(let r)): return l == r
+      case (.field6(let l), .field6(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum SubEnum: SwiftProtobuf.Enum {

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -519,6 +519,18 @@ struct ProtobufUnittest_TestAllRequiredTypes {
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -120,6 +120,18 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
     case oneofBool(Bool)
     case oneofString(String)
     case oneofInt32(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {
@@ -258,24 +270,64 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.ExtensibleMessage 
   enum OneOf_OGood: Equatable {
     case a(Int32)
     case b(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood) -> Bool {
+      switch (lhs, rhs) {
+      case (.a(let l), .a(let r)): return l == r
+      case (.b(let l), .b(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with a field in the middle of the range.
   enum OneOf_OConflictField: Equatable {
     case a2(Int32)
     case b2(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField) -> Bool {
+      switch (lhs, rhs) {
+      case (.a2(let l), .a2(let r)): return l == r
+      case (.b2(let l), .b2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with an extension range in the middle of the range.
   enum OneOf_OConflictExtensionsStart: Equatable {
     case a3(Int32)
     case b3(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart) -> Bool {
+      switch (lhs, rhs) {
+      case (.a3(let l), .a3(let r)): return l == r
+      case (.b3(let l), .b3(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with an extension range in the middle of the range.
   enum OneOf_OConflictExtensionsEnd: Equatable {
     case a4(Int32)
     case b4(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd) -> Bool {
+      switch (lhs, rhs) {
+      case (.a4(let l), .a4(let r)): return l == r
+      case (.b4(let l), .b4(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -140,6 +140,18 @@ struct ProtobufUnittest_OneOfContainer {
     case option2(ProtobufUnittest_OneOfOptionMessage2)
     case option3(ProtobufUnittest_OneOfContainer.Option3)
     case option4(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_OneOfContainer.OneOf_Option, rhs: ProtobufUnittest_OneOfContainer.OneOf_Option) -> Bool {
+      switch (lhs, rhs) {
+      case (.option1(let l), .option1(let r)): return l == r
+      case (.option2(let l), .option2(let r)): return l == r
+      case (.option3(let l), .option3(let r)): return l == r
+      case (.option4(let l), .option4(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct Option3 {

--- a/Reference/unittest_swift_oneof_merging.pb.swift
+++ b/Reference/unittest_swift_oneof_merging.pb.swift
@@ -86,6 +86,18 @@ struct SwiftUnittest_TestMessage {
     case oneofNestedMessage(SwiftUnittest_TestMessage.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: SwiftUnittest_TestMessage.OneOf_OneofField, rhs: SwiftUnittest_TestMessage.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -571,6 +571,32 @@ struct ProtobufUnittest_Message2 {
     case oneofGroup(ProtobufUnittest_Message2.OneofGroup)
     case oneofMessage(ProtobufUnittest_Message2)
     case oneofEnum(ProtobufUnittest_Message2.Enum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum Enum: SwiftProtobuf.Enum {

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -488,6 +488,31 @@ struct ProtobufUnittest_Message3 {
     /// No 'group' in proto3.
     case oneofMessage(ProtobufUnittest_Message3)
     case oneofEnum(ProtobufUnittest_Message3.Enum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum Enum: SwiftProtobuf.Enum {

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -298,6 +298,18 @@ struct Conformance_ConformanceRequest {
     /// Google internal only.  Opensource testees just skip it.
     case jspbPayload(String)
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -432,6 +444,22 @@ struct Conformance_ConformanceResponse {
     /// If the input was successfully parsed and the requested output was
     /// TEXT_FORMAT, serialize to TEXT_FORMAT and set it in this field.
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -909,6 +909,23 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField, rhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -980,6 +980,23 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -191,7 +191,11 @@ internal func decodeVarint(_ stream: InputStream) throws -> UInt64 {
 
   // Buffer to reuse within nextByte.
   var readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
-  defer { readBuffer.deallocate() }
+  #if swift(>=4.1)
+    defer { readBuffer.deallocate() }
+  #else
+    defer { readBuffer.deallocate(capacity: 1) }
+  #endif
 
   func nextByte() throws -> UInt8 {
     let bytesRead = stream.read(readBuffer, maxLength: 1)

--- a/Sources/SwiftProtobuf/DoubleParser.swift
+++ b/Sources/SwiftProtobuf/DoubleParser.swift
@@ -21,9 +21,13 @@ internal class DoubleParser {
     // In theory, JSON writers should be able to represent any IEEE Double
     // in at most 25 bytes, but many writers will emit more digits than
     // necessary, so we size this generously.
-    private var work =
-        UnsafeMutableRawBufferPointer.allocate(byteCount: 128,
-                                               alignment: MemoryLayout<UInt8>.alignment)
+    #if swift(>=4.1)
+      private var work =
+          UnsafeMutableRawBufferPointer.allocate(byteCount: 128,
+                                                 alignment: MemoryLayout<UInt8>.alignment)
+    #else
+      private var work = UnsafeMutableRawBufferPointer.allocate(count: 128)
+    #endif
 
     deinit {
         work.deallocate()
@@ -42,7 +46,11 @@ internal class DoubleParser {
         }
         // Copy it to the work buffer and null-terminate it
         let source = UnsafeRawBufferPointer(start: bytes, count: count)
-        work.copyMemory(from:source)
+        #if swift(>=4.1)
+          work.copyMemory(from:source)
+        #else
+          work.copyBytes(from:source)
+        #endif
         work[count] = 0
 
         // Use C library strtod() to parse it

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -125,7 +125,11 @@ extension Google_Protobuf_FieldMask {
   ///   defined using the JSON names for the fields.
   public init?(jsonPaths: String...) {
     // TODO: This should fail if any of the conversions from JSON fails
-    self.init(protoPaths: jsonPaths.compactMap(JSONToProto))
+    #if swift(>=4.1)
+      self.init(protoPaths: jsonPaths.compactMap(JSONToProto))
+    #else
+      self.init(protoPaths: jsonPaths.flatMap(JSONToProto))
+    #endif
   }
 
   // It would be nice if to have an initializer that accepted Swift property

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -53,7 +53,12 @@ fileprivate class InternPool {
 
   deinit {
     for buff in interned {
-        buff.deallocate()
+        #if swift(>=4.1)
+          buff.deallocate()
+        #else
+          let p = UnsafeMutableRawPointer(mutating: buff.baseAddress)!
+          p.deallocate(bytes: buff.count, alignedTo: 1)
+        #endif
     }
   }
 }

--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -26,6 +26,12 @@ public struct UnknownStorage: Equatable {
   /// fields of a decoded message.
   public private(set) var data = Internal.emptyData
 
+#if !swift(>=4.1)
+  public static func ==(lhs: UnknownStorage, rhs: UnknownStorage) -> Bool {
+    return lhs.data == rhs.data
+  }
+#endif
+
   public init() {}
 
   internal mutating func append(protobufData: Data) {

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -198,6 +198,20 @@ public struct Google_Protobuf_Value {
     case structValue(Google_Protobuf_Struct)
     /// Represents a repeated `Value`.
     case listValue(Google_Protobuf_ListValue)
+
+  #if !swift(>=4.1)
+    public static func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
+      switch (lhs, rhs) {
+      case (.nullValue(let l), .nullValue(let r)): return l == r
+      case (.numberValue(let l), .numberValue(let r)): return l == r
+      case (.stringValue(let l), .stringValue(let r)): return l == r
+      case (.boolValue(let l), .boolValue(let r)): return l == r
+      case (.structValue(let l), .structValue(let r)): return l == r
+      case (.listValue(let l), .listValue(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   public init() {}

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -210,7 +210,32 @@ class OneofGenerator {
                 "case \(f.swiftName)(\(f.swiftType))\n")
         }
 
+        // Equatable conformance
+        p.print("\n")
         p.outdent()
+        p.print("#if !swift(>=4.1)\n")
+        p.indent()
+        p.print(
+            "\(visibility)static func ==(lhs: \(swiftFullName), rhs: \(swiftFullName)) -> Bool {\n")
+        p.indent()
+        p.print("switch (lhs, rhs) {\n")
+        for f in fields {
+            p.print("case (\(f.dottedSwiftName)(let l), \(f.dottedSwiftName)(let r)): return l == r\n")
+        }
+        if fields.count > 1 {
+            // A tricky edge case: If the oneof only has a single case, then
+            // the case pattern generated above is exhaustive and generating a
+            // default produces a compiler error. If there is more than one
+            // case, then the case patterns are not exhaustive (because we
+            // don't compare mismatched pairs), and we have to include a
+            // default.
+            p.print("default: return false\n")
+        }
+        p.print("}\n")
+        p.outdent()
+        p.print("}\n")
+        p.outdent()
+        p.print("#endif\n")
         p.print("}\n")
     }
 

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -298,6 +298,18 @@ struct Conformance_ConformanceRequest {
     /// Google internal only.  Opensource testees just skip it.
     case jspbPayload(String)
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -432,6 +444,22 @@ struct Conformance_ConformanceResponse {
     /// If the input was successfully parsed and the requested output was
     /// TEXT_FORMAT, serialize to TEXT_FORMAT and set it in this field.
     case textPayload(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.jspbPayload(let l), .jspbPayload(let r)): return l == r
+      case (.textPayload(let l), .textPayload(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -980,6 +980,23 @@ struct ProtobufTestMessages_Proto3_TestAllTypesProto3 {
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypesProto3.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1111,6 +1111,18 @@ struct ProtobufUnittest_TestAllTypes {
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1290,6 +1302,14 @@ struct ProtobufUnittest_TestDeprecatedFields {
 
   enum OneOf_OneofFields: Equatable {
     case deprecatedInt32InOneof(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestDeprecatedFields.OneOf_OneofFields, rhs: ProtobufUnittest_TestDeprecatedFields.OneOf_OneofFields) -> Bool {
+      switch (lhs, rhs) {
+      case (.deprecatedInt32InOneof(let l), .deprecatedInt32InOneof(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -3105,6 +3125,18 @@ struct ProtobufUnittest_TestOneof {
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct FooGroup {
@@ -3387,6 +3419,23 @@ struct ProtobufUnittest_TestOneof2 {
     case fooMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case fooGroup(ProtobufUnittest_TestOneof2.FooGroup)
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooCord(let l), .fooCord(let r)): return l == r
+      case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
+      case (.fooBytes(let l), .fooBytes(let r)): return l == r
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum OneOf_Bar: Equatable {
@@ -3396,6 +3445,20 @@ struct ProtobufUnittest_TestOneof2 {
     case barStringPiece(String)
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+      switch (lhs, rhs) {
+      case (.barInt(let l), .barInt(let r)): return l == r
+      case (.barString(let l), .barString(let r)): return l == r
+      case (.barCord(let l), .barCord(let r)): return l == r
+      case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
+      case (.barBytes(let l), .barBytes(let r)): return l == r
+      case (.barEnum(let l), .barEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -3534,6 +3597,17 @@ struct ProtobufUnittest_TestRequiredOneof {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {
@@ -4266,6 +4340,18 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.ExtensibleMessage {
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypes)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct OptionalGroup {

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -150,6 +150,14 @@ struct ProtobufUnittest_TestMessageWithCustomOptions {
 
   enum OneOf_AnOneof: Equatable {
     case oneofField(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofField(let l), .oneofField(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   enum AnEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -769,6 +769,19 @@ struct ProtobufUnittest_TestAllTypesLite {
     case oneofString(String)
     case oneofBytes(Data)
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1417,6 +1430,18 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.ExtensibleMessag
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypesLite)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct OptionalGroup {
@@ -1540,6 +1565,23 @@ struct ProtobufUnittest_TestOneofParsingLite {
     case oneofStringStringPiece(String)
     case oneofBytesStringPiece(Data)
     case oneofEnum(ProtobufUnittest_V2EnumLite)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField, rhs: ProtobufUnittest_TestOneofParsingLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofSubmessage(let l), .oneofSubmessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofStringCord(let l), .oneofStringCord(let r)): return l == r
+      case (.oneofBytesCord(let l), .oneofBytesCord(let r)): return l == r
+      case (.oneofStringStringPiece(let l), .oneofStringStringPiece(let r)): return l == r
+      case (.oneofBytesStringPiece(let l), .oneofBytesStringPiece(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -699,6 +699,19 @@ struct ProtobufUnittestNoArena_TestAllTypes {
     case oneofString(String)
     case oneofBytes(Data)
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -399,6 +399,18 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes {
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -104,6 +104,16 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage {
   enum OneOf_Foo: Equatable {
     case integerField(Int32)
     case stringField(String)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.integerField(let l), .integerField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -178,6 +178,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage {
   enum OneOf_O: Equatable {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}
@@ -219,6 +229,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra {
   enum OneOf_O: Equatable {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -130,6 +130,16 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage {
   enum OneOf_O: Equatable {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -415,6 +415,18 @@ struct Proto3Unittest_TestAllTypes {
     case oneofNestedMessage(Proto3Unittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3Unittest_TestAllTypes.OneOf_OneofField, rhs: Proto3Unittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -645,6 +657,14 @@ struct Proto3Unittest_TestOneof2 {
 
   enum OneOf_Foo: Equatable {
     case fooEnum(Proto3Unittest_TestOneof2.NestedEnum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3Unittest_TestOneof2.OneOf_Foo, rhs: Proto3Unittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -415,6 +415,18 @@ struct Proto3ArenaUnittest_TestAllTypes {
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -519,6 +519,18 @@ struct ProtobufUnittest_TestAllRequiredTypes {
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -120,6 +120,18 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage {
     case oneofBool(Bool)
     case oneofString(String)
     case oneofInt32(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {
@@ -258,24 +270,64 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.ExtensibleMessage 
   enum OneOf_OGood: Equatable {
     case a(Int32)
     case b(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood) -> Bool {
+      switch (lhs, rhs) {
+      case (.a(let l), .a(let r)): return l == r
+      case (.b(let l), .b(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with a field in the middle of the range.
   enum OneOf_OConflictField: Equatable {
     case a2(Int32)
     case b2(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField) -> Bool {
+      switch (lhs, rhs) {
+      case (.a2(let l), .a2(let r)): return l == r
+      case (.b2(let l), .b2(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with an extension range in the middle of the range.
   enum OneOf_OConflictExtensionsStart: Equatable {
     case a3(Int32)
     case b3(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart) -> Bool {
+      switch (lhs, rhs) {
+      case (.a3(let l), .a3(let r)): return l == r
+      case (.b3(let l), .b3(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   /// Gaps with an extension range in the middle of the range.
   enum OneOf_OConflictExtensionsEnd: Equatable {
     case a4(Int32)
     case b4(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd, rhs: Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd) -> Bool {
+      switch (lhs, rhs) {
+      case (.a4(let l), .a4(let r)): return l == r
+      case (.b4(let l), .b4(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -140,6 +140,18 @@ struct ProtobufUnittest_OneOfContainer {
     case option2(ProtobufUnittest_OneOfOptionMessage2)
     case option3(ProtobufUnittest_OneOfContainer.Option3)
     case option4(Int32)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_OneOfContainer.OneOf_Option, rhs: ProtobufUnittest_OneOfContainer.OneOf_Option) -> Bool {
+      switch (lhs, rhs) {
+      case (.option1(let l), .option1(let r)): return l == r
+      case (.option2(let l), .option2(let r)): return l == r
+      case (.option3(let l), .option3(let r)): return l == r
+      case (.option4(let l), .option4(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct Option3 {

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
@@ -86,6 +86,18 @@ struct SwiftUnittest_TestMessage {
     case oneofNestedMessage(SwiftUnittest_TestMessage.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: SwiftUnittest_TestMessage.OneOf_OneofField, rhs: SwiftUnittest_TestMessage.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   struct NestedMessage {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -571,6 +571,32 @@ struct ProtobufUnittest_Message2 {
     case oneofGroup(ProtobufUnittest_Message2.OneofGroup)
     case oneofMessage(ProtobufUnittest_Message2)
     case oneofEnum(ProtobufUnittest_Message2.Enum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum Enum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -488,6 +488,31 @@ struct ProtobufUnittest_Message3 {
     /// No 'group' in proto3.
     case oneofMessage(ProtobufUnittest_Message3)
     case oneofEnum(ProtobufUnittest_Message3.Enum)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   enum Enum: SwiftProtobuf.Enum {

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -485,6 +485,32 @@ struct ProtobufUnittest_OneofWellKnownTypes {
     case boolField(SwiftProtobuf.Google_Protobuf_BoolValue)
     case stringField(SwiftProtobuf.Google_Protobuf_StringValue)
     case bytesField(SwiftProtobuf.Google_Protobuf_BytesValue)
+
+  #if !swift(>=4.1)
+    static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.anyField(let l), .anyField(let r)): return l == r
+      case (.apiField(let l), .apiField(let r)): return l == r
+      case (.durationField(let l), .durationField(let r)): return l == r
+      case (.emptyField(let l), .emptyField(let r)): return l == r
+      case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
+      case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
+      case (.structField(let l), .structField(let r)): return l == r
+      case (.timestampField(let l), .timestampField(let r)): return l == r
+      case (.typeField(let l), .typeField(let r)): return l == r
+      case (.doubleField(let l), .doubleField(let r)): return l == r
+      case (.floatField(let l), .floatField(let r)): return l == r
+      case (.int64Field(let l), .int64Field(let r)): return l == r
+      case (.uint64Field(let l), .uint64Field(let r)): return l == r
+      case (.int32Field(let l), .int32Field(let r)): return l == r
+      case (.uint32Field(let l), .uint32Field(let r)): return l == r
+      case (.boolField(let l), .boolField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.bytesField(let l), .bytesField(let r)): return l == r
+      default: return false
+      }
+    }
+  #endif
   }
 
   init() {}


### PR DESCRIPTION
This reverts commit 687cff576a4a9b52cb34cf6b70766e996525b522.

SwiftPM only has constants for 4.0 and 4.2 (as well as the compiler only taking
those values (and not 4.1)). So to drop the 4.0 from there, it would actually
mean moving up to 4.2 which is more agressive than our policy, so it seem like
we have to keep 4.0 support because you can't tell the SwiftPM or the compiler
to be atleast 4.1. So we can't drop support until we can move all the way up
to 4.2.