### PR TITLE
Use dictionary subscript with default.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -86,9 +86,9 @@ public final class SwiftProtobufNamer {
   private func computeRelativeNames(enum e: EnumDescriptor) {
     let stripper = NamingUtils.PrefixStripper(prefix: e.name)
 
-    /// Determine the initial canidate name for the name before
+    /// Determine the initial candidate name for the name before
     /// doing duplicate checks.
-    func canidateName(_ enumValue: EnumValueDescriptor) -> String {
+    func candidateName(_ enumValue: EnumValueDescriptor) -> String {
       let baseName = enumValue.name
       if let stripped = stripper.strip(from: baseName) {
         let camelCased = NamingUtils.toLowerCamelCase(stripped)
@@ -100,13 +100,13 @@ public final class SwiftProtobufNamer {
     }
 
     // Bucketed based on candidate names to check for duplicates.
-    var canidates = [String:[EnumValueDescriptor]]()
+    var candidates = [String:[EnumValueDescriptor]]()
     for enumValue in e.values {
-      let canidate = canidateName(enumValue)
-      canidates[canidate, default:[]].append(enumValue)
+      let candidate = candidateName(enumValue)
+      candidates[candidate, default:[]].append(enumValue)
     }
 
-    for (camelCased, enumValues) in canidates {
+    for (camelCased, enumValues) in candidates {
       // If there is only one, sanitize and cache it.
       guard enumValues.count > 1 else {
         enumValueRelativeNameCache[enumValues.first!.fullName] =

--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -103,14 +103,7 @@ public final class SwiftProtobufNamer {
     var canidates = [String:[EnumValueDescriptor]]()
     for enumValue in e.values {
       let canidate = canidateName(enumValue)
-
-      if var existing = canidates[canidate] {
-        existing.append(enumValue)
-        canidates[canidate] = existing
-      } else {
-        canidates[canidate] = [enumValue]
-      }
-
+      canidates[canidate, default:[]].append(enumValue)
     }
 
     for (camelCased, enumValues) in canidates {


### PR DESCRIPTION
https://developer.apple.com/documentation/swift/dictionary/2894528-subscript
says it goes back to Xcode 9, so at this point, our min Swift version should be
ensuring things always support it.

The only other place that it might make sense to use this appears to be within
the SimpleExtensionMap, but the values looked up get filtered before adding to
them, so it seems like the fast path might for not being in the map might still
be worth while.