### PR TITLE
build: add a CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(protobuf
+  LANGUAGES Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+include(SwiftSupport)
+
+add_subdirectory(Sources)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(SwiftProtobuf)
+add_subdirectory(swiftProtobufPluginLibrary)
+add_subdirectory(protoc-gen-swift)

--- a/Sources/SwiftProtobuf/CMakeLists.txt
+++ b/Sources/SwiftProtobuf/CMakeLists.txt
@@ -1,0 +1,97 @@
+add_library(SwiftProtobuf
+  any.pb.swift
+  AnyMessageStorage.swift
+  AnyUnpackError.swift
+  api.pb.swift
+  BinaryDecoder.swift
+  BinaryDecodingError.swift
+  BinaryDecodingOptions.swift
+  BinaryDelimited.swift
+  BinaryEncoder.swift
+  BinaryEncodingError.swift
+  BinaryEncodingSizeVisitor.swift
+  BinaryEncodingVisitor.swift
+  CustomJSONCodable.swift
+  Data+Extensions.swift
+  Decoder.swift
+  descriptor.pb.swift
+  DoubleParser.swift
+  duration.pb.swift
+  empty.pb.swift
+  Enum.swift
+  ExtensibleMessage.swift
+  ExtensionFields.swift
+  ExtensionFieldValueSet.swift
+  ExtensionMap.swift
+  FieldTag.swift
+  FieldTypes.swift
+  field_mask.pb.swift
+  Google_Protobuf_Any+Extensions.swift
+  Google_Protobuf_Any+Registry.swift
+  Google_Protobuf_Duration+Extensions.swift
+  Google_Protobuf_FieldMask+Extensions.swift
+  Google_Protobuf_ListValue+Extensions.swift
+  Google_Protobuf_Struct+Extensions.swift
+  Google_Protobuf_Timestamp+Extensions.swift
+  Google_Protobuf_Value+Extensions.swift
+  Google_Protobuf_Wrappers+Extensions.swift
+  HashVisitor.swift
+  Internal.swift
+  JSONDecoder.swift
+  JSONDecodingError.swift
+  JSONDecodingOptions.swift
+  JSONEncoder.swift
+  JSONEncodingError.swift
+  JSONEncodingOptions.swift
+  JSONEncodingVisitor.swift
+  JSONMapEncodingVisitor.swift
+  JSONScanner.swift
+  MathUtils.swift
+  Message+AnyAdditions.swift
+  Message+BinaryAdditions.swift
+  Message+JSONAdditions.swift
+  Message+JSONArrayAdditions.swift
+  Message+TextFormatAdditions.swift
+  Message.swift
+  MessageExtension.swift
+  NameMap.swift
+  ProtobufAPIVersionCheck.swift
+  ProtobufMap.swift
+  ProtoNameProviding.swift
+  SelectiveVisitor.swift
+  SimpleExtensionMap.swift
+  source_context.pb.swift
+  StringUtils.swift
+  struct.pb.swift
+  TextFormatDecoder.swift
+  TextFormatDecodingError.swift
+  TextFormatEncoder.swift
+  TextFormatEncodingOptions.swift
+  TextFormatEncodingVisitor.swift
+  TextFormatScanner.swift
+  timestamp.pb.swift
+  TimeUtils.swift
+  type.pb.swift
+  UnknownStorage.swift
+  UnsafeBufferPointer+Shims.swift
+  UnsafeRawPointer+Shims.swift
+  Varint.swift
+  Version.swift
+  Visitor.swift
+  WireFormat.swift
+  wrappers.pb.swift
+  ZigZag.swift)
+set_target_properties(SwiftProtobuf PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+
+install(TARGETS SwiftProtobuf
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:SwiftProtobuf,Swift_MODULE_DIRECTORY>/SwiftProtobuf.swiftdoc
+  $<TARGET_PROPERTY:SwiftProtobuf,Swift_MODULE_DIRECTORY>/SwiftProtobuf.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+set_property(GLOBAL APPEND PROPERTY Protobuf_EXPORTS SwiftProtobuf)

--- a/Sources/SwiftProtobufPluginLibrary/CMakeLists.txt
+++ b/Sources/SwiftProtobufPluginLibrary/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(SwiftProtobufPluginLibrary
+  Array+Extensions.swift
+  CodePrinter.swift
+  Descriptor+Extensions.swift
+  Descriptor.swift
+  FieldNumbers.swift
+  Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift
+  Google_Protobuf_SourceCodeInfo+Extensions.swift
+  NamingUtils.swift
+  plugin.pb.swift
+  ProtoFileToModuleMappings.swift
+  ProvidesLocationPath.swift
+  ProvidesSourceCodeLocation.swift
+  SwiftLanguage.swift
+  SwiftProtobufInfo.swift
+  SwiftProtobufNamer.swift
+  swift_protobuf_module_mappings.pb.swift
+  UnicodeScalar+Extensions.swift)
+target_link_libraries(SwiftProtobufPluginLibrary PUBLIC
+  SwiftProtobuf)
+
+
+install(TARGETS SwiftProtobufPluginLibrary
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+get_swift_host_arch(swift_arch)
+install(FILES
+  $<TARGET_PROPERTY:SwiftProtobufPluginLibrary,Swift_MODULE_DIRECTORY>/SwiftProtobufPluginLibrary.swiftdoc
+  $<TARGET_PROPERTY:SwiftProtobufPluginLibrary,Swift_MODULE_DIRECTORY>/SwiftProtobufPluginLibrary.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+set_property(GLOBAL APPEND PROPERTY Protobuf_EXPORTS SwiftProtobufPluginLibrary)

--- a/Sources/protoc-gen-swift/CMakeLists.txt
+++ b/Sources/protoc-gen-swift/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_executable(protoc-gen-swift
+  CommandLine+Extensions.swift
+  Descriptor+Extensions.swift
+  EnumGenerator.swift
+  ExtensionSetGenerator.swift
+  FieldGenerator.swift
+  FileGenerator.swift
+  FileIo.swift
+  GenerationError.swift
+  GeneratorOptions.swift
+  Google_Protobuf_DescriptorProto+Extensions.swift
+  Google_Protobuf_FileDescriptorProto+Extensions.swift
+  main.swift
+  MessageFieldGenerator.swift
+  MessageGenerator.swift
+  MessageStorageClassGenerator.swift
+  OneofGenerator.swift
+  StringUtils.swift
+  Version.swift)
+target_link_libraries(protoc-gen-swift PRIVATE
+  SwiftProtobufPluginLibrary
+  SwiftProtobuf)
+
+
+install(TARGETS protoc-gen-swift
+  DESTINATION bin)
+set_property(GLOBAL APPEND PROPERTY Protobuf_EXPORTS protoc-gen-swift)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,37 @@
+
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()


### PR DESCRIPTION
This adds a CMake based build for supporting platforms where
swift-package-manager is not yet ready.  This enables building
swift-protobuf on Windows.