### PR TITLE
Avoid collecting unknown fields while scanning for message.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -97,9 +97,14 @@ internal struct TextFormatEncodingVisitor: Visitor {
           try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) -> () in
             if let baseAddress = body.baseAddress, body.count > 0 {
               let p = baseAddress.assumingMemoryBound(to: UInt8.self)
+              // All fields will be directly handled, so there is no need for
+              // the unknown field buffering/collection (when scannings to see
+              // if something is a message, this would be extremely wasteful).
+              var binaryOptions = BinaryDecodingOptions()
+              binaryOptions.discardUnknownFields = true
               var decoder = BinaryDecoder(forReadingFrom: p,
                                           count: body.count,
-                                          options: BinaryDecodingOptions())
+                                          options: binaryOptions)
               try visitUnknown(decoder: &decoder, groupFieldNumber: nil)
             }
           }


### PR DESCRIPTION
When generating TextFormat for unknown fields, the attempt to see if a length
delimited field is a submessage was building up the unknown data pointlessly,
instead allow it to be forced to be discarded to skip this overhead.