### PR TITLE
tweaking the README to expose the packagename

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ the plugin above:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
+    .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
 ],
 targets: [
     .target(name: "MyTarget", dependencies: ["SwiftProtobuf"]),


### PR DESCRIPTION
With Xcode 11.4 (and swift 5.2), swiftpm won't otherwise recognize the
packages. Took me several hours to hunt this down, so I wanted to share
it so the default value you might copy-pasta into your own Package.swift
would work correctly.