### PR TITLE
Use withContiguousStorageIfAvailable for String encoding in BinaryEnc…

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncoder.swift
+++ b/Sources/SwiftProtobuf/BinaryEncoder.swift
@@ -127,20 +127,21 @@ internal struct BinaryEncoder {
 
     // Write a string field, including the leading index/tag value.
     mutating func putStringValue(value: String) {
+        let utf8 = value.utf8
         #if swift(>=5.0)
             // If the String does not support an internal representation in a form
             // of contiguous storage, body is not called and nil is returned.
-            let isAvailable = value.utf8.withContiguousStorageIfAvailable { (body: UnsafeBufferPointer<UInt8>) -> Int in
+            let isAvailable = utf8.withContiguousStorageIfAvailable { (body: UnsafeBufferPointer<UInt8>) -> Int in
                 putVarInt(value: body.count)
                 return append(contentsOf: UnsafeRawBufferPointer(body))
             }
         #else
-            let isAvailable: String? = nil
+            let isAvailable: Int? = nil
         #endif
             if isAvailable == nil {
-                let count = value.utf8.count
+                let count = utf8.count
                 putVarInt(value: count)
-                for b in value.utf8 {
+                for b in utf8 {
                     pointer.storeBytes(of: b, as: UInt8.self)
                     pointer = pointer.advanced(by: 1)
                 }

--- a/Sources/SwiftProtobuf/BinaryEncoder.swift
+++ b/Sources/SwiftProtobuf/BinaryEncoder.swift
@@ -127,20 +127,24 @@ internal struct BinaryEncoder {
 
     // Write a string field, including the leading index/tag value.
     mutating func putStringValue(value: String) {
-        // If the String does not support an internal representation in a form
-        // of contiguous storage, body is not called and nil is returned.
-        let isAvailable = value.utf8.withContiguousStorageIfAvailable { (body: UnsafeBufferPointer<UInt8>) -> Int in
-            putVarInt(value: body.count)
-            return append(contentsOf: UnsafeRawBufferPointer(body))
-        }
-        if isAvailable == nil {
-            let count = value.utf8.count
-            putVarInt(value: count)
-            for b in value.utf8 {
-                pointer.storeBytes(of: b, as: UInt8.self)
-                pointer = pointer.advanced(by: 1)
+        #if swift(>=5.0)
+            // If the String does not support an internal representation in a form
+            // of contiguous storage, body is not called and nil is returned.
+            let isAvailable = value.utf8.withContiguousStorageIfAvailable { (body: UnsafeBufferPointer<UInt8>) -> Int in
+                putVarInt(value: body.count)
+                return append(contentsOf: UnsafeRawBufferPointer(body))
             }
-        }
+        #else
+            let isAvailable: String? = nil
+        #endif
+            if isAvailable == nil {
+                let count = value.utf8.count
+                putVarInt(value: count)
+                for b in value.utf8 {
+                    pointer.storeBytes(of: b, as: UInt8.self)
+                    pointer = pointer.advanced(by: 1)
+                }
+            }
     }
 
     mutating func putBytesValue(value: Data) {


### PR DESCRIPTION
I am proposing the following change for issue #919 which is labeled as "help-wanted".

The part that might be unexpected is the modification to `append(contentsOf:)`. I made that function return a value, the number of bytes appended from the input buffer, to silence the compiler warning: `Constant 'isAvailable' inferred to have type '()?', which may be unexpected`.

Resolves issue #919.