### PR TITLE
Update min version information.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,5 +31,5 @@ let package = Package(
     .testTarget(name: "SwiftProtobufPluginLibraryTests",
                 dependencies: ["SwiftProtobufPluginLibrary"]),
   ],
-  swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
+  swiftLanguageVersions: [.v4, .v4_2, .version("5")]
 )

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ your project as explained below.
 
 To use Swift with Protocol buffers, you'll need:
 
-* A Swift 4.0 or later compiler (Xcode 9.1 or later).  Support is included
+* A Swift 4.2 or later compiler (Xcode 10.0 or later).  Support is included
 for the Swift Package Manager; or using the included Xcode project. The Swift
 protobuf project is being developed and tested against the latest release
 version of Swift available from [Swift.org](https://swift.org)


### PR DESCRIPTION
5.2 has been out a while so update the docs accordingly.

Also remove the .v3 in Package.swift, we remove that support a while ago.