### PR TITLE
fix swift protobuf build for swift below 5.0

### DIFF
--- a/Sources/SwiftProtobuf/Data+Extensions.swift
+++ b/Sources/SwiftProtobuf/Data+Extensions.swift
@@ -16,6 +16,7 @@ import Foundation
 
 #if !swift(>=5.0)
 internal extension Data {
+    @usableFromInline
     func withUnsafeBytes<T>(_ body: (UnsafeRawBufferPointer) throws -> T) rethrows -> T {
         let c = count
         return try withUnsafeBytes { (p: UnsafePointer<UInt8>) throws -> T in


### PR DESCRIPTION
When compiling with swift version below 5.0, it complains that `Data.withUnsafeBytes` is internal and cannot be referenced from an `@inlinable` function, from https://github.com/apple/swift-protobuf/blob/master/Sources/SwiftProtobuf/Message%2BBinaryAdditions.swift#L146, which is newly introduced by https://github.com/apple/swift-protobuf/commit/7f8daf3c54570234ed49aa5762d3ba9c20b2b452

In fact, `Data.withUnsafeBytes` is defined inside `Data+Extensions` (https://github.com/apple/swift-protobuf/blob/master/Sources/SwiftProtobuf/Data%2BExtensions.swift#L19) as internal, but not `@usableFromInline`. And according to  Apple's documentation, `@inlinable` code "can interact with internal symbols declared in the same module that are marked with the usableFromInline attribute" (https://docs.swift.org/swift-book/ReferenceManual/Attributes.html).

Compiling with XCode 10.2 (using swift 5.0) and above does not reproduce this issue while compiling with XCode 10.1 (using swift 4.2) does.

References
XCode version and Swift version mapping: https://developer.apple.com/xcode/whats-new/#:~:targetText=Xcode%2010.1%20includes%20Swift%204.2.
xcode-version and swift-version flags: http://go/swift-monthly#swift-version-attribute-has-been-removed