### PR TITLE
Move required field support for oneof into a generated helper.

### DIFF
--- a/Reference/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto2.pb.swift
@@ -911,6 +911,11 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum)
 
+    fileprivate var isInitialized: Bool {
+      guard case .oneofNestedMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField, rhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -1678,7 +1683,7 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       if let v = _storage._recursiveMessage, !v.isInitialized {return false}
       if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedNestedMessage) {return false}
       if !SwiftProtobuf.Internal.areAllInitialized(_storage._mapStringNestedMessage) {return false}
-      if case .oneofNestedMessage(let v)? = _storage._oneofField, !v.isInitialized {return false}
+      if let v = _storage._oneofField, !v.isInitialized {return false}
       return true
     }
   }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -3636,6 +3636,11 @@ struct ProtobufUnittest_TestRequiredOneof {
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
 
+    fileprivate var isInitialized: Bool {
+      guard case .fooMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -10999,7 +11004,7 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
   ]
 
   public var isInitialized: Bool {
-    if case .fooMessage(let v)? = self.foo, !v.isInitialized {return false}
+    if let v = self.foo, !v.isInitialized {return false}
     return true
   }
 

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -521,6 +521,11 @@ struct ProtobufUnittest_TestAllRequiredTypes {
     case oneofString(String)
     case oneofBytes(Data)
 
+    fileprivate var isInitialized: Bool {
+      guard case .oneofNestedMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -950,7 +955,7 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
       if let v = _storage._requiredGroup, !v.isInitialized {return false}
       if let v = _storage._requiredNestedMessage, !v.isInitialized {return false}
       if let v = _storage._requiredLazyMessage, !v.isInitialized {return false}
-      if case .oneofNestedMessage(let v)? = _storage._oneofField, !v.isInitialized {return false}
+      if let v = _storage._oneofField, !v.isInitialized {return false}
       return true
     }
   }

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -139,6 +139,15 @@ struct ProtobufUnittest_OneOfContainer {
     case option3(ProtobufUnittest_OneOfContainer.Option3)
     case option4(Int32)
 
+    fileprivate var isInitialized: Bool {
+      switch self {
+      case .option1(let v): return v.isInitialized
+      case .option2(let v): return v.isInitialized
+      case .option3(let v): return v.isInitialized
+      default: return true
+      }
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_OneOfContainer.OneOf_Option, rhs: ProtobufUnittest_OneOfContainer.OneOf_Option) -> Bool {
       switch (lhs, rhs) {
@@ -268,12 +277,7 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   public var isInitialized: Bool {
-    switch self.option {
-    case .option1(let v)?: if !v.isInitialized {return false}
-    case .option2(let v)?: if !v.isInitialized {return false}
-    case .option3(let v)?: if !v.isInitialized {return false}
-    default: break
-    }
+    if let v = self.option, !v.isInitialized {return false}
     return true
   }
 

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -911,6 +911,11 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum)
 
+    fileprivate var isInitialized: Bool {
+      guard case .oneofNestedMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField, rhs: ProtobufTestMessages_Proto2_TestAllTypesProto2.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -1678,7 +1683,7 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
       if let v = _storage._recursiveMessage, !v.isInitialized {return false}
       if !SwiftProtobuf.Internal.areAllInitialized(_storage._repeatedNestedMessage) {return false}
       if !SwiftProtobuf.Internal.areAllInitialized(_storage._mapStringNestedMessage) {return false}
-      if case .oneofNestedMessage(let v)? = _storage._oneofField, !v.isInitialized {return false}
+      if let v = _storage._oneofField, !v.isInitialized {return false}
       return true
     }
   }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -3636,6 +3636,11 @@ struct ProtobufUnittest_TestRequiredOneof {
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
 
+    fileprivate var isInitialized: Bool {
+      guard case .fooMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -10999,7 +11004,7 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
   ]
 
   public var isInitialized: Bool {
-    if case .fooMessage(let v)? = self.foo, !v.isInitialized {return false}
+    if let v = self.foo, !v.isInitialized {return false}
     return true
   }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -521,6 +521,11 @@ struct ProtobufUnittest_TestAllRequiredTypes {
     case oneofString(String)
     case oneofBytes(Data)
 
+    fileprivate var isInitialized: Bool {
+      guard case .oneofNestedMessage(let v) = self else {return true}
+      return v.isInitialized
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -950,7 +955,7 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
       if let v = _storage._requiredGroup, !v.isInitialized {return false}
       if let v = _storage._requiredNestedMessage, !v.isInitialized {return false}
       if let v = _storage._requiredLazyMessage, !v.isInitialized {return false}
-      if case .oneofNestedMessage(let v)? = _storage._oneofField, !v.isInitialized {return false}
+      if let v = _storage._oneofField, !v.isInitialized {return false}
       return true
     }
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -139,6 +139,15 @@ struct ProtobufUnittest_OneOfContainer {
     case option3(ProtobufUnittest_OneOfContainer.Option3)
     case option4(Int32)
 
+    fileprivate var isInitialized: Bool {
+      switch self {
+      case .option1(let v): return v.isInitialized
+      case .option2(let v): return v.isInitialized
+      case .option3(let v): return v.isInitialized
+      default: return true
+      }
+    }
+
   #if !swift(>=4.1)
     static func ==(lhs: ProtobufUnittest_OneOfContainer.OneOf_Option, rhs: ProtobufUnittest_OneOfContainer.OneOf_Option) -> Bool {
       switch (lhs, rhs) {
@@ -268,12 +277,7 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   public var isInitialized: Bool {
-    switch self.option {
-    case .option1(let v)?: if !v.isInitialized {return false}
-    case .option2(let v)?: if !v.isInitialized {return false}
-    case .option3(let v)?: if !v.isInitialized {return false}
-    default: break
-    }
+    if let v = self.option, !v.isInitialized {return false}
     return true
   }
 


### PR DESCRIPTION
The helper is fileprivate, so the compiler should always inline it, but this will help when dealing with static usage for non optimized builds (#1034).
