### PR TITLE
Add .dynamic library type for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
   products: [
     .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
     .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"]),
+    .library(name: "SwiftProtobufDynamic", type: .dynamic, targets: ["SwiftProtobuf"]),
     .library(name: "SwiftProtobufPluginLibrary", targets: ["SwiftProtobufPluginLibrary"]),
+    .library(name: "SwiftProtobufPluginLibraryDynamic", type: .dynamic, targets: ["SwiftProtobufPluginLibrary"]),
   ],
   targets: [
     .target(name: "SwiftProtobuf"),


### PR DESCRIPTION
We'd like to progressively adopt Swift Package Manger into our existing app whose dependencies are managed by cocoapods + `use_frameworks!`, without `.dynamic` option, we can't choose dynamic library version of SwiftProtobuf. 

Here is the screenshot after adding `.dynamic` in my fork

![Screen Shot 2020-08-12 at 1 29 51 PM](https://user-images.githubusercontent.com/360470/89979275-eea72c00-dca1-11ea-9da1-f1f33fbec60f.png)

We can still import SwiftProtobuf like below:

```swift
import SwiftProtobuf
```

The final copied framework name is `SwiftProtobufDynamic`

![Screen Shot 2020-08-12 at 1 30 36 PM](https://user-images.githubusercontent.com/360470/89979276-f2d34980-dca1-11ea-82e8-9e0dff58599c.png)
