### PR TITLE
Don't hardcode the `SwiftProtobuf` module name everywhere

### DIFF
--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -214,7 +214,7 @@ extension FieldDescriptor {
     switch type {
     case .bool: return "false"
     case .string: return "String()"
-    case .bytes: return "SwiftProtobuf.Internal.emptyData"
+    case .bytes: return "\(Version.moduleName).Internal.emptyData"
     case .group, .message:
       return namer.fullName(message: messageType) + "()"
     case .enum:
@@ -235,31 +235,31 @@ extension FieldDescriptor {
       let valueTraits = valueField.traitsType(namer: namer)
       switch valueField.type {
       case .message:  // Map's can't have a group as the value
-        return "SwiftProtobuf._ProtobufMessageMap<\(keyTraits),\(valueTraits)>"
+        return "\(Version.moduleName)._ProtobufMessageMap<\(keyTraits),\(valueTraits)>"
       case .enum:
-        return "SwiftProtobuf._ProtobufEnumMap<\(keyTraits),\(valueTraits)>"
+        return "\(Version.moduleName)._ProtobufEnumMap<\(keyTraits),\(valueTraits)>"
       default:
-        return "SwiftProtobuf._ProtobufMap<\(keyTraits),\(valueTraits)>"
+        return "\(Version.moduleName)._ProtobufMap<\(keyTraits),\(valueTraits)>"
       }
     }
     switch type {
-    case .double: return "SwiftProtobuf.ProtobufDouble"
-    case .float: return "SwiftProtobuf.ProtobufFloat"
-    case .int64: return "SwiftProtobuf.ProtobufInt64"
-    case .uint64: return "SwiftProtobuf.ProtobufUInt64"
-    case .int32: return "SwiftProtobuf.ProtobufInt32"
-    case .fixed64: return "SwiftProtobuf.ProtobufFixed64"
-    case .fixed32: return "SwiftProtobuf.ProtobufFixed32"
-    case .bool: return "SwiftProtobuf.ProtobufBool"
-    case .string: return "SwiftProtobuf.ProtobufString"
+    case .double: return "\(Version.moduleName).ProtobufDouble"
+    case .float: return "\(Version.moduleName).ProtobufFloat"
+    case .int64: return "\(Version.moduleName).ProtobufInt64"
+    case .uint64: return "\(Version.moduleName).ProtobufUInt64"
+    case .int32: return "\(Version.moduleName).ProtobufInt32"
+    case .fixed64: return "\(Version.moduleName).ProtobufFixed64"
+    case .fixed32: return "\(Version.moduleName).ProtobufFixed32"
+    case .bool: return "\(Version.moduleName).ProtobufBool"
+    case .string: return "\(Version.moduleName).ProtobufString"
     case .group, .message: return namer.fullName(message: messageType)
-    case .bytes: return "SwiftProtobuf.ProtobufBytes"
-    case .uint32: return "SwiftProtobuf.ProtobufUInt32"
+    case .bytes: return "\(Version.moduleName).ProtobufBytes"
+    case .uint32: return "\(Version.moduleName).ProtobufUInt32"
     case .enum: return namer.fullName(enum: enumType)
-    case .sfixed32: return "SwiftProtobuf.ProtobufSFixed32"
-    case .sfixed64: return "SwiftProtobuf.ProtobufSFixed64"
-    case .sint32: return "SwiftProtobuf.ProtobufSInt32"
-    case .sint64: return "SwiftProtobuf.ProtobufSInt64"
+    case .sfixed32: return "\(Version.moduleName).ProtobufSFixed32"
+    case .sfixed64: return "\(Version.moduleName).ProtobufSFixed64"
+    case .sint32: return "\(Version.moduleName).ProtobufSInt32"
+    case .sint64: return "\(Version.moduleName).ProtobufSInt64"
     }
   }
 }

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -58,7 +58,7 @@ class EnumGenerator {
 
     p.print("\n")
     p.print(enumDescriptor.protoSourceComments())
-    p.print("\(visibility)enum \(swiftRelativeName): SwiftProtobuf.Enum {\n")
+    p.print("\(visibility)enum \(swiftRelativeName): \(Version.moduleName).Enum {\n")
     p.indent()
     p.print("\(visibility)typealias RawValue = Int\n")
 
@@ -120,7 +120,7 @@ class EnumGenerator {
 
   func generateRuntimeSupport(printer p: inout CodePrinter) {
     p.print("\n")
-    p.print("extension \(swiftFullName): SwiftProtobuf._ProtoNameProviding {\n")
+    p.print("extension \(swiftFullName): \(Version.moduleName)._ProtoNameProviding {\n")
     p.indent()
     generateProtoNameProviding(printer: &p)
     p.outdent()
@@ -156,7 +156,7 @@ class EnumGenerator {
   private func generateProtoNameProviding(printer p: inout CodePrinter) {
     let visibility = generatorOptions.visibilitySourceSnippet
 
-    p.print("\(visibility)static let _protobuf_nameMap: SwiftProtobuf._NameMap = [\n")
+    p.print("\(visibility)static let _protobuf_nameMap: \(Version.moduleName)._NameMap = [\n")
     p.indent()
     for v in mainEnumValueDescriptorsSorted {
       if v.aliases.isEmpty {

--- a/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
@@ -47,7 +47,7 @@ class ExtensionSetGenerator {
             default: modifier = ""
             }
 
-            return "SwiftProtobuf.\(label)\(modifier)ExtensionField"
+            return "\(Version.moduleName).\(label)\(modifier)ExtensionField"
         }
 
         init(descriptor: FieldDescriptor, generatorOptions: GeneratorOptions, namer: SwiftProtobufNamer) {
@@ -81,7 +81,7 @@ class ExtensionSetGenerator {
 
             p.print(
               comments,
-              "\(visibility)\(scope)let \(swiftRelativeExtensionName) = SwiftProtobuf.MessageExtension<\(extensionFieldType)<\(traitsType)>, \(containingTypeSwiftFullName)>(\n")
+              "\(visibility)\(scope)let \(swiftRelativeExtensionName) = \(Version.moduleName).MessageExtension<\(extensionFieldType)<\(traitsType)>, \(containingTypeSwiftFullName)>(\n")
             p.indent()
             p.print(
               "_protobuf_fieldNumber: \(fieldDescriptor.number),\n",
@@ -223,7 +223,7 @@ class ExtensionSetGenerator {
           "/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed\n",
           "/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create\n",
           "/// a larger `SwiftProtobuf.SimpleExtensionMap`.\n",
-          "\(generatorOptions.visibilitySourceSnippet)let \(filePrefix)\(filenameAsIdentifer)_Extensions: SwiftProtobuf.SimpleExtensionMap = [\n")
+          "\(generatorOptions.visibilitySourceSnippet)let \(filePrefix)\(filenameAsIdentifer)_Extensions: \(Version.moduleName).SimpleExtensionMap = [\n")
         p.indent()
         var separator = ""
         for e in extensions {

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -93,7 +93,7 @@ class FileGenerator {
         if !fileDescriptor.isBundledProto {
             // The well known types ship with the runtime, everything else needs
             // to import the runtime.
-            p.print("import SwiftProtobuf\n")
+            p.print("import \(Version.moduleName)\n")
         }
         if let neededImports = generatorOptions.protoToModuleMappings.neededModules(forFile: fileDescriptor) {
             p.print("\n")
@@ -190,10 +190,10 @@ class FileGenerator {
             "// incompatible with the version of SwiftProtobuf to which you are linking.\n",
             "// Please ensure that you are building against the same version of the API\n",
             "// that was used to generate this file.\n",
-            "fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {\n")
+            "fileprivate struct _GeneratedWithProtocGenSwiftVersion: \(Version.moduleName).ProtobufAPIVersionCheck {\n")
         p.indent()
         p.print(
-            "struct _\(v): SwiftProtobuf.ProtobufAPIVersion_\(v) {}\n",
+            "struct _\(v): \(Version.moduleName).ProtobufAPIVersion_\(v) {}\n",
             "typealias Version = _\(v)\n")
         p.outdent()
         p.print("}\n")

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -161,7 +161,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
         guard isGroupOrMessage && fieldDescriptor.messageType.hasRequiredFields() else { return }
 
         if isRepeated {  // Map or Array
-            p.print("if !SwiftProtobuf.Internal.areAllInitialized(\(storedProperty)) {return false}\n")
+            p.print("if !\(Version.moduleName).Internal.areAllInitialized(\(storedProperty)) {return false}\n")
         } else {
             p.print("if let v = \(storedProperty), !v.isInitialized {return false}\n")
         }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -118,7 +118,7 @@ class MessageGenerator {
 
     let conformances: String
     if isExtensible {
-      conformances = ": SwiftProtobuf.ExtensibleMessage"
+      conformances = ": \(Version.moduleName).ExtensibleMessage"
     } else {
       conformances = ""
     }
@@ -127,7 +127,7 @@ class MessageGenerator {
         descriptor.protoSourceComments(),
         "\(visibility)struct \(swiftRelativeName)\(conformances) {\n")
     p.indent()
-    p.print("// SwiftProtobuf.Message conformance is added in an extension below. See the\n",
+    p.print("// \(Version.moduleName).Message conformance is added in an extension below. See the\n",
             "// `Message` and `Message+*Additions` files in the SwiftProtobuf library for\n",
             "// methods supported on all messages.\n")
 
@@ -137,7 +137,7 @@ class MessageGenerator {
 
     p.print(
         "\n",
-        "\(visibility)var unknownFields = SwiftProtobuf.UnknownStorage()\n")
+        "\(visibility)var unknownFields = \(Version.moduleName).UnknownStorage()\n")
 
     for o in oneofs {
       o.generateMainEnum(printer: &p)
@@ -164,7 +164,7 @@ class MessageGenerator {
     if isExtensible {
       p.print(
           "\n",
-          "\(visibility)var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()\n")
+          "\(visibility)var _protobuf_extensionFieldValues = \(Version.moduleName).ExtensionFieldValueSet()\n")
     }
     if let storage = storage {
       if !isExtensible {
@@ -200,7 +200,7 @@ class MessageGenerator {
   func generateRuntimeSupport(printer p: inout CodePrinter, file: FileGenerator, parent: MessageGenerator?) {
     p.print(
         "\n",
-        "extension \(swiftFullName): SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {\n")
+        "extension \(swiftFullName): \(Version.moduleName).Message, \(Version.moduleName)._MessageImplementationBase, \(Version.moduleName)._ProtoNameProviding {\n")
     p.indent()
 
     if let parent = parent {
@@ -239,9 +239,9 @@ class MessageGenerator {
 
   private func generateProtoNameProviding(printer p: inout CodePrinter) {
     if fields.isEmpty {
-      p.print("\(visibility)static let _protobuf_nameMap = SwiftProtobuf._NameMap()\n")
+      p.print("\(visibility)static let _protobuf_nameMap = \(Version.moduleName)._NameMap()\n")
     } else {
-      p.print("\(visibility)static let _protobuf_nameMap: SwiftProtobuf._NameMap = [\n")
+      p.print("\(visibility)static let _protobuf_nameMap: \(Version.moduleName)._NameMap = [\n")
       p.indent()
       for f in fields {
         p.print("\(f.number): \(f.fieldMapNames),\n")
@@ -256,7 +256,7 @@ class MessageGenerator {
   ///
   /// - Parameter p: The code printer.
   private func generateDecodeMessage(printer p: inout CodePrinter) {
-    p.print("\(visibility)mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {\n")
+    p.print("\(visibility)mutating func decodeMessage<D: \(Version.moduleName).Decoder>(decoder: inout D) throws {\n")
     p.indent()
     if storage != nil {
       p.print("_ = _uniqueStorage()\n")
@@ -319,7 +319,7 @@ class MessageGenerator {
   ///
   /// - Parameter p: The code printer.
   private func generateTraverse(printer p: inout CodePrinter) {
-    p.print("\(visibility)func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {\n")
+    p.print("\(visibility)func traverse<V: \(Version.moduleName).Visitor>(visitor: inout V) throws {\n")
     p.indent()
     generateWithLifetimeExtension(printer: &p, throws: true) { p in
       if let storage = storage {

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -61,7 +61,7 @@ func trimWhitespace(_ s: String) -> String {
 ///  \n\r\t\\\'\" and three-digit octal escapes but nothing else.
 func escapedToDataLiteral(_ s: String) -> String {
   if s.isEmpty {
-    return "SwiftProtobuf.Internal.emptyData"
+    return "\(Version.moduleName).Internal.emptyData"
   }
   var out = "Data(["
   var separator = ""

--- a/Sources/protoc-gen-swift/Version.swift
+++ b/Sources/protoc-gen-swift/Version.swift
@@ -27,5 +27,8 @@ struct Version {
     // or API-changing).
     static let compatibilityVersion = 2
 
+    // Name of the SwiftProtobuf module
+    static let moduleName = "SwiftProtobuf"
+
     static let copyright = "Copyright (C) 2014-2017 Apple Inc. and the project authors"
 }

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -101,7 +101,7 @@ struct GeneratorPlugin {
         + "In particular, if you have renamed this program, you will need to\n"
         + "adjust the protoc command-line option accordingly.\n"
         + "\n"
-        + "The generated Swift output requires the SwiftProtobuf \(SwiftProtobuf.Version.versionString)\n"
+        + "The generated Swift output requires the \(Version.moduleName) \(SwiftProtobuf.Version.versionString)\n"
         + "library be included in your project.\n"
         + "\n"
         + "If you use `swift build` to compile your project, add this to\n"


### PR DESCRIPTION
This moves the `SwiftProtobuf` module name that will be written
into the generated code to a single place in the generator.
