### PR TITLE
[581] Enables better error handling for JSONDecodingError

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -31,7 +31,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
     case "-":
       // Only accept '-' as very first character
       if total > 0 {
-        throw JSONDecodingError.malformedDuration
+        throw JSONDecodingError.malformed(duration: text)
       }
       digits.append(c)
     case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
@@ -39,14 +39,14 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
       digitCount += 1
     case ".":
       if let _ = seconds {
-        throw JSONDecodingError.malformedDuration
+        throw JSONDecodingError.malformed(duration: text)
       }
       let digitString = String(digits)
       if let s = Int64(digitString),
         s >= minDurationSeconds && s <= maxDurationSeconds {
         seconds = s
       } else {
-        throw JSONDecodingError.malformedDuration
+        throw JSONDecodingError.malformed(duration: text)
       }
       digits.removeAll()
       digitCount = 0
@@ -69,7 +69,7 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
             nanos = rawNanos
           }
         } else {
-          throw JSONDecodingError.malformedDuration
+          throw JSONDecodingError.malformed(duration: text)
         }
       } else {
         // No fraction, we just have an integral number of seconds
@@ -78,20 +78,20 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
           s >= minDurationSeconds && s <= maxDurationSeconds {
           seconds = s
         } else {
-          throw JSONDecodingError.malformedDuration
+          throw JSONDecodingError.malformed(duration: text)
         }
       }
       // Fail if there are characters after 's'
       if chars.next() != nil {
-        throw JSONDecodingError.malformedDuration
+        throw JSONDecodingError.malformed(duration: text)
       }
       return (seconds!, nanos)
     default:
-      throw JSONDecodingError.malformedDuration
+      throw JSONDecodingError.malformed(duration: text)
     }
     total += 1
   }
-  throw JSONDecodingError.malformedDuration
+  throw JSONDecodingError.malformed(duration: text)
 }
 
 private func formatDuration(seconds: Int64, nanos: Int32) -> String? {

--- a/Sources/SwiftProtobuf/JSONDecodingError.swift
+++ b/Sources/SwiftProtobuf/JSONDecodingError.swift
@@ -44,9 +44,9 @@ public enum JSONDecodingError: Error {
     /// We hit the end of the JSON string and expected something more...
     case truncated
     /// A JSON Duration could not be parsed
-    case malformedDuration
+    case malformed(duration: String)
     /// A JSON Timestamp could not be parsed
-    case malformedTimestamp
+    case malformed(timestamp: String)
     /// A FieldMask could not be parsed
     case malformedFieldMask
     /// Extraneous data remained after decoding should have been complete


### PR DESCRIPTION
The following PR provides a better error handling in the JSONDecodingError enum, where it would return part of the string as a part of the error Closes #581 