### PR TITLE
JSON/TextFormat submessage encoding performance

### DIFF
--- a/Performance/generators/cpp.sh
+++ b/Performance/generators/cpp.sh
@@ -21,6 +21,11 @@ function print_cpp_set_field() {
   type=$2
 
   case "$type" in
+    repeated\ message)
+      echo "  for (auto i = 0; i < repeated_count; i++) {"
+      echo "    message.add_field$num()->set_optional_int32($((200+num)));"
+      echo "  }"
+      ;;
     repeated\ string)
       echo "  for (auto i = 0; i < repeated_count; i++) {"
       echo "    message.add_field$num(\"$((200+num))\");"
@@ -50,6 +55,9 @@ function print_cpp_set_field() {
       echo "  for (auto i = 0; i < repeated_count; i++) {"
       echo "    message.add_field$num($((200+num)));"
       echo "  }"
+      ;;
+    message)
+      echo "  message.mutable_field$num()->set_optional_int32($((200+num)));"
       ;;
     string)
       echo "  message.set_field$num(\"$((200+num))\");"

--- a/Performance/generators/proto.sh
+++ b/Performance/generators/proto.sh
@@ -37,7 +37,31 @@ function print_proto_field() {
 function generate_homogeneous_test_proto() {
   cat >"$gen_message_path" <<EOF
 syntax = "proto$proto_syntax";
+EOF
 
+  case "$field_type" in
+      *message)
+	  case "$field_type" in
+	      repeated\ message)
+		  out_field_type="repeated SubMessage"
+		  ;;
+	      message)
+		  out_field_type="SubMessage"
+		  ;;
+	      *)
+		  echo "XXX Invalid field type ``$field_type''"
+		  ;;
+	  esac
+	  echo "message SubMessage {" >>"$gen_message_path"
+	  echo "  int32 optional_int32 = 1;" >>"$gen_message_path"
+	  echo "}" >>"$gen_message_path"
+	  ;;
+      *)
+	  out_field_type="$field_type"
+	  ;;
+  esac
+
+  cat >>"$gen_message_path" <<EOF
 message PerfMessage {
   enum PerfEnum {
     ZERO = 0;
@@ -49,7 +73,7 @@ message PerfMessage {
 EOF
 
   for field_number in $(seq 1 "$field_count"); do
-    print_proto_field "$field_number" "$field_type" >>"$gen_message_path"
+    print_proto_field "$field_number" "$out_field_type" >>"$gen_message_path"
   done
 
   cat >>"$gen_message_path" <<EOF

--- a/Performance/generators/swift.sh
+++ b/Performance/generators/swift.sh
@@ -21,6 +21,11 @@ function print_swift_set_field() {
   type=$2
 
   case "$type" in
+    repeated\ message)
+      echo "    for _ in 0..<repeatedCount {"
+      echo "      message.field$num.append(SubMessage.with { \$0.optionalInt32 = $((200+num)) })"
+      echo "    }"
+      ;;
     repeated\ bytes)
       echo "    for _ in 0..<repeatedCount {"
       echo "      message.field$num.append(Data(repeating:$((num)), count: 20))"
@@ -55,6 +60,9 @@ function print_swift_set_field() {
       echo "    for _ in 0..<repeatedCount {"
       echo "      message.field$num.append($((200+num)))"
       echo "    }"
+      ;;
+    message)
+      echo "    message.field$num = SubMessage.with { \$0.optionalInt32 = $((200+num)) }"
       ;;
     bytes)
       echo "    message.field$num = Data(repeating:$((num)), count: 20)"

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -154,6 +154,11 @@ internal struct JSONEncoder {
         separator = nil
     }
 
+    internal mutating func startNestedObject() {
+        data.append(asciiOpenCurlyBracket)
+        separator = nil
+    }
+
     /// Append a close curly brace `}` to the JSON.
     internal mutating func endObject() {
         data.append(asciiCloseCurlyBracket)

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -166,8 +166,19 @@ internal struct JSONEncodingVisitor: Visitor {
 
   mutating func visitSingularMessageField<M: Message>(value: M, fieldNumber: Int) throws {
     try startField(for: fieldNumber)
-    let json = try value.jsonUTF8Data(options: options)
-    encoder.append(utf8Data: json)
+    if let m = value as? _CustomJSONCodable {
+      let json = try m.encodedJSONString(options: options)
+      encoder.append(text: json)
+    } else if let newNameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap {
+      encoder.startNestedObject()
+      let oldNameMap = self.nameMap
+      self.nameMap = newNameMap
+      try value.traverse(visitor: &self)
+      self.nameMap = oldNameMap
+      endObject()
+    } else {
+      throw JSONEncodingError.missingFieldNames
+    }
   }
 
   mutating func visitSingularGroupField<G: Message>(value: G, fieldNumber: Int) throws {
@@ -274,12 +285,35 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
-    let localOptions = options
-    try _visitRepeated(value: value, fieldNumber: fieldNumber) {
-      (encoder: inout JSONEncoder, v: M) throws in
-      let json = try v.jsonUTF8Data(options: localOptions)
-      encoder.append(utf8Data: json)
+    try startField(for: fieldNumber)
+    var comma = false
+    encoder.startArray()
+    if let _ = M.self as? _CustomJSONCodable.Type {
+      for v in value {
+        if comma {
+          encoder.comma()
+        }
+        comma = true
+        let json = try v.jsonString(options: options)
+        encoder.append(text: json)
+      }
+    } else if let newNameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap {
+      let oldNameMap = self.nameMap
+      self.nameMap = newNameMap
+      for v in value {
+        if comma {
+          encoder.comma()
+        }
+        comma = true
+        encoder.startNestedObject()
+        try v.traverse(visitor: &self)
+        encoder.endObject()
+      }
+      self.nameMap = oldNameMap
+    } else {
+      throw JSONEncodingError.missingFieldNames
     }
+    encoder.endArray()
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -298,8 +298,11 @@ internal struct JSONEncodingVisitor: Visitor {
         encoder.append(text: json)
       }
     } else if let newNameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap {
+      // Install inner object's name map
       let oldNameMap = self.nameMap
       self.nameMap = newNameMap
+      // Restore outer object's name map before returning
+      defer { self.nameMap = oldNameMap }
       for v in value {
         if comma {
           encoder.comma()
@@ -309,7 +312,6 @@ internal struct JSONEncodingVisitor: Visitor {
         try v.traverse(visitor: &self)
         encoder.endObject()
       }
-      self.nameMap = oldNameMap
     } else {
       throw JSONEncodingError.missingFieldNames
     }

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -29,6 +29,7 @@ private let asciiNewline = UInt8(ascii: "\n")
 private let asciiUpperA = UInt8(ascii: "A")
 
 private let tabSize = 2
+private let tab = [UInt8](repeating: asciiSpace, count: tabSize)
 
 /// TextFormatEncoder has no public members.
 internal struct TextFormatEncoder {
@@ -49,6 +50,10 @@ internal struct TextFormatEncoder {
         data.append(contentsOf: name.utf8Buffer)
     }
 
+    internal mutating func append(bytes: [UInt8]) {
+        data.append(contentsOf: bytes)
+    }
+
     private mutating func append(text: String) {
         data.append(contentsOf: text.utf8)
     }
@@ -67,6 +72,11 @@ internal struct TextFormatEncoder {
     mutating func emitFieldName(name: StaticString) {
         let buff = UnsafeBufferPointer(start: name.utf8Start, count: name.utf8CodeUnitCount)
         emitFieldName(name: buff)
+    }
+
+    mutating func emitFieldName(name: [UInt8]) {
+        indent()
+        data.append(contentsOf: name)
     }
 
     mutating func emitExtensionFieldName(name: String) {
@@ -93,15 +103,11 @@ internal struct TextFormatEncoder {
     //    name_of_field {key: value key2: value2}
     mutating func startMessageField() {
         append(staticText: " {\n")
-        for _ in 1...tabSize {
-            indentString.append(asciiSpace)
-        }
+        indentString.append(contentsOf: tab)
     }
 
     mutating func endMessageField() {
-        for _ in 1...tabSize {
-            indentString.remove(at: indentString.count - 1)
-        }
+        indentString.removeLast(tabSize)
         indent()
         append(staticText: "}\n")
     }

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -246,6 +246,12 @@ internal struct TextFormatEncodingVisitor: Visitor {
       self.nameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap
       self.nameResolver = [:]
       self.extensions = (value as? ExtensibleMessage)?._protobuf_extensionFieldValues
+      // Restore state before returning
+      defer {
+        self.extensions = oldExtensions
+        self.nameResolver = oldNameResolver
+        self.nameMap = oldNameMap
+      }
       // Encode submessage
       encoder.startMessageField()
       if let any = value as? Google_Protobuf_Any {
@@ -254,10 +260,6 @@ internal struct TextFormatEncodingVisitor: Visitor {
           try! value.traverse(visitor: &self)
       }
       encoder.endMessageField()
-      // Restore state
-      self.extensions = oldExtensions
-      self.nameResolver = oldNameResolver
-      self.nameMap = oldNameMap
   }
 
   // Emit the full "verbose" form of an Any.  This writes the typeURL

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -292,8 +292,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   // the name lookup once for the array, rather than once for each element:
 
   mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putFloatValue(value: v)
           encoder.endRegularField()
@@ -301,8 +302,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedDoubleField(value: [Double], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putDoubleValue(value: v)
           encoder.endRegularField()
@@ -310,8 +312,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt32Field(value: [Int32], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putInt64(value: Int64(v))
           encoder.endRegularField()
@@ -319,8 +322,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt64Field(value: [Int64], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putInt64(value: v)
           encoder.endRegularField()
@@ -328,8 +332,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putUInt64(value: UInt64(v))
           encoder.endRegularField()
@@ -337,8 +342,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putUInt64(value: v)
           encoder.endRegularField()
@@ -365,8 +371,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedBoolField(value: [Bool], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putBoolValue(value: v)
           encoder.endRegularField()
@@ -374,8 +381,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedStringField(value: [String], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putStringValue(value: v)
           encoder.endRegularField()
@@ -383,8 +391,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedBytesField(value: [Data], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putBytesValue(value: v)
           encoder.endRegularField()
@@ -392,8 +401,9 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
+      let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
-          emitFieldName(lookingUp: fieldNumber)
+          encoder.emitFieldName(name: fieldName)
           encoder.startRegularField()
           encoder.putEnumValue(value: v)
           encoder.endRegularField()


### PR DESCRIPTION
On my local system, this change yields a 5x speedup for JSON and TextFormat encoding with:
```
Performance/perf_runner.sh 100 'repeated message'
```

The test with 100 message fields (not repeated) shows better than 2.5x speedup with this change.

Previously, JSON and TextFormat handled submessages by creating a completely new encoder, encoding the sub message, then appending the result to the outer encoder.  Now, they work the same way as the binary encoder, reusing the same encoder in nested submessages and avoiding the extra data copies.

TODO: The test above also demonstrates problems with decoding array fields in general (due to incremental appends) and with binary encoding of submessages (due to the extra recursive traversal to accumulate size).