### PR TITLE
Add Message.with to the performance suite

### DIFF
--- a/Performance/generators/swift.sh
+++ b/Performance/generators/swift.sh
@@ -98,6 +98,10 @@ extension Harness {
         populateFields(of: &message)
       }
 
+      message = measureSubtask("Populate fields with with") {
+        return populateFieldsWithWith()
+      }
+
       // Exercise binary serialization.
       let data = try measureSubtask("Encode binary") {
         return try message.serializedData()
@@ -139,6 +143,20 @@ EOF
   fi
 
   cat >> "$gen_harness_path" <<EOF
+  }
+
+  private func populateFieldsWithWith() -> PerfMessage {
+    return PerfMessage.with { message in
+EOF
+
+  if [[ "$proto_type" == "homogeneous" ]]; then
+    generate_swift_homogenerous_populate_fields_body
+  else
+    generate_swift_heterogenerous_populate_fields_body
+  fi
+
+  cat >> "$gen_harness_path" <<EOF
+    }
   }
 }
 EOF

--- a/Performance/js/harness-visualization.js
+++ b/Performance/js/harness-visualization.js
@@ -3,6 +3,7 @@
   // on the plot axis.
   var benchmarks = [
     'New message', 'Populate fields',
+    'Populate fields with with',
     'Encode binary', 'Decode binary',
     'Encode JSON', 'Decode JSON',
     'Encode text', 'Decode text',


### PR DESCRIPTION
This patch adds `Message.with` to the tasks that are benchmarked in the performance suite.

This work was originally intended as a precursor to a patch that would add `@inlinable` to `Message.with`. However, as #763 exists I'd rather hold off and let the project consider that work more holistically. That said, the extra benchmark does have value in and of itself so I'm proposing it here.

I've added the benchmark without an equivalent in C++-land as there is no natural equivalent.

Below is a screenshot of the result as run on my machine:

<img width="1606" alt="Screenshot 2019-11-20 at 09 55 00" src="https://user-images.githubusercontent.com/1382556/69228876-4c2ba380-0b7c-11ea-82ee-120e8e522ace.png">