### PR TITLE
Eliminate NamingUtils's awareness of SwiftProtobufNamer

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -49,10 +49,10 @@ public final class SwiftProtobufNamer {
   /// Calculate the relative name for the given message.
   public func relativeName(message: Descriptor) -> String {
     if message.containingType != nil {
-      return NamingUtils.sanitize(messageName: message.name, namer: self)
+      return NamingUtils.sanitize(messageName: message.name, forbiddenTypeNames: [self.swiftProtobufModuleName])
     } else {
       let prefix = typePrefix(forFile: message.file)
-      return NamingUtils.sanitize(messageName: prefix + message.name, namer: self)
+      return NamingUtils.sanitize(messageName: prefix + message.name, forbiddenTypeNames: [self.swiftProtobufModuleName])
     }
   }
 
@@ -68,10 +68,10 @@ public final class SwiftProtobufNamer {
   /// Calculate the relative name for the given enum.
   public func relativeName(enum e: EnumDescriptor) -> String {
     if e.containingType != nil {
-      return NamingUtils.sanitize(enumName: e.name, namer: self)
+      return NamingUtils.sanitize(enumName: e.name, forbiddenTypeNames: [self.swiftProtobufModuleName])
     } else {
       let prefix = typePrefix(forFile: e.file)
-      return NamingUtils.sanitize(enumName: prefix + e.name, namer: self)
+      return NamingUtils.sanitize(enumName: prefix + e.name, forbiddenTypeNames: [self.swiftProtobufModuleName])
     }
   }
 
@@ -193,7 +193,7 @@ public final class SwiftProtobufNamer {
   /// Calculate the relative name for the given oneof.
   public func relativeName(oneof: OneofDescriptor) -> String {
     let camelCase = NamingUtils.toUpperCamelCase(oneof.name)
-    return NamingUtils.sanitize(oneofName: "OneOf_\(camelCase)", namer: self)
+    return NamingUtils.sanitize(oneofName: "OneOf_\(camelCase)", forbiddenTypeNames: [self.swiftProtobufModuleName])
   }
 
   /// Calculate the full name for the given oneof.

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
@@ -14,8 +14,6 @@ import SwiftProtobuf
 
 class Test_NamingUtils: XCTestCase {
 
-  let namer = SwiftProtobufNamer(protoFileToModuleMappings: ProtoFileToModuleMappings(swiftProtobufModuleName: "RenamedSwiftProtobuf"), targetModule: "Target")
-
   func testTypePrefix() throws {
     // package, swiftPrefix, expected
     let tests: [(String, String?, String)] = [
@@ -132,7 +130,7 @@ class Test_NamingUtils: XCTestCase {
       ( "___", "___Message" ),
     ]
     for (input, expected) in tests {
-      XCTAssertEqual(NamingUtils.sanitize(messageName: input, namer: namer), expected)
+      XCTAssertEqual(NamingUtils.sanitize(messageName: input, forbiddenTypeNames: ["RenamedSwiftProtobuf"]), expected)
     }
   }
 
@@ -165,7 +163,7 @@ class Test_NamingUtils: XCTestCase {
       ( "___", "___Enum" ),
     ]
     for (input, expected) in tests {
-      XCTAssertEqual(NamingUtils.sanitize(enumName: input, namer: namer), expected)
+      XCTAssertEqual(NamingUtils.sanitize(enumName: input, forbiddenTypeNames: ["RenamedSwiftProtobuf"]), expected)
     }
   }
 
@@ -197,7 +195,7 @@ class Test_NamingUtils: XCTestCase {
       ( "___", "___Oneof" ),
     ]
     for (input, expected) in tests {
-      XCTAssertEqual(NamingUtils.sanitize(oneofName: input, namer: namer), expected)
+      XCTAssertEqual(NamingUtils.sanitize(oneofName: input, forbiddenTypeNames: ["RenamedSwiftProtobuf"]), expected)
     }
   }
 


### PR DESCRIPTION
In response to @thomasvl 's comments in #1017.