### PR TITLE
Remove the empty check since it was the only one.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -228,10 +228,6 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
 
   mutating func visitPackedEnumField<E: Enum>(value: [E],
                                      fieldNumber: Int) throws {
-    guard !value.isEmpty else {
-      return
-    }
-
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += tagSize

--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -105,18 +105,21 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedFloatField(value: [Float], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<Float>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedDoubleField(value: [Double], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<Double>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -127,6 +130,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -137,6 +141,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedSInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -147,6 +152,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedSInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -157,6 +163,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -167,6 +174,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     var dataSize = 0
     for v in value {
@@ -177,30 +185,35 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
   }
 
   mutating func visitPackedFixed32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<UInt32>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedFixed64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<UInt64>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedSFixed32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<Int32>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedSFixed64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count * MemoryLayout<Int64>.size
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
   }
 
   mutating func visitPackedBoolField(value: [Bool], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited).encodedSize
     let dataSize = value.count
     serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
@@ -217,6 +230,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E],
                                        fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += value.count * tagSize
@@ -228,6 +242,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
 
   mutating func visitPackedEnumField<E: Enum>(value: [E],
                                      fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .varint).encodedSize
     serializedSize += tagSize
@@ -249,6 +264,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M],
                                              fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .lengthDelimited).encodedSize
     serializedSize += value.count * tagSize
@@ -270,6 +286,7 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G],
                                            fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     let tagSize = FieldTag(fieldNumber: fieldNumber,
                            wireFormat: .startGroup).encodedSize
     serializedSize += 2 * value.count * tagSize

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -123,6 +123,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   // Packed Fields
 
   mutating func visitPackedFloatField(value: [Float], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<Float>.size)
     for v in value {
@@ -131,6 +132,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedDoubleField(value: [Double], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<Double>.size)
     for v in value {
@@ -139,6 +141,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -151,6 +154,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -163,6 +167,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedSInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -175,6 +180,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedSInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -187,6 +193,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -199,6 +206,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {
@@ -211,6 +219,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedFixed32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<UInt32>.size)
     for v in value {
@@ -219,6 +228,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedFixed64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<UInt64>.size)
     for v in value {
@@ -227,6 +237,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedSFixed32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<Int32>.size)
     for v in value {
@@ -235,6 +246,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedSFixed64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count * MemoryLayout<Int64>.size)
     for v in value {
@@ -243,6 +255,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedBoolField(value: [Bool], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     encoder.putVarInt(value: value.count)
     for v in value {
@@ -251,6 +264,7 @@ internal struct BinaryEncodingVisitor: Visitor {
   }
 
   mutating func visitPackedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     encoder.startField(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
     var packedSize = 0
     for v in value {

--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -145,6 +145,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -157,6 +158,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedDoubleField(value: [Double], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -169,6 +171,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -181,6 +184,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -193,6 +197,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -205,6 +210,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -217,6 +223,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedSInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -229,6 +236,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedSInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -241,6 +249,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedFixed32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -253,6 +262,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedFixed64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -265,6 +275,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedSFixed32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -277,6 +288,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedSFixed64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -289,6 +301,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedBoolField(value: [Bool], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -301,6 +314,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedStringField(value: [String], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -313,6 +327,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedBytesField(value: [Data], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -325,6 +340,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       hasher.combine(value)
@@ -337,6 +353,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       for v in value {
@@ -351,6 +368,7 @@ internal struct HashVisitor: Visitor {
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     #if swift(>=4.2)
       hasher.combine(fieldNumber)
       for v in value {

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -142,6 +142,7 @@ internal struct JSONEncodingVisitor: Visitor {
     fieldNumber: Int,
     encode: (inout JSONEncoder, T) throws -> ()
   ) throws {
+    assert(!value.isEmpty)
     try startField(for: fieldNumber)
     var comma = false
     encoder.startArray()
@@ -285,6 +286,7 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try startField(for: fieldNumber)
     var comma = false
     encoder.startArray()
@@ -319,6 +321,7 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     // Google does not serialize groups into JSON
   }
 

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -328,6 +328,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   // the name lookup once for the array, rather than once for each element:
 
   mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -338,6 +339,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedDoubleField(value: [Double], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -348,6 +350,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt32Field(value: [Int32], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -358,6 +361,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedInt64Field(value: [Int64], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -368,6 +372,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -378,6 +383,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -407,6 +413,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedBoolField(value: [Bool], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -417,6 +424,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedStringField(value: [String], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -427,6 +435,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedBytesField(value: [Data], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -437,6 +446,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       for v in value {
           encoder.emitFieldName(name: fieldName)
@@ -449,6 +459,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   // Messages and groups
   mutating func visitRepeatedMessageField<M: Message>(value: [M],
                                              fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       // Look up field name against outer message encoding state
       let fieldName = formatFieldName(lookingUp: fieldNumber)
       // Cache old encoder state
@@ -493,6 +504,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
     value: [T], fieldNumber: Int,
     encode: (T, inout TextFormatEncoder) -> ()
   ) throws {
+      assert(!value.isEmpty)
       emitFieldName(lookingUp: fieldNumber)
       encoder.startRegularField()
       var firstItem = true

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -492,108 +492,126 @@ extension Visitor {
   // repeated values differently from singular, so overrides these.
 
   public mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularFloatField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedDoubleField(value: [Double], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularDoubleField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularInt32Field(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularInt64Field(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularUInt32Field(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularUInt64Field(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedSInt32Field(value: [Int32], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularSInt32Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedSInt64Field(value: [Int64], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularSInt64Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedFixed32Field(value: [UInt32], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularFixed32Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedFixed64Field(value: [UInt64], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularFixed64Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedSFixed32Field(value: [Int32], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularSFixed32Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedSFixed64Field(value: [Int64], fieldNumber: Int) throws {
+      assert(!value.isEmpty)
       for v in value {
           try visitSingularSFixed64Field(value: v, fieldNumber: fieldNumber)
       }
   }
 
   public mutating func visitRepeatedBoolField(value: [Bool], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularBoolField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedStringField(value: [String], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularStringField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedBytesField(value: [Data], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularBytesField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
         try visitSingularEnumField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularMessageField(value: v, fieldNumber: fieldNumber)
     }
   }
 
   public mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     for v in value {
       try visitSingularGroupField(value: v, fieldNumber: fieldNumber)
     }
@@ -605,59 +623,73 @@ extension Visitor {
   // overridden by Protobuf Binary and Text.
 
   public mutating func visitPackedFloatField(value: [Float], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedFloatField(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedDoubleField(value: [Double], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedDoubleField(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedInt32Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedUInt32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedUInt32Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedUInt64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedUInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedSInt32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedInt32Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedSInt64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedFixed32Field(value: [UInt32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedUInt32Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedFixed64Field(value: [UInt64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedUInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedSFixed32Field(value: [Int32], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedInt32Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedSFixed64Field(value: [Int64], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitPackedInt64Field(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedBoolField(value: [Bool], fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedBoolField(value: value, fieldNumber: fieldNumber)
   }
 
   public mutating func visitPackedEnumField<E: Enum>(value: [E],
                                             fieldNumber: Int) throws {
+    assert(!value.isEmpty)
     try visitRepeatedEnumField(value: value, fieldNumber: fieldNumber)
   }
 


### PR DESCRIPTION
The generated traverse methods should never call on a repeated field
that is empty.

Fixes #988