### PR TITLE
Drop the 3.11.4 protobuf release from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         swift: ["5.2.1-bionic", "5.1.5-bionic", "4.2.4"]
+        # "v3.11.4" not listed as that release doesn't support --experimental_allow_proto3_optional
         # master as of 4/4/2020: cf601047ebf87cf7f443753ded41132eb689cb10
-        protobuf_gitref: ["v3.11.4", "cf601047ebf87cf7f443753ded41132eb689cb10"]
+        protobuf_gitref: ["cf601047ebf87cf7f443753ded41132eb689cb10"]
         include:
           - swift: "5.2.1-bionic"
             platform: "ubuntu-18.04"


### PR DESCRIPTION
Since we need newer features to generate, it can't be directly tested without lots of conditionals in the Makefile.
