### PR TITLE
Revise storage decision

### DIFF
--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -311,42 +311,42 @@ struct Google_Protobuf_FieldDescriptorProto {
   // methods supported on all messages.
 
   var name: String {
-    get {return _name ?? String()}
-    set {_name = newValue}
+    get {return _storage._name ?? String()}
+    set {_uniqueStorage()._name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  var hasName: Bool {return self._name != nil}
+  var hasName: Bool {return _storage._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  mutating func clearName() {self._name = nil}
+  mutating func clearName() {_uniqueStorage()._name = nil}
 
   var number: Int32 {
-    get {return _number ?? 0}
-    set {_number = newValue}
+    get {return _storage._number ?? 0}
+    set {_uniqueStorage()._number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  var hasNumber: Bool {return self._number != nil}
+  var hasNumber: Bool {return _storage._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  mutating func clearNumber() {self._number = nil}
+  mutating func clearNumber() {_uniqueStorage()._number = nil}
 
   var label: Google_Protobuf_FieldDescriptorProto.Label {
-    get {return _label ?? .optional}
-    set {_label = newValue}
+    get {return _storage._label ?? .optional}
+    set {_uniqueStorage()._label = newValue}
   }
   /// Returns true if `label` has been explicitly set.
-  var hasLabel: Bool {return self._label != nil}
+  var hasLabel: Bool {return _storage._label != nil}
   /// Clears the value of `label`. Subsequent reads from it will return its default value.
-  mutating func clearLabel() {self._label = nil}
+  mutating func clearLabel() {_uniqueStorage()._label = nil}
 
   /// If type_name is set, this need not be set.  If both this and type_name
   /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
-    get {return _type ?? .double}
-    set {_type = newValue}
+    get {return _storage._type ?? .double}
+    set {_uniqueStorage()._type = newValue}
   }
   /// Returns true if `type` has been explicitly set.
-  var hasType: Bool {return self._type != nil}
+  var hasType: Bool {return _storage._type != nil}
   /// Clears the value of `type`. Subsequent reads from it will return its default value.
-  mutating func clearType() {self._type = nil}
+  mutating func clearType() {_uniqueStorage()._type = nil}
 
   /// For message and enum types, this is the name of the type.  If the name
   /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
@@ -354,24 +354,24 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   var typeName: String {
-    get {return _typeName ?? String()}
-    set {_typeName = newValue}
+    get {return _storage._typeName ?? String()}
+    set {_uniqueStorage()._typeName = newValue}
   }
   /// Returns true if `typeName` has been explicitly set.
-  var hasTypeName: Bool {return self._typeName != nil}
+  var hasTypeName: Bool {return _storage._typeName != nil}
   /// Clears the value of `typeName`. Subsequent reads from it will return its default value.
-  mutating func clearTypeName() {self._typeName = nil}
+  mutating func clearTypeName() {_uniqueStorage()._typeName = nil}
 
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   var extendee: String {
-    get {return _extendee ?? String()}
-    set {_extendee = newValue}
+    get {return _storage._extendee ?? String()}
+    set {_uniqueStorage()._extendee = newValue}
   }
   /// Returns true if `extendee` has been explicitly set.
-  var hasExtendee: Bool {return self._extendee != nil}
+  var hasExtendee: Bool {return _storage._extendee != nil}
   /// Clears the value of `extendee`. Subsequent reads from it will return its default value.
-  mutating func clearExtendee() {self._extendee = nil}
+  mutating func clearExtendee() {_uniqueStorage()._extendee = nil}
 
   /// For numeric types, contains the original text representation of the value.
   /// For booleans, "true" or "false".
@@ -379,46 +379,46 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
-    get {return _defaultValue ?? String()}
-    set {_defaultValue = newValue}
+    get {return _storage._defaultValue ?? String()}
+    set {_uniqueStorage()._defaultValue = newValue}
   }
   /// Returns true if `defaultValue` has been explicitly set.
-  var hasDefaultValue: Bool {return self._defaultValue != nil}
+  var hasDefaultValue: Bool {return _storage._defaultValue != nil}
   /// Clears the value of `defaultValue`. Subsequent reads from it will return its default value.
-  mutating func clearDefaultValue() {self._defaultValue = nil}
+  mutating func clearDefaultValue() {_uniqueStorage()._defaultValue = nil}
 
   /// If set, gives the index of a oneof in the containing type's oneof_decl
   /// list.  This field is a member of that oneof.
   var oneofIndex: Int32 {
-    get {return _oneofIndex ?? 0}
-    set {_oneofIndex = newValue}
+    get {return _storage._oneofIndex ?? 0}
+    set {_uniqueStorage()._oneofIndex = newValue}
   }
   /// Returns true if `oneofIndex` has been explicitly set.
-  var hasOneofIndex: Bool {return self._oneofIndex != nil}
+  var hasOneofIndex: Bool {return _storage._oneofIndex != nil}
   /// Clears the value of `oneofIndex`. Subsequent reads from it will return its default value.
-  mutating func clearOneofIndex() {self._oneofIndex = nil}
+  mutating func clearOneofIndex() {_uniqueStorage()._oneofIndex = nil}
 
   /// JSON name of this field. The value is set by protocol compiler. If the
   /// user has set a "json_name" option on this field, that option's value
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   var jsonName: String {
-    get {return _jsonName ?? String()}
-    set {_jsonName = newValue}
+    get {return _storage._jsonName ?? String()}
+    set {_uniqueStorage()._jsonName = newValue}
   }
   /// Returns true if `jsonName` has been explicitly set.
-  var hasJsonName: Bool {return self._jsonName != nil}
+  var hasJsonName: Bool {return _storage._jsonName != nil}
   /// Clears the value of `jsonName`. Subsequent reads from it will return its default value.
-  mutating func clearJsonName() {self._jsonName = nil}
+  mutating func clearJsonName() {_uniqueStorage()._jsonName = nil}
 
   var options: Google_Protobuf_FieldOptions {
-    get {return _options ?? Google_Protobuf_FieldOptions()}
-    set {_options = newValue}
+    get {return _storage._options ?? Google_Protobuf_FieldOptions()}
+    set {_uniqueStorage()._options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  var hasOptions: Bool {return self._options != nil}
+  var hasOptions: Bool {return _storage._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  mutating func clearOptions() {self._options = nil}
+  mutating func clearOptions() {_uniqueStorage()._options = nil}
 
   /// If true, this is a proto3 "optional". When a proto3 field is optional, it
   /// tracks presence regardless of field type.
@@ -442,13 +442,13 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// Proto2 optional fields do not set this flag, because they already indicate
   /// optional with `LABEL_OPTIONAL`.
   var proto3Optional: Bool {
-    get {return _proto3Optional ?? false}
-    set {_proto3Optional = newValue}
+    get {return _storage._proto3Optional ?? false}
+    set {_uniqueStorage()._proto3Optional = newValue}
   }
   /// Returns true if `proto3Optional` has been explicitly set.
-  var hasProto3Optional: Bool {return self._proto3Optional != nil}
+  var hasProto3Optional: Bool {return _storage._proto3Optional != nil}
   /// Clears the value of `proto3Optional`. Subsequent reads from it will return its default value.
-  mutating func clearProto3Optional() {self._proto3Optional = nil}
+  mutating func clearProto3Optional() {_uniqueStorage()._proto3Optional = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -581,17 +581,7 @@ struct Google_Protobuf_FieldDescriptorProto {
 
   init() {}
 
-  fileprivate var _name: String? = nil
-  fileprivate var _number: Int32? = nil
-  fileprivate var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
-  fileprivate var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
-  fileprivate var _typeName: String? = nil
-  fileprivate var _extendee: String? = nil
-  fileprivate var _defaultValue: String? = nil
-  fileprivate var _oneofIndex: Int32? = nil
-  fileprivate var _jsonName: String? = nil
-  fileprivate var _options: Google_Protobuf_FieldOptions? = nil
-  fileprivate var _proto3Optional: Bool? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -2425,82 +2415,136 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProt
     17: .standard(proto: "proto3_optional"),
   ]
 
+  fileprivate class _StorageClass {
+    var _name: String? = nil
+    var _number: Int32? = nil
+    var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
+    var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
+    var _typeName: String? = nil
+    var _extendee: String? = nil
+    var _defaultValue: String? = nil
+    var _oneofIndex: Int32? = nil
+    var _jsonName: String? = nil
+    var _options: Google_Protobuf_FieldOptions? = nil
+    var _proto3Optional: Bool? = nil
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _name = source._name
+      _number = source._number
+      _label = source._label
+      _type = source._type
+      _typeName = source._typeName
+      _extendee = source._extendee
+      _defaultValue = source._defaultValue
+      _oneofIndex = source._oneofIndex
+      _jsonName = source._jsonName
+      _options = source._options
+      _proto3Optional = source._proto3Optional
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public var isInitialized: Bool {
-    if let v = self._options, !v.isInitialized {return false}
-    return true
+    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._options, !v.isInitialized {return false}
+      return true
+    }
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self._name) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self._extendee) }()
-      case 3: try { try decoder.decodeSingularInt32Field(value: &self._number) }()
-      case 4: try { try decoder.decodeSingularEnumField(value: &self._label) }()
-      case 5: try { try decoder.decodeSingularEnumField(value: &self._type) }()
-      case 6: try { try decoder.decodeSingularStringField(value: &self._typeName) }()
-      case 7: try { try decoder.decodeSingularStringField(value: &self._defaultValue) }()
-      case 8: try { try decoder.decodeSingularMessageField(value: &self._options) }()
-      case 9: try { try decoder.decodeSingularInt32Field(value: &self._oneofIndex) }()
-      case 10: try { try decoder.decodeSingularStringField(value: &self._jsonName) }()
-      case 17: try { try decoder.decodeSingularBoolField(value: &self._proto3Optional) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._name) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._extendee) }()
+        case 3: try { try decoder.decodeSingularInt32Field(value: &_storage._number) }()
+        case 4: try { try decoder.decodeSingularEnumField(value: &_storage._label) }()
+        case 5: try { try decoder.decodeSingularEnumField(value: &_storage._type) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._typeName) }()
+        case 7: try { try decoder.decodeSingularStringField(value: &_storage._defaultValue) }()
+        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._options) }()
+        case 9: try { try decoder.decodeSingularInt32Field(value: &_storage._oneofIndex) }()
+        case 10: try { try decoder.decodeSingularStringField(value: &_storage._jsonName) }()
+        case 17: try { try decoder.decodeSingularBoolField(value: &_storage._proto3Optional) }()
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._name {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    }
-    if let v = self._extendee {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
-    if let v = self._number {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-    }
-    if let v = self._label {
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
-    }
-    if let v = self._type {
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    }
-    if let v = self._typeName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    }
-    if let v = self._defaultValue {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-    }
-    if let v = self._options {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }
-    if let v = self._oneofIndex {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
-    }
-    if let v = self._jsonName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
-    }
-    if let v = self._proto3Optional {
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 17)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._name {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._extendee {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._number {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._label {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
+      }
+      if let v = _storage._type {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+      if let v = _storage._typeName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+      }
+      if let v = _storage._defaultValue {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+      }
+      if let v = _storage._options {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      }
+      if let v = _storage._oneofIndex {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
+      }
+      if let v = _storage._jsonName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+      }
+      if let v = _storage._proto3Optional {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 17)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Google_Protobuf_FieldDescriptorProto, rhs: Google_Protobuf_FieldDescriptorProto) -> Bool {
-    if lhs._name != rhs._name {return false}
-    if lhs._number != rhs._number {return false}
-    if lhs._label != rhs._label {return false}
-    if lhs._type != rhs._type {return false}
-    if lhs._typeName != rhs._typeName {return false}
-    if lhs._extendee != rhs._extendee {return false}
-    if lhs._defaultValue != rhs._defaultValue {return false}
-    if lhs._oneofIndex != rhs._oneofIndex {return false}
-    if lhs._jsonName != rhs._jsonName {return false}
-    if lhs._options != rhs._options {return false}
-    if lhs._proto3Optional != rhs._proto3Optional {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._name != rhs_storage._name {return false}
+        if _storage._number != rhs_storage._number {return false}
+        if _storage._label != rhs_storage._label {return false}
+        if _storage._type != rhs_storage._type {return false}
+        if _storage._typeName != rhs_storage._typeName {return false}
+        if _storage._extendee != rhs_storage._extendee {return false}
+        if _storage._defaultValue != rhs_storage._defaultValue {return false}
+        if _storage._oneofIndex != rhs_storage._oneofIndex {return false}
+        if _storage._jsonName != rhs_storage._jsonName {return false}
+        if _storage._options != rhs_storage._options {return false}
+        if _storage._proto3Optional != rhs_storage._proto3Optional {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -3336,153 +3336,147 @@ struct ProtobufUnittest_TestOneof2 {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOneof2.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooCord: String {
     get {
-      if case .fooCord(let v)? = _storage._foo {return v}
+      if case .fooCord(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooCord(newValue)}
+    set {foo = .fooCord(newValue)}
   }
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v)? = _storage._foo {return v}
+      if case .fooStringPiece(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooStringPiece(newValue)}
+    set {foo = .fooStringPiece(newValue)}
   }
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v)? = _storage._foo {return v}
+      if case .fooBytes(let v)? = foo {return v}
       return Data()
     }
-    set {_uniqueStorage()._foo = .fooBytes(newValue)}
+    set {foo = .fooBytes(newValue)}
   }
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v)? = _storage._foo {return v}
+      if case .fooEnum(let v)? = foo {return v}
       return .foo
     }
-    set {_uniqueStorage()._foo = .fooEnum(newValue)}
+    set {foo = .fooEnum(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {return v}
+      if case .fooGroup(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.FooGroup()
     }
-    set {_uniqueStorage()._foo = .fooGroup(newValue)}
+    set {foo = .fooGroup(newValue)}
   }
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v)? = _storage._foo {return v}
+      if case .fooLazyMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooLazyMessage(newValue)}
+    set {foo = .fooLazyMessage(newValue)}
   }
 
-  var bar: OneOf_Bar? {
-    get {return _storage._bar}
-    set {_uniqueStorage()._bar = newValue}
-  }
+  var bar: ProtobufUnittest_TestOneof2.OneOf_Bar? = nil
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v)? = _storage._bar {return v}
+      if case .barInt(let v)? = bar {return v}
       return 5
     }
-    set {_uniqueStorage()._bar = .barInt(newValue)}
+    set {bar = .barInt(newValue)}
   }
 
   var barString: String {
     get {
-      if case .barString(let v)? = _storage._bar {return v}
+      if case .barString(let v)? = bar {return v}
       return "STRING"
     }
-    set {_uniqueStorage()._bar = .barString(newValue)}
+    set {bar = .barString(newValue)}
   }
 
   var barCord: String {
     get {
-      if case .barCord(let v)? = _storage._bar {return v}
+      if case .barCord(let v)? = bar {return v}
       return "CORD"
     }
-    set {_uniqueStorage()._bar = .barCord(newValue)}
+    set {bar = .barCord(newValue)}
   }
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v)? = _storage._bar {return v}
+      if case .barStringPiece(let v)? = bar {return v}
       return "SPIECE"
     }
-    set {_uniqueStorage()._bar = .barStringPiece(newValue)}
+    set {bar = .barStringPiece(newValue)}
   }
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v)? = _storage._bar {return v}
+      if case .barBytes(let v)? = bar {return v}
       return Data([66, 89, 84, 69, 83])
     }
-    set {_uniqueStorage()._bar = .barBytes(newValue)}
+    set {bar = .barBytes(newValue)}
   }
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v)? = _storage._bar {return v}
+      if case .barEnum(let v)? = bar {return v}
       return .bar
     }
-    set {_uniqueStorage()._bar = .barEnum(newValue)}
+    set {bar = .barEnum(newValue)}
   }
 
   var bazInt: Int32 {
-    get {return _storage._bazInt ?? 0}
-    set {_uniqueStorage()._bazInt = newValue}
+    get {return _bazInt ?? 0}
+    set {_bazInt = newValue}
   }
   /// Returns true if `bazInt` has been explicitly set.
-  var hasBazInt: Bool {return _storage._bazInt != nil}
+  var hasBazInt: Bool {return self._bazInt != nil}
   /// Clears the value of `bazInt`. Subsequent reads from it will return its default value.
-  mutating func clearBazInt() {_uniqueStorage()._bazInt = nil}
+  mutating func clearBazInt() {self._bazInt = nil}
 
   var bazString: String {
-    get {return _storage._bazString ?? "BAZ"}
-    set {_uniqueStorage()._bazString = newValue}
+    get {return _bazString ?? "BAZ"}
+    set {_bazString = newValue}
   }
   /// Returns true if `bazString` has been explicitly set.
-  var hasBazString: Bool {return _storage._bazString != nil}
+  var hasBazString: Bool {return self._bazString != nil}
   /// Clears the value of `bazString`. Subsequent reads from it will return its default value.
-  mutating func clearBazString() {_uniqueStorage()._bazString = nil}
+  mutating func clearBazString() {self._bazString = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3674,7 +3668,8 @@ struct ProtobufUnittest_TestOneof2 {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _bazInt: Int32? = nil
+  fileprivate var _bazString: String? = nil
 }
 
 #if swift(>=4.2)
@@ -11039,243 +11034,205 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
     19: .standard(proto: "baz_string"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
-    var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
-    var _bazInt: Int32? = nil
-    var _bazString: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-      _bar = source._bar
-      _bazInt = source._bazInt
-      _bazString = source._bazString
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        }()
-        case 2: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        }()
-        case 3: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooCord(v)}
-        }()
-        case 4: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooStringPiece(v)}
-        }()
-        case 5: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._foo = .fooBytes(v)}
-        }()
-        case 6: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_TestOneof2.NestedEnum?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._foo = .fooEnum(v)}
-        }()
-        case 7: try {
-          var v: ProtobufUnittest_TestOneof2.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        }()
-        case 8: try {
-          var v: ProtobufUnittest_TestOneof2.FooGroup?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooGroup(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._foo = .fooGroup(v)}
-        }()
-        case 11: try {
-          var v: ProtobufUnittest_TestOneof2.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooLazyMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooLazyMessage(v)}
-        }()
-        case 12: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._bar = .barInt(v)}
-        }()
-        case 13: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barString(v)}
-        }()
-        case 14: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barCord(v)}
-        }()
-        case 15: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barStringPiece(v)}
-        }()
-        case 16: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._bar = .barBytes(v)}
-        }()
-        case 17: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_TestOneof2.NestedEnum?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._bar = .barEnum(v)}
-        }()
-        case 18: try { try decoder.decodeSingularInt32Field(value: &_storage._bazInt) }()
-        case 19: try { try decoder.decodeSingularStringField(value: &_storage._bazString) }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      }()
+      case 2: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      }()
+      case 3: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooCord(v)}
+      }()
+      case 4: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooStringPiece(v)}
+      }()
+      case 5: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.foo = .fooBytes(v)}
+      }()
+      case 6: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_TestOneof2.NestedEnum?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.foo = .fooEnum(v)}
+      }()
+      case 7: try {
+        var v: ProtobufUnittest_TestOneof2.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      }()
+      case 8: try {
+        var v: ProtobufUnittest_TestOneof2.FooGroup?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooGroup(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.foo = .fooGroup(v)}
+      }()
+      case 11: try {
+        var v: ProtobufUnittest_TestOneof2.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooLazyMessage(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooLazyMessage(v)}
+      }()
+      case 12: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.bar = .barInt(v)}
+      }()
+      case 13: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barString(v)}
+      }()
+      case 14: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barCord(v)}
+      }()
+      case 15: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barStringPiece(v)}
+      }()
+      case 16: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.bar = .barBytes(v)}
+      }()
+      case 17: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_TestOneof2.NestedEnum?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.bar = .barEnum(v)}
+      }()
+      case 18: try { try decoder.decodeSingularInt32Field(value: &self._bazInt) }()
+      case 19: try { try decoder.decodeSingularStringField(value: &self._bazString) }()
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._foo {
-      case .fooInt?: try {
-        guard case .fooInt(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }()
-      case .fooString?: try {
-        guard case .fooString(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }()
-      case .fooCord?: try {
-        guard case .fooCord(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      }()
-      case .fooStringPiece?: try {
-        guard case .fooStringPiece(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-      }()
-      case .fooBytes?: try {
-        guard case .fooBytes(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-      }()
-      case .fooEnum?: try {
-        guard case .fooEnum(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-      }()
-      case .fooMessage?: try {
-        guard case .fooMessage(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }()
-      case .fooGroup?: try {
-        guard case .fooGroup(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-      }()
-      case .fooLazyMessage?: try {
-        guard case .fooLazyMessage(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }()
-      case nil: break
-      }
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._bar {
-      case .barInt?: try {
-        guard case .barInt(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-      }()
-      case .barString?: try {
-        guard case .barString(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-      }()
-      case .barCord?: try {
-        guard case .barCord(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-      }()
-      case .barStringPiece?: try {
-        guard case .barStringPiece(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-      }()
-      case .barBytes?: try {
-        guard case .barBytes(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-      }()
-      case .barEnum?: try {
-        guard case .barEnum(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-      }()
-      case nil: break
-      }
-      if let v = _storage._bazInt {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
-      }
-      if let v = _storage._bazString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 19)
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.foo {
+    case .fooInt?: try {
+      guard case .fooInt(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }()
+    case .fooString?: try {
+      guard case .fooString(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }()
+    case .fooCord?: try {
+      guard case .fooCord(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }()
+    case .fooStringPiece?: try {
+      guard case .fooStringPiece(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    }()
+    case .fooBytes?: try {
+      guard case .fooBytes(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+    }()
+    case .fooEnum?: try {
+      guard case .fooEnum(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    }()
+    case .fooMessage?: try {
+      guard case .fooMessage(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }()
+    case .fooGroup?: try {
+      guard case .fooGroup(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+    }()
+    case .fooLazyMessage?: try {
+      guard case .fooLazyMessage(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+    }()
+    case nil: break
+    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.bar {
+    case .barInt?: try {
+      guard case .barInt(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+    }()
+    case .barString?: try {
+      guard case .barString(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+    }()
+    case .barCord?: try {
+      guard case .barCord(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+    }()
+    case .barStringPiece?: try {
+      guard case .barStringPiece(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+    }()
+    case .barBytes?: try {
+      guard case .barBytes(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+    }()
+    case .barEnum?: try {
+      guard case .barEnum(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+    }()
+    case nil: break
+    }
+    if let v = self._bazInt {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
+    }
+    if let v = self._bazString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 19)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneof2, rhs: ProtobufUnittest_TestOneof2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        if _storage._bar != rhs_storage._bar {return false}
-        if _storage._bazInt != rhs_storage._bazInt {return false}
-        if _storage._bazString != rhs_storage._bazString {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
+    if lhs.bar != rhs.bar {return false}
+    if lhs._bazInt != rhs._bazInt {return false}
+    if lhs._bazString != rhs._bazString {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -316,153 +316,150 @@ struct ProtobufUnittest_OneofWellKnownTypes {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField? = nil
 
   var anyField: SwiftProtobuf.Google_Protobuf_Any {
     get {
-      if case .anyField(let v)? = _storage._oneofField {return v}
+      if case .anyField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Any()
     }
-    set {_uniqueStorage()._oneofField = .anyField(newValue)}
+    set {oneofField = .anyField(newValue)}
   }
 
   var apiField: SwiftProtobuf.Google_Protobuf_Api {
     get {
-      if case .apiField(let v)? = _storage._oneofField {return v}
+      if case .apiField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Api()
     }
-    set {_uniqueStorage()._oneofField = .apiField(newValue)}
+    set {oneofField = .apiField(newValue)}
   }
 
   var durationField: SwiftProtobuf.Google_Protobuf_Duration {
     get {
-      if case .durationField(let v)? = _storage._oneofField {return v}
+      if case .durationField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Duration()
     }
-    set {_uniqueStorage()._oneofField = .durationField(newValue)}
+    set {oneofField = .durationField(newValue)}
   }
 
   var emptyField: SwiftProtobuf.Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v)? = _storage._oneofField {return v}
+      if case .emptyField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Empty()
     }
-    set {_uniqueStorage()._oneofField = .emptyField(newValue)}
+    set {oneofField = .emptyField(newValue)}
   }
 
   var fieldMaskField: SwiftProtobuf.Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v)? = _storage._oneofField {return v}
+      if case .fieldMaskField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_FieldMask()
     }
-    set {_uniqueStorage()._oneofField = .fieldMaskField(newValue)}
+    set {oneofField = .fieldMaskField(newValue)}
   }
 
   var sourceContextField: SwiftProtobuf.Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v)? = _storage._oneofField {return v}
+      if case .sourceContextField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_SourceContext()
     }
-    set {_uniqueStorage()._oneofField = .sourceContextField(newValue)}
+    set {oneofField = .sourceContextField(newValue)}
   }
 
   var structField: SwiftProtobuf.Google_Protobuf_Struct {
     get {
-      if case .structField(let v)? = _storage._oneofField {return v}
+      if case .structField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Struct()
     }
-    set {_uniqueStorage()._oneofField = .structField(newValue)}
+    set {oneofField = .structField(newValue)}
   }
 
   var timestampField: SwiftProtobuf.Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v)? = _storage._oneofField {return v}
+      if case .timestampField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Timestamp()
     }
-    set {_uniqueStorage()._oneofField = .timestampField(newValue)}
+    set {oneofField = .timestampField(newValue)}
   }
 
   var typeField: SwiftProtobuf.Google_Protobuf_Type {
     get {
-      if case .typeField(let v)? = _storage._oneofField {return v}
+      if case .typeField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Type()
     }
-    set {_uniqueStorage()._oneofField = .typeField(newValue)}
+    set {oneofField = .typeField(newValue)}
   }
 
   var doubleField: SwiftProtobuf.Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v)? = _storage._oneofField {return v}
+      if case .doubleField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_DoubleValue()
     }
-    set {_uniqueStorage()._oneofField = .doubleField(newValue)}
+    set {oneofField = .doubleField(newValue)}
   }
 
   var floatField: SwiftProtobuf.Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v)? = _storage._oneofField {return v}
+      if case .floatField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_FloatValue()
     }
-    set {_uniqueStorage()._oneofField = .floatField(newValue)}
+    set {oneofField = .floatField(newValue)}
   }
 
   var int64Field: SwiftProtobuf.Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v)? = _storage._oneofField {return v}
+      if case .int64Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Int64Value()
     }
-    set {_uniqueStorage()._oneofField = .int64Field(newValue)}
+    set {oneofField = .int64Field(newValue)}
   }
 
   var uint64Field: SwiftProtobuf.Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v)? = _storage._oneofField {return v}
+      if case .uint64Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_UInt64Value()
     }
-    set {_uniqueStorage()._oneofField = .uint64Field(newValue)}
+    set {oneofField = .uint64Field(newValue)}
   }
 
   var int32Field: SwiftProtobuf.Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v)? = _storage._oneofField {return v}
+      if case .int32Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Int32Value()
     }
-    set {_uniqueStorage()._oneofField = .int32Field(newValue)}
+    set {oneofField = .int32Field(newValue)}
   }
 
   var uint32Field: SwiftProtobuf.Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v)? = _storage._oneofField {return v}
+      if case .uint32Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_UInt32Value()
     }
-    set {_uniqueStorage()._oneofField = .uint32Field(newValue)}
+    set {oneofField = .uint32Field(newValue)}
   }
 
   var boolField: SwiftProtobuf.Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v)? = _storage._oneofField {return v}
+      if case .boolField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_BoolValue()
     }
-    set {_uniqueStorage()._oneofField = .boolField(newValue)}
+    set {oneofField = .boolField(newValue)}
   }
 
   var stringField: SwiftProtobuf.Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v)? = _storage._oneofField {return v}
+      if case .stringField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_StringValue()
     }
-    set {_uniqueStorage()._oneofField = .stringField(newValue)}
+    set {oneofField = .stringField(newValue)}
   }
 
   var bytesField: SwiftProtobuf.Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v)? = _storage._oneofField {return v}
+      if case .bytesField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_BytesValue()
     }
-    set {_uniqueStorage()._oneofField = .bytesField(newValue)}
+    set {oneofField = .bytesField(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -572,8 +569,6 @@ struct ProtobufUnittest_OneofWellKnownTypes {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// A map field for each well-known type. We only
@@ -1116,295 +1111,263 @@ extension ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProt
     18: .standard(proto: "bytes_field"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try {
-          var v: SwiftProtobuf.Google_Protobuf_Any?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .anyField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .anyField(v)}
-        }()
-        case 2: try {
-          var v: SwiftProtobuf.Google_Protobuf_Api?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .apiField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .apiField(v)}
-        }()
-        case 3: try {
-          var v: SwiftProtobuf.Google_Protobuf_Duration?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .durationField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .durationField(v)}
-        }()
-        case 4: try {
-          var v: SwiftProtobuf.Google_Protobuf_Empty?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .emptyField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .emptyField(v)}
-        }()
-        case 5: try {
-          var v: SwiftProtobuf.Google_Protobuf_FieldMask?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .fieldMaskField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .fieldMaskField(v)}
-        }()
-        case 6: try {
-          var v: SwiftProtobuf.Google_Protobuf_SourceContext?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .sourceContextField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .sourceContextField(v)}
-        }()
-        case 7: try {
-          var v: SwiftProtobuf.Google_Protobuf_Struct?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .structField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .structField(v)}
-        }()
-        case 8: try {
-          var v: SwiftProtobuf.Google_Protobuf_Timestamp?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .timestampField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .timestampField(v)}
-        }()
-        case 9: try {
-          var v: SwiftProtobuf.Google_Protobuf_Type?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .typeField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .typeField(v)}
-        }()
-        case 10: try {
-          var v: SwiftProtobuf.Google_Protobuf_DoubleValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .doubleField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .doubleField(v)}
-        }()
-        case 11: try {
-          var v: SwiftProtobuf.Google_Protobuf_FloatValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .floatField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .floatField(v)}
-        }()
-        case 12: try {
-          var v: SwiftProtobuf.Google_Protobuf_Int64Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .int64Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .int64Field(v)}
-        }()
-        case 13: try {
-          var v: SwiftProtobuf.Google_Protobuf_UInt64Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .uint64Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .uint64Field(v)}
-        }()
-        case 14: try {
-          var v: SwiftProtobuf.Google_Protobuf_Int32Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .int32Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .int32Field(v)}
-        }()
-        case 15: try {
-          var v: SwiftProtobuf.Google_Protobuf_UInt32Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .uint32Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .uint32Field(v)}
-        }()
-        case 16: try {
-          var v: SwiftProtobuf.Google_Protobuf_BoolValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .boolField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .boolField(v)}
-        }()
-        case 17: try {
-          var v: SwiftProtobuf.Google_Protobuf_StringValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .stringField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .stringField(v)}
-        }()
-        case 18: try {
-          var v: SwiftProtobuf.Google_Protobuf_BytesValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .bytesField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .bytesField(v)}
-        }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try {
+        var v: SwiftProtobuf.Google_Protobuf_Any?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .anyField(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .anyField(v)}
+      }()
+      case 2: try {
+        var v: SwiftProtobuf.Google_Protobuf_Api?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .apiField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .apiField(v)}
+      }()
+      case 3: try {
+        var v: SwiftProtobuf.Google_Protobuf_Duration?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .durationField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .durationField(v)}
+      }()
+      case 4: try {
+        var v: SwiftProtobuf.Google_Protobuf_Empty?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .emptyField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .emptyField(v)}
+      }()
+      case 5: try {
+        var v: SwiftProtobuf.Google_Protobuf_FieldMask?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .fieldMaskField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .fieldMaskField(v)}
+      }()
+      case 6: try {
+        var v: SwiftProtobuf.Google_Protobuf_SourceContext?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .sourceContextField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .sourceContextField(v)}
+      }()
+      case 7: try {
+        var v: SwiftProtobuf.Google_Protobuf_Struct?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .structField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .structField(v)}
+      }()
+      case 8: try {
+        var v: SwiftProtobuf.Google_Protobuf_Timestamp?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .timestampField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .timestampField(v)}
+      }()
+      case 9: try {
+        var v: SwiftProtobuf.Google_Protobuf_Type?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .typeField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .typeField(v)}
+      }()
+      case 10: try {
+        var v: SwiftProtobuf.Google_Protobuf_DoubleValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .doubleField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .doubleField(v)}
+      }()
+      case 11: try {
+        var v: SwiftProtobuf.Google_Protobuf_FloatValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .floatField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .floatField(v)}
+      }()
+      case 12: try {
+        var v: SwiftProtobuf.Google_Protobuf_Int64Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .int64Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .int64Field(v)}
+      }()
+      case 13: try {
+        var v: SwiftProtobuf.Google_Protobuf_UInt64Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .uint64Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .uint64Field(v)}
+      }()
+      case 14: try {
+        var v: SwiftProtobuf.Google_Protobuf_Int32Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .int32Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .int32Field(v)}
+      }()
+      case 15: try {
+        var v: SwiftProtobuf.Google_Protobuf_UInt32Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .uint32Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .uint32Field(v)}
+      }()
+      case 16: try {
+        var v: SwiftProtobuf.Google_Protobuf_BoolValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .boolField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .boolField(v)}
+      }()
+      case 17: try {
+        var v: SwiftProtobuf.Google_Protobuf_StringValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .stringField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .stringField(v)}
+      }()
+      case 18: try {
+        var v: SwiftProtobuf.Google_Protobuf_BytesValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .bytesField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .bytesField(v)}
+      }()
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._oneofField {
-      case .anyField?: try {
-        guard case .anyField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }()
-      case .apiField?: try {
-        guard case .apiField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }()
-      case .durationField?: try {
-        guard case .durationField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }()
-      case .emptyField?: try {
-        guard case .emptyField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }()
-      case .fieldMaskField?: try {
-        guard case .fieldMaskField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }()
-      case .sourceContextField?: try {
-        guard case .sourceContextField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }()
-      case .structField?: try {
-        guard case .structField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }()
-      case .timestampField?: try {
-        guard case .timestampField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }()
-      case .typeField?: try {
-        guard case .typeField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }()
-      case .doubleField?: try {
-        guard case .doubleField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }()
-      case .floatField?: try {
-        guard case .floatField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }()
-      case .int64Field?: try {
-        guard case .int64Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-      }()
-      case .uint64Field?: try {
-        guard case .uint64Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-      }()
-      case .int32Field?: try {
-        guard case .int32Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-      }()
-      case .uint32Field?: try {
-        guard case .uint32Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-      }()
-      case .boolField?: try {
-        guard case .boolField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-      }()
-      case .stringField?: try {
-        guard case .stringField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-      }()
-      case .bytesField?: try {
-        guard case .bytesField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-      }()
-      case nil: break
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.oneofField {
+    case .anyField?: try {
+      guard case .anyField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }()
+    case .apiField?: try {
+      guard case .apiField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .durationField?: try {
+      guard case .durationField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case .emptyField?: try {
+      guard case .emptyField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }()
+    case .fieldMaskField?: try {
+      guard case .fieldMaskField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }()
+    case .sourceContextField?: try {
+      guard case .sourceContextField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .structField?: try {
+      guard case .structField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }()
+    case .timestampField?: try {
+      guard case .timestampField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }()
+    case .typeField?: try {
+      guard case .typeField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }()
+    case .doubleField?: try {
+      guard case .doubleField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    }()
+    case .floatField?: try {
+      guard case .floatField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+    }()
+    case .int64Field?: try {
+      guard case .int64Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+    }()
+    case .uint64Field?: try {
+      guard case .uint64Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+    }()
+    case .int32Field?: try {
+      guard case .int32Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+    }()
+    case .uint32Field?: try {
+      guard case .uint32Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    }()
+    case .boolField?: try {
+      guard case .boolField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+    }()
+    case .stringField?: try {
+      guard case .stringField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+    }()
+    case .bytesField?: try {
+      guard case .bytesField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+    }()
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes, rhs: ProtobufUnittest_OneofWellKnownTypes) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -286,29 +286,28 @@ struct SDTExternalRefs {
   // methods supported on all messages.
 
   var desc: SwiftProtobuf.Google_Protobuf_DescriptorProto {
-    get {return _desc ?? SwiftProtobuf.Google_Protobuf_DescriptorProto()}
-    set {_desc = newValue}
+    get {return _storage._desc ?? SwiftProtobuf.Google_Protobuf_DescriptorProto()}
+    set {_uniqueStorage()._desc = newValue}
   }
   /// Returns true if `desc` has been explicitly set.
-  var hasDesc: Bool {return self._desc != nil}
+  var hasDesc: Bool {return _storage._desc != nil}
   /// Clears the value of `desc`. Subsequent reads from it will return its default value.
-  mutating func clearDesc() {self._desc = nil}
+  mutating func clearDesc() {_uniqueStorage()._desc = nil}
 
   var ver: Google_Protobuf_Compiler_Version {
-    get {return _ver ?? Google_Protobuf_Compiler_Version()}
-    set {_ver = newValue}
+    get {return _storage._ver ?? Google_Protobuf_Compiler_Version()}
+    set {_uniqueStorage()._ver = newValue}
   }
   /// Returns true if `ver` has been explicitly set.
-  var hasVer: Bool {return self._ver != nil}
+  var hasVer: Bool {return _storage._ver != nil}
   /// Clears the value of `ver`. Subsequent reads from it will return its default value.
-  mutating func clearVer() {self._ver = nil}
+  mutating func clearVer() {_uniqueStorage()._ver = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _desc: SwiftProtobuf.Google_Protobuf_DescriptorProto? = nil
-  fileprivate var _ver: Google_Protobuf_Compiler_Version? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 struct SDTScoperForExt {
@@ -894,37 +893,73 @@ extension SDTExternalRefs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
     2: .same(proto: "ver"),
   ]
 
+  fileprivate class _StorageClass {
+    var _desc: SwiftProtobuf.Google_Protobuf_DescriptorProto? = nil
+    var _ver: Google_Protobuf_Compiler_Version? = nil
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _desc = source._desc
+      _ver = source._ver
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public var isInitialized: Bool {
-    if let v = self._desc, !v.isInitialized {return false}
-    return true
+    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._desc, !v.isInitialized {return false}
+      return true
+    }
   }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularMessageField(value: &self._desc) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._ver) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._desc) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._ver) }()
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._desc {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ver {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._desc {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._ver {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SDTExternalRefs, rhs: SDTExternalRefs) -> Bool {
-    if lhs._desc != rhs._desc {return false}
-    if lhs._ver != rhs._ver {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._desc != rhs_storage._desc {return false}
+        if _storage._ver != rhs_storage._ver {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -311,42 +311,42 @@ public struct Google_Protobuf_FieldDescriptorProto {
   // methods supported on all messages.
 
   public var name: String {
-    get {return _name ?? String()}
-    set {_name = newValue}
+    get {return _storage._name ?? String()}
+    set {_uniqueStorage()._name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {return self._name != nil}
+  public var hasName: Bool {return _storage._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
-  public mutating func clearName() {self._name = nil}
+  public mutating func clearName() {_uniqueStorage()._name = nil}
 
   public var number: Int32 {
-    get {return _number ?? 0}
-    set {_number = newValue}
+    get {return _storage._number ?? 0}
+    set {_uniqueStorage()._number = newValue}
   }
   /// Returns true if `number` has been explicitly set.
-  public var hasNumber: Bool {return self._number != nil}
+  public var hasNumber: Bool {return _storage._number != nil}
   /// Clears the value of `number`. Subsequent reads from it will return its default value.
-  public mutating func clearNumber() {self._number = nil}
+  public mutating func clearNumber() {_uniqueStorage()._number = nil}
 
   public var label: Google_Protobuf_FieldDescriptorProto.Label {
-    get {return _label ?? .optional}
-    set {_label = newValue}
+    get {return _storage._label ?? .optional}
+    set {_uniqueStorage()._label = newValue}
   }
   /// Returns true if `label` has been explicitly set.
-  public var hasLabel: Bool {return self._label != nil}
+  public var hasLabel: Bool {return _storage._label != nil}
   /// Clears the value of `label`. Subsequent reads from it will return its default value.
-  public mutating func clearLabel() {self._label = nil}
+  public mutating func clearLabel() {_uniqueStorage()._label = nil}
 
   /// If type_name is set, this need not be set.  If both this and type_name
   /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   public var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
-    get {return _type ?? .double}
-    set {_type = newValue}
+    get {return _storage._type ?? .double}
+    set {_uniqueStorage()._type = newValue}
   }
   /// Returns true if `type` has been explicitly set.
-  public var hasType: Bool {return self._type != nil}
+  public var hasType: Bool {return _storage._type != nil}
   /// Clears the value of `type`. Subsequent reads from it will return its default value.
-  public mutating func clearType() {self._type = nil}
+  public mutating func clearType() {_uniqueStorage()._type = nil}
 
   /// For message and enum types, this is the name of the type.  If the name
   /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
@@ -354,24 +354,24 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   public var typeName: String {
-    get {return _typeName ?? String()}
-    set {_typeName = newValue}
+    get {return _storage._typeName ?? String()}
+    set {_uniqueStorage()._typeName = newValue}
   }
   /// Returns true if `typeName` has been explicitly set.
-  public var hasTypeName: Bool {return self._typeName != nil}
+  public var hasTypeName: Bool {return _storage._typeName != nil}
   /// Clears the value of `typeName`. Subsequent reads from it will return its default value.
-  public mutating func clearTypeName() {self._typeName = nil}
+  public mutating func clearTypeName() {_uniqueStorage()._typeName = nil}
 
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   public var extendee: String {
-    get {return _extendee ?? String()}
-    set {_extendee = newValue}
+    get {return _storage._extendee ?? String()}
+    set {_uniqueStorage()._extendee = newValue}
   }
   /// Returns true if `extendee` has been explicitly set.
-  public var hasExtendee: Bool {return self._extendee != nil}
+  public var hasExtendee: Bool {return _storage._extendee != nil}
   /// Clears the value of `extendee`. Subsequent reads from it will return its default value.
-  public mutating func clearExtendee() {self._extendee = nil}
+  public mutating func clearExtendee() {_uniqueStorage()._extendee = nil}
 
   /// For numeric types, contains the original text representation of the value.
   /// For booleans, "true" or "false".
@@ -379,46 +379,46 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   public var defaultValue: String {
-    get {return _defaultValue ?? String()}
-    set {_defaultValue = newValue}
+    get {return _storage._defaultValue ?? String()}
+    set {_uniqueStorage()._defaultValue = newValue}
   }
   /// Returns true if `defaultValue` has been explicitly set.
-  public var hasDefaultValue: Bool {return self._defaultValue != nil}
+  public var hasDefaultValue: Bool {return _storage._defaultValue != nil}
   /// Clears the value of `defaultValue`. Subsequent reads from it will return its default value.
-  public mutating func clearDefaultValue() {self._defaultValue = nil}
+  public mutating func clearDefaultValue() {_uniqueStorage()._defaultValue = nil}
 
   /// If set, gives the index of a oneof in the containing type's oneof_decl
   /// list.  This field is a member of that oneof.
   public var oneofIndex: Int32 {
-    get {return _oneofIndex ?? 0}
-    set {_oneofIndex = newValue}
+    get {return _storage._oneofIndex ?? 0}
+    set {_uniqueStorage()._oneofIndex = newValue}
   }
   /// Returns true if `oneofIndex` has been explicitly set.
-  public var hasOneofIndex: Bool {return self._oneofIndex != nil}
+  public var hasOneofIndex: Bool {return _storage._oneofIndex != nil}
   /// Clears the value of `oneofIndex`. Subsequent reads from it will return its default value.
-  public mutating func clearOneofIndex() {self._oneofIndex = nil}
+  public mutating func clearOneofIndex() {_uniqueStorage()._oneofIndex = nil}
 
   /// JSON name of this field. The value is set by protocol compiler. If the
   /// user has set a "json_name" option on this field, that option's value
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   public var jsonName: String {
-    get {return _jsonName ?? String()}
-    set {_jsonName = newValue}
+    get {return _storage._jsonName ?? String()}
+    set {_uniqueStorage()._jsonName = newValue}
   }
   /// Returns true if `jsonName` has been explicitly set.
-  public var hasJsonName: Bool {return self._jsonName != nil}
+  public var hasJsonName: Bool {return _storage._jsonName != nil}
   /// Clears the value of `jsonName`. Subsequent reads from it will return its default value.
-  public mutating func clearJsonName() {self._jsonName = nil}
+  public mutating func clearJsonName() {_uniqueStorage()._jsonName = nil}
 
   public var options: Google_Protobuf_FieldOptions {
-    get {return _options ?? Google_Protobuf_FieldOptions()}
-    set {_options = newValue}
+    get {return _storage._options ?? Google_Protobuf_FieldOptions()}
+    set {_uniqueStorage()._options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {return self._options != nil}
+  public var hasOptions: Bool {return _storage._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {self._options = nil}
+  public mutating func clearOptions() {_uniqueStorage()._options = nil}
 
   /// If true, this is a proto3 "optional". When a proto3 field is optional, it
   /// tracks presence regardless of field type.
@@ -442,13 +442,13 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// Proto2 optional fields do not set this flag, because they already indicate
   /// optional with `LABEL_OPTIONAL`.
   public var proto3Optional: Bool {
-    get {return _proto3Optional ?? false}
-    set {_proto3Optional = newValue}
+    get {return _storage._proto3Optional ?? false}
+    set {_uniqueStorage()._proto3Optional = newValue}
   }
   /// Returns true if `proto3Optional` has been explicitly set.
-  public var hasProto3Optional: Bool {return self._proto3Optional != nil}
+  public var hasProto3Optional: Bool {return _storage._proto3Optional != nil}
   /// Clears the value of `proto3Optional`. Subsequent reads from it will return its default value.
-  public mutating func clearProto3Optional() {self._proto3Optional = nil}
+  public mutating func clearProto3Optional() {_uniqueStorage()._proto3Optional = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -581,17 +581,7 @@ public struct Google_Protobuf_FieldDescriptorProto {
 
   public init() {}
 
-  fileprivate var _name: String? = nil
-  fileprivate var _number: Int32? = nil
-  fileprivate var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
-  fileprivate var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
-  fileprivate var _typeName: String? = nil
-  fileprivate var _extendee: String? = nil
-  fileprivate var _defaultValue: String? = nil
-  fileprivate var _oneofIndex: Int32? = nil
-  fileprivate var _jsonName: String? = nil
-  fileprivate var _options: Google_Protobuf_FieldOptions? = nil
-  fileprivate var _proto3Optional: Bool? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 #if swift(>=4.2)
@@ -2425,82 +2415,136 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProt
     17: .standard(proto: "proto3_optional"),
   ]
 
+  fileprivate class _StorageClass {
+    var _name: String? = nil
+    var _number: Int32? = nil
+    var _label: Google_Protobuf_FieldDescriptorProto.Label? = nil
+    var _type: Google_Protobuf_FieldDescriptorProto.TypeEnum? = nil
+    var _typeName: String? = nil
+    var _extendee: String? = nil
+    var _defaultValue: String? = nil
+    var _oneofIndex: Int32? = nil
+    var _jsonName: String? = nil
+    var _options: Google_Protobuf_FieldOptions? = nil
+    var _proto3Optional: Bool? = nil
+
+    static let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _name = source._name
+      _number = source._number
+      _label = source._label
+      _type = source._type
+      _typeName = source._typeName
+      _extendee = source._extendee
+      _defaultValue = source._defaultValue
+      _oneofIndex = source._oneofIndex
+      _jsonName = source._jsonName
+      _options = source._options
+      _proto3Optional = source._proto3Optional
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public var isInitialized: Bool {
-    if let v = self._options, !v.isInitialized {return false}
-    return true
+    return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._options, !v.isInitialized {return false}
+      return true
+    }
   }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self._name) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self._extendee) }()
-      case 3: try { try decoder.decodeSingularInt32Field(value: &self._number) }()
-      case 4: try { try decoder.decodeSingularEnumField(value: &self._label) }()
-      case 5: try { try decoder.decodeSingularEnumField(value: &self._type) }()
-      case 6: try { try decoder.decodeSingularStringField(value: &self._typeName) }()
-      case 7: try { try decoder.decodeSingularStringField(value: &self._defaultValue) }()
-      case 8: try { try decoder.decodeSingularMessageField(value: &self._options) }()
-      case 9: try { try decoder.decodeSingularInt32Field(value: &self._oneofIndex) }()
-      case 10: try { try decoder.decodeSingularStringField(value: &self._jsonName) }()
-      case 17: try { try decoder.decodeSingularBoolField(value: &self._proto3Optional) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._name) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._extendee) }()
+        case 3: try { try decoder.decodeSingularInt32Field(value: &_storage._number) }()
+        case 4: try { try decoder.decodeSingularEnumField(value: &_storage._label) }()
+        case 5: try { try decoder.decodeSingularEnumField(value: &_storage._type) }()
+        case 6: try { try decoder.decodeSingularStringField(value: &_storage._typeName) }()
+        case 7: try { try decoder.decodeSingularStringField(value: &_storage._defaultValue) }()
+        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._options) }()
+        case 9: try { try decoder.decodeSingularInt32Field(value: &_storage._oneofIndex) }()
+        case 10: try { try decoder.decodeSingularStringField(value: &_storage._jsonName) }()
+        case 17: try { try decoder.decodeSingularBoolField(value: &_storage._proto3Optional) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._name {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    }
-    if let v = self._extendee {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
-    if let v = self._number {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-    }
-    if let v = self._label {
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
-    }
-    if let v = self._type {
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    }
-    if let v = self._typeName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    }
-    if let v = self._defaultValue {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 7)
-    }
-    if let v = self._options {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    }
-    if let v = self._oneofIndex {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
-    }
-    if let v = self._jsonName {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
-    }
-    if let v = self._proto3Optional {
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 17)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if let v = _storage._name {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      }
+      if let v = _storage._extendee {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+      if let v = _storage._number {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
+      }
+      if let v = _storage._label {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
+      }
+      if let v = _storage._type {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+      if let v = _storage._typeName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+      }
+      if let v = _storage._defaultValue {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 7)
+      }
+      if let v = _storage._options {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      }
+      if let v = _storage._oneofIndex {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
+      }
+      if let v = _storage._jsonName {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+      }
+      if let v = _storage._proto3Optional {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 17)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Google_Protobuf_FieldDescriptorProto, rhs: Google_Protobuf_FieldDescriptorProto) -> Bool {
-    if lhs._name != rhs._name {return false}
-    if lhs._number != rhs._number {return false}
-    if lhs._label != rhs._label {return false}
-    if lhs._type != rhs._type {return false}
-    if lhs._typeName != rhs._typeName {return false}
-    if lhs._extendee != rhs._extendee {return false}
-    if lhs._defaultValue != rhs._defaultValue {return false}
-    if lhs._oneofIndex != rhs._oneofIndex {return false}
-    if lhs._jsonName != rhs._jsonName {return false}
-    if lhs._options != rhs._options {return false}
-    if lhs._proto3Optional != rhs._proto3Optional {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._name != rhs_storage._name {return false}
+        if _storage._number != rhs_storage._number {return false}
+        if _storage._label != rhs_storage._label {return false}
+        if _storage._type != rhs_storage._type {return false}
+        if _storage._typeName != rhs_storage._typeName {return false}
+        if _storage._extendee != rhs_storage._extendee {return false}
+        if _storage._defaultValue != rhs_storage._defaultValue {return false}
+        if _storage._oneofIndex != rhs_storage._oneofIndex {return false}
+        if _storage._jsonName != rhs_storage._jsonName {return false}
+        if _storage._options != rhs_storage._options {return false}
+        if _storage._proto3Optional != rhs_storage._proto3Optional {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/protoc-gen-swift/CMakeLists.txt
+++ b/Sources/protoc-gen-swift/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(protoc-gen-swift
   MessageFieldGenerator.swift
   MessageGenerator.swift
   MessageStorageClassGenerator.swift
+  MessageStorageDecision.swift
   OneofGenerator.swift
   StringUtils.swift
   Version.swift)

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -73,44 +73,6 @@ extension Descriptor {
     return helper(self)
   }
 
-  /// Returns True if this message recurisvely contains itself as a singular
-  /// field.
-  func containsRecursiveSingularField() -> Bool {
-    let initialFile = self.file!
-
-    func helper(_ descriptor: Descriptor, messageStack: [Descriptor]) -> Bool {
-      var messageStack = messageStack
-      messageStack.append(descriptor)
-      return descriptor.fields.contains {
-        guard $0.label != .repeated else { return false }
-        // Ignore fields that aren’t messages or groups.
-        guard $0.type == .message || $0.type == .group else { return false }
-        guard let messageType = $0.messageType else { return false }
-
-        // Proto files are a graph without cycles, to be recursive, the messages
-        // in the cycle must be defined in the same file.
-        guard messageType.file === initialFile else { return false }
-
-        // Did things recurse?
-        if let first = messageStack.firstIndex(where: { $0 === messageType }) {
-          // Yes, to the message being checked.
-          if first == messageStack.startIndex {
-            return true
-          }
-
-          // It recursed to something lower in the graph, so no need to
-          // process it again.
-          return false
-        }
-
-        // Examine sub-message.
-        return helper(messageType, messageStack: messageStack)
-      }
-    }
-
-    return helper(self, messageStack: [])
-  }
-
   /// A `String` containing a comma-delimited list of Swift range expressions
   /// covering the extension ranges for this message.
   ///

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -85,13 +85,15 @@ extension Descriptor {
         guard $0.type == .message || $0.type == .group else { return false }
         guard let messageType = $0.messageType else { return false }
 
-        // We only care if the message or sub-message recurses to the root message.
-        if messageType === messageStack[0] {
-          return true
-        }
+        // Did things recurse?
+        if let first = messageStack.firstIndex(where: { $0 === messageType }) {
+          // Yes, to the message being checked.
+          if first == messageStack.startIndex {
+            return true
+          }
 
-        // Skip other messages already messageStack.
-        if (messageStack.contains { $0 === messageType }) {
+          // It recursed to something lower in the graph, so no need to
+          // process it again.
           return false
         }
 

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -76,6 +76,8 @@ extension Descriptor {
   /// Returns True if this message recurisvely contains itself as a singular
   /// field.
   func containsRecursiveSingularField() -> Bool {
+    let initialFile = self.file!
+
     func helper(_ descriptor: Descriptor, messageStack: [Descriptor]) -> Bool {
       var messageStack = messageStack
       messageStack.append(descriptor)
@@ -84,6 +86,10 @@ extension Descriptor {
         // Ignore fields that aren’t messages or groups.
         guard $0.type == .message || $0.type == .group else { return false }
         guard let messageType = $0.messageType else { return false }
+
+        // Proto files are a graph without cycles, to be recursive, the messages
+        // in the cycle must be defined in the same file.
+        guard messageType.file === initialFile else { return false }
 
         // Did things recurse?
         if let first = messageStack.firstIndex(where: { $0 === messageType }) {

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -160,7 +160,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
     }
 
     func generateIsInitializedCheck(printer p: inout CodePrinter) {
-        guard isGroupOrMessage && fieldDescriptor.messageType.hasRequiredFields() else { return }
+        guard isGroupOrMessage && fieldDescriptor.messageType.containsRequiredFields() else { return }
 
         if isRepeated {  // Map or Array
             p.print("if !\(namer.swiftProtobufModuleName).Internal.areAllInitialized(\(storedProperty)) {return false}\n")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -53,7 +53,7 @@ class MessageGenerator {
     // when the message has one or more oneof{}s. As that will efficively
     // reduce the real number of fields and the message might not need heap
     // storage yet.
-    let useHeapStorage = isAnyMessage || descriptor.fields.count > 16 || hasRecursiveSingularField(descriptor: descriptor)
+    let useHeapStorage = isAnyMessage || descriptor.fields.count > 16 || descriptor.containsRecursiveSingularField()
 
     oneofs = descriptor.realOneofs.map {
       return OneofGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer, usesHeapStorage: useHeapStorage)
@@ -503,39 +503,6 @@ class MessageGenerator {
       p.outdent()
       p.print("}\n")
     }
-  }
-}
-
-fileprivate func hasRecursiveSingularField(descriptor: Descriptor, visited: [Descriptor] = []) -> Bool {
-  var visited = visited
-  visited.append(descriptor)
-  return descriptor.fields.contains {
-    // Ignore fields that aren’t messages or groups.
-    if $0.type != .message && $0.type != .group {
-      return false
-    }
-
-    // Repeated fields already use heap storage (for the array).
-    if $0.label == .repeated {
-      return false
-    }
-
-    guard let messageType = $0.messageType else {
-      return false
-    }
-
-    // We only care if the message or sub-message recurses to the root message.
-    if messageType === visited[0] {
-      return true
-    }
-
-    // Skip other visited fields.
-    if (visited.contains { $0 === messageType }) {
-      return false
-    }
-
-    // Examine sub-message.
-    return hasRecursiveSingularField(descriptor: messageType, visited: visited)
   }
 }
 

--- a/Sources/protoc-gen-swift/MessageStorageDecision.swift
+++ b/Sources/protoc-gen-swift/MessageStorageDecision.swift
@@ -1,0 +1,149 @@
+// Sources/protoc-gen-swift/MessageGenerator.swift - Per-message logic
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+
+import SwiftProtobufPluginLibrary
+
+// The file attempts to isolate the decisions around when to use heap based
+// storage vs. inlining it into the value times. At the moment the decicions
+// are entirely based on field counts and language requires, but this could be
+// revised in the future to better account for the actually *real* memory
+// impacts.
+
+/// Wraps the calcuation of the "cost" of fields.
+///
+/// As mentioned in the file comment, these numbers can be revised in the futute
+/// to compute a real stack/heap cost if desired.
+fileprivate enum FieldCost {
+  /// Of a repeated field.
+  static let repeated = 1
+  /// Of a map field.
+  static let map = 1
+
+  /// Of "Plan Old Data" (ints, floating point) field that is 64 bits
+  static let singlePOD32 = 1
+  /// Of "Plan Old Data" (ints, floating point) field that is 64 bits
+  static let singlePOD64 = 1
+  /// Of bool field.
+  static let singleBool = 1
+  /// Of a `string` field.
+  static let singleString = 1
+  /// Of a `bytes` field.
+  static let singleBytes = 1
+
+  /// A single Message field where the message in question uses storgage.
+  static let singleMessageFieldUsingStorage = 1
+
+  static func estimate(_ field: FieldDescriptor) -> Int {
+    guard field.label != .repeated else {
+      // Repeated fields don't count the exact types, just fixed costs.
+      return field.isMap ? FieldCost.map : FieldCost.repeated
+    }
+
+    switch field.type {
+    case .bool:
+      return 1
+    case .int32, .sint32, .uint32, .fixed32, .sfixed32, .float, .enum:
+      return FieldCost.singlePOD32
+    case .int64, .sint64, .uint64, .fixed64, .sfixed64, .double:
+      return FieldCost.singlePOD64
+    case .string:
+      return FieldCost.singleString
+    case .bytes:
+      return FieldCost.singleBytes
+    case .group, .message:
+      return analyse(descriptor: field.messageType!).costAsField
+    }
+  }
+}
+
+/// Maxium computed cost of a Message's fields allow before it uses Storage.
+fileprivate let totalFieldCostRequiringStorage = 17
+
+/// The result of analysis, if the message should use heap storage and the
+/// cost of the message when used as a field in other messages.
+fileprivate struct AnalyseResult {
+  let usesStorage: Bool
+  let costAsField: Int
+
+  init(usesStorage: Bool, costAsField: Int) {
+    precondition(costAsField < totalFieldCostRequiringStorage || usesStorage)
+    self.usesStorage = usesStorage
+    self.costAsField = costAsField
+  }
+
+  @inlinable
+  init(_ costAsField: Int) {
+    self.init(usesStorage: false, costAsField: costAsField)
+  }
+
+  /// The message should use storage.
+  static let useStorage =
+    Self(usesStorage: true, costAsField: FieldCost.singleMessageFieldUsingStorage)
+}
+
+/// Cache for the `analyse(descriptor:)` results to avoid doing them multiple
+/// times.
+fileprivate var analysisCache: Dictionary<String,AnalyseResult> = [
+  // google.protobuf.Any can be seeded.
+  ".google.protobuf.Any": .useStorage,
+]
+
+/// Analyse the given descriptor to decide if it should use storage and what
+/// the cost of it will be when appearing as a single field in another message.
+fileprivate func analyse(descriptor: Descriptor) -> AnalyseResult {
+  if let analysis = analysisCache[descriptor.fullName] {
+    return analysis
+  }
+
+  func helper(_ descriptor: Descriptor) -> AnalyseResult {
+    if descriptor.containsRecursiveSingularField() {
+      return .useStorage
+    }
+
+    var fieldsCost: Int = 0
+
+    // Compute a cost for all the fields that aren't in a oneof.
+    for f in descriptor.fields {
+      guard f.oneofIndex == nil else { continue }
+      fieldsCost += FieldCost.estimate(f)
+      if fieldsCost >= totalFieldCostRequiringStorage {
+        return .useStorage
+      }
+    }
+
+    // Add in the cost of the largest field of each oneof.
+    for o in descriptor.oneofs {
+      var oneofCost: Int = 0
+      for f in o.fields {
+        oneofCost = max(oneofCost, FieldCost.estimate(f))
+        if (fieldsCost + oneofCost) >= totalFieldCostRequiringStorage {
+          return .useStorage
+        }
+      }
+      fieldsCost += oneofCost
+    }
+    assert(fieldsCost <= totalFieldCostRequiringStorage)
+
+    return AnalyseResult(fieldsCost)
+  }
+
+  let result = helper(descriptor)
+  analysisCache[descriptor.fullName] = result
+  return result
+}
+
+/// Encapsulates the decision choices around when a Message should use
+/// heap based storage.
+enum MessageStorageDecision {
+  /// Compute if a message should use heap based sortage or not.
+  static func shouldUseHeapStorage(descriptor: Descriptor) -> Bool {
+    return analyse(descriptor: descriptor).usesStorage
+  }
+}

--- a/Sources/protoc-gen-swift/MessageStorageDecision.swift
+++ b/Sources/protoc-gen-swift/MessageStorageDecision.swift
@@ -58,7 +58,7 @@ fileprivate enum FieldCost {
     case .bytes:
       return FieldCost.singleBytes
     case .group, .message:
-      return analyse(descriptor: field.messageType!).costAsField
+      return analyze(descriptor: field.messageType!).costAsField
     }
   }
 }
@@ -68,7 +68,7 @@ fileprivate let totalFieldCostRequiringStorage = 17
 
 /// The result of analysis, if the message should use heap storage and the
 /// cost of the message when used as a field in other messages.
-fileprivate struct AnalyseResult {
+fileprivate struct AnalyzeResult {
   let usesStorage: Bool
   let costAsField: Int
 
@@ -85,19 +85,19 @@ fileprivate struct AnalyseResult {
 
   /// The message should use storage.
   static let useStorage =
-    AnalyseResult(usesStorage: true, costAsField: FieldCost.singleMessageFieldUsingStorage)
+    AnalyzeResult(usesStorage: true, costAsField: FieldCost.singleMessageFieldUsingStorage)
 }
 
-/// Cache for the `analyse(descriptor:)` results to avoid doing them multiple
+/// Cache for the `analyze(descriptor:)` results to avoid doing them multiple
 /// times.
-fileprivate var analysisCache: Dictionary<String,AnalyseResult> = [
+fileprivate var analysisCache: Dictionary<String,AnalyzeResult> = [
   // google.protobuf.Any can be seeded.
   ".google.protobuf.Any": .useStorage,
 ]
 
-/// Analyse the given descriptor to decide if it should use storage and what
+/// Analyze the given descriptor to decide if it should use storage and what
 /// the cost of it will be when appearing as a single field in another message.
-fileprivate func analyse(descriptor: Descriptor) -> AnalyseResult {
+fileprivate func analyze(descriptor: Descriptor) -> AnalyzeResult {
   if let analysis = analysisCache[descriptor.fullName] {
     return analysis
   }
@@ -143,7 +143,7 @@ fileprivate func analyse(descriptor: Descriptor) -> AnalyseResult {
     return recursionHelper(descriptor, messageStack: [])
   }
 
-  func helper(_ descriptor: Descriptor) -> AnalyseResult {
+  func helper(_ descriptor: Descriptor) -> AnalyzeResult {
     if containsRecursiveSingularField(descriptor) {
       return .useStorage
     }
@@ -172,7 +172,7 @@ fileprivate func analyse(descriptor: Descriptor) -> AnalyseResult {
     }
     assert(fieldsCost <= totalFieldCostRequiringStorage)
 
-    return AnalyseResult(fieldsCost)
+    return AnalyzeResult(fieldsCost)
   }
 
   let result = helper(descriptor)
@@ -185,6 +185,6 @@ fileprivate func analyse(descriptor: Descriptor) -> AnalyseResult {
 enum MessageStorageDecision {
   /// Compute if a message should use heap based sortage or not.
   static func shouldUseHeapStorage(descriptor: Descriptor) -> Bool {
-    return analyse(descriptor: descriptor).usesStorage
+    return analyze(descriptor: descriptor).usesStorage
   }
 }

--- a/Sources/protoc-gen-swift/MessageStorageDecision.swift
+++ b/Sources/protoc-gen-swift/MessageStorageDecision.swift
@@ -85,7 +85,7 @@ fileprivate struct AnalyseResult {
 
   /// The message should use storage.
   static let useStorage =
-    Self(usesStorage: true, costAsField: FieldCost.singleMessageFieldUsingStorage)
+    AnalyseResult(usesStorage: true, costAsField: FieldCost.singleMessageFieldUsingStorage)
 }
 
 /// Cache for the `analyse(descriptor:)` results to avoid doing them multiple

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -213,7 +213,7 @@ class OneofGenerator {
 
         // A helper for isInitialized
         let fieldsToCheck = fields.filter {
-            $0.isGroupOrMessage && $0.messageType.hasRequiredFields()
+            $0.isGroupOrMessage && $0.messageType.containsRequiredFields()
         }
         if !fieldsToCheck.isEmpty {
           p.print(
@@ -446,7 +446,7 @@ class OneofGenerator {
 
         // Confirm there is message field with required fields.
         let firstRequired = fields.first {
-            $0.isGroupOrMessage && $0.messageType.hasRequiredFields()
+            $0.isGroupOrMessage && $0.messageType.containsRequiredFields()
         }
         guard firstRequired != nil else { return }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -3336,153 +3336,147 @@ struct ProtobufUnittest_TestOneof2 {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var foo: OneOf_Foo? {
-    get {return _storage._foo}
-    set {_uniqueStorage()._foo = newValue}
-  }
+  var foo: ProtobufUnittest_TestOneof2.OneOf_Foo? = nil
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {return v}
+      if case .fooInt(let v)? = foo {return v}
       return 0
     }
-    set {_uniqueStorage()._foo = .fooInt(newValue)}
+    set {foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {return v}
+      if case .fooString(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooString(newValue)}
+    set {foo = .fooString(newValue)}
   }
 
   var fooCord: String {
     get {
-      if case .fooCord(let v)? = _storage._foo {return v}
+      if case .fooCord(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooCord(newValue)}
+    set {foo = .fooCord(newValue)}
   }
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v)? = _storage._foo {return v}
+      if case .fooStringPiece(let v)? = foo {return v}
       return String()
     }
-    set {_uniqueStorage()._foo = .fooStringPiece(newValue)}
+    set {foo = .fooStringPiece(newValue)}
   }
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v)? = _storage._foo {return v}
+      if case .fooBytes(let v)? = foo {return v}
       return Data()
     }
-    set {_uniqueStorage()._foo = .fooBytes(newValue)}
+    set {foo = .fooBytes(newValue)}
   }
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v)? = _storage._foo {return v}
+      if case .fooEnum(let v)? = foo {return v}
       return .foo
     }
-    set {_uniqueStorage()._foo = .fooEnum(newValue)}
+    set {foo = .fooEnum(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {return v}
+      if case .fooMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooMessage(newValue)}
+    set {foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {return v}
+      if case .fooGroup(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.FooGroup()
     }
-    set {_uniqueStorage()._foo = .fooGroup(newValue)}
+    set {foo = .fooGroup(newValue)}
   }
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v)? = _storage._foo {return v}
+      if case .fooLazyMessage(let v)? = foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {_uniqueStorage()._foo = .fooLazyMessage(newValue)}
+    set {foo = .fooLazyMessage(newValue)}
   }
 
-  var bar: OneOf_Bar? {
-    get {return _storage._bar}
-    set {_uniqueStorage()._bar = newValue}
-  }
+  var bar: ProtobufUnittest_TestOneof2.OneOf_Bar? = nil
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v)? = _storage._bar {return v}
+      if case .barInt(let v)? = bar {return v}
       return 5
     }
-    set {_uniqueStorage()._bar = .barInt(newValue)}
+    set {bar = .barInt(newValue)}
   }
 
   var barString: String {
     get {
-      if case .barString(let v)? = _storage._bar {return v}
+      if case .barString(let v)? = bar {return v}
       return "STRING"
     }
-    set {_uniqueStorage()._bar = .barString(newValue)}
+    set {bar = .barString(newValue)}
   }
 
   var barCord: String {
     get {
-      if case .barCord(let v)? = _storage._bar {return v}
+      if case .barCord(let v)? = bar {return v}
       return "CORD"
     }
-    set {_uniqueStorage()._bar = .barCord(newValue)}
+    set {bar = .barCord(newValue)}
   }
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v)? = _storage._bar {return v}
+      if case .barStringPiece(let v)? = bar {return v}
       return "SPIECE"
     }
-    set {_uniqueStorage()._bar = .barStringPiece(newValue)}
+    set {bar = .barStringPiece(newValue)}
   }
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v)? = _storage._bar {return v}
+      if case .barBytes(let v)? = bar {return v}
       return Data([66, 89, 84, 69, 83])
     }
-    set {_uniqueStorage()._bar = .barBytes(newValue)}
+    set {bar = .barBytes(newValue)}
   }
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v)? = _storage._bar {return v}
+      if case .barEnum(let v)? = bar {return v}
       return .bar
     }
-    set {_uniqueStorage()._bar = .barEnum(newValue)}
+    set {bar = .barEnum(newValue)}
   }
 
   var bazInt: Int32 {
-    get {return _storage._bazInt ?? 0}
-    set {_uniqueStorage()._bazInt = newValue}
+    get {return _bazInt ?? 0}
+    set {_bazInt = newValue}
   }
   /// Returns true if `bazInt` has been explicitly set.
-  var hasBazInt: Bool {return _storage._bazInt != nil}
+  var hasBazInt: Bool {return self._bazInt != nil}
   /// Clears the value of `bazInt`. Subsequent reads from it will return its default value.
-  mutating func clearBazInt() {_uniqueStorage()._bazInt = nil}
+  mutating func clearBazInt() {self._bazInt = nil}
 
   var bazString: String {
-    get {return _storage._bazString ?? "BAZ"}
-    set {_uniqueStorage()._bazString = newValue}
+    get {return _bazString ?? "BAZ"}
+    set {_bazString = newValue}
   }
   /// Returns true if `bazString` has been explicitly set.
-  var hasBazString: Bool {return _storage._bazString != nil}
+  var hasBazString: Bool {return self._bazString != nil}
   /// Clears the value of `bazString`. Subsequent reads from it will return its default value.
-  mutating func clearBazString() {_uniqueStorage()._bazString = nil}
+  mutating func clearBazString() {self._bazString = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3674,7 +3668,8 @@ struct ProtobufUnittest_TestOneof2 {
 
   init() {}
 
-  fileprivate var _storage = _StorageClass.defaultInstance
+  fileprivate var _bazInt: Int32? = nil
+  fileprivate var _bazString: String? = nil
 }
 
 #if swift(>=4.2)
@@ -11039,243 +11034,205 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
     19: .standard(proto: "baz_string"),
   ]
 
-  fileprivate class _StorageClass {
-    var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
-    var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
-    var _bazInt: Int32? = nil
-    var _bazString: String? = nil
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _foo = source._foo
-      _bar = source._bar
-      _bazInt = source._bazInt
-      _bazString = source._bazString
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._foo = .fooInt(v)}
-        }()
-        case 2: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooString(v)}
-        }()
-        case 3: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooCord(v)}
-        }()
-        case 4: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._foo = .fooStringPiece(v)}
-        }()
-        case 5: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._foo = .fooBytes(v)}
-        }()
-        case 6: try {
-          if _storage._foo != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_TestOneof2.NestedEnum?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._foo = .fooEnum(v)}
-        }()
-        case 7: try {
-          var v: ProtobufUnittest_TestOneof2.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooMessage(v)}
-        }()
-        case 8: try {
-          var v: ProtobufUnittest_TestOneof2.FooGroup?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooGroup(let m) = current {v = m}
-          }
-          try decoder.decodeSingularGroupField(value: &v)
-          if let v = v {_storage._foo = .fooGroup(v)}
-        }()
-        case 11: try {
-          var v: ProtobufUnittest_TestOneof2.NestedMessage?
-          if let current = _storage._foo {
-            try decoder.handleConflictingOneOf()
-            if case .fooLazyMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._foo = .fooLazyMessage(v)}
-        }()
-        case 12: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._bar = .barInt(v)}
-        }()
-        case 13: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barString(v)}
-        }()
-        case 14: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barCord(v)}
-        }()
-        case 15: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._bar = .barStringPiece(v)}
-        }()
-        case 16: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: Data?
-          try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._bar = .barBytes(v)}
-        }()
-        case 17: try {
-          if _storage._bar != nil {try decoder.handleConflictingOneOf()}
-          var v: ProtobufUnittest_TestOneof2.NestedEnum?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._bar = .barEnum(v)}
-        }()
-        case 18: try { try decoder.decodeSingularInt32Field(value: &_storage._bazInt) }()
-        case 19: try { try decoder.decodeSingularStringField(value: &_storage._bazString) }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.foo = .fooInt(v)}
+      }()
+      case 2: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooString(v)}
+      }()
+      case 3: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooCord(v)}
+      }()
+      case 4: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.foo = .fooStringPiece(v)}
+      }()
+      case 5: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.foo = .fooBytes(v)}
+      }()
+      case 6: try {
+        if self.foo != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_TestOneof2.NestedEnum?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.foo = .fooEnum(v)}
+      }()
+      case 7: try {
+        var v: ProtobufUnittest_TestOneof2.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooMessage(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooMessage(v)}
+      }()
+      case 8: try {
+        var v: ProtobufUnittest_TestOneof2.FooGroup?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooGroup(let m) = current {v = m}
+        }
+        try decoder.decodeSingularGroupField(value: &v)
+        if let v = v {self.foo = .fooGroup(v)}
+      }()
+      case 11: try {
+        var v: ProtobufUnittest_TestOneof2.NestedMessage?
+        if let current = self.foo {
+          try decoder.handleConflictingOneOf()
+          if case .fooLazyMessage(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.foo = .fooLazyMessage(v)}
+      }()
+      case 12: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {self.bar = .barInt(v)}
+      }()
+      case 13: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barString(v)}
+      }()
+      case 14: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barCord(v)}
+      }()
+      case 15: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {self.bar = .barStringPiece(v)}
+      }()
+      case 16: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: Data?
+        try decoder.decodeSingularBytesField(value: &v)
+        if let v = v {self.bar = .barBytes(v)}
+      }()
+      case 17: try {
+        if self.bar != nil {try decoder.handleConflictingOneOf()}
+        var v: ProtobufUnittest_TestOneof2.NestedEnum?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {self.bar = .barEnum(v)}
+      }()
+      case 18: try { try decoder.decodeSingularInt32Field(value: &self._bazInt) }()
+      case 19: try { try decoder.decodeSingularStringField(value: &self._bazString) }()
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._foo {
-      case .fooInt?: try {
-        guard case .fooInt(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-      }()
-      case .fooString?: try {
-        guard case .fooString(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-      }()
-      case .fooCord?: try {
-        guard case .fooCord(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      }()
-      case .fooStringPiece?: try {
-        guard case .fooStringPiece(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-      }()
-      case .fooBytes?: try {
-        guard case .fooBytes(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-      }()
-      case .fooEnum?: try {
-        guard case .fooEnum(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-      }()
-      case .fooMessage?: try {
-        guard case .fooMessage(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }()
-      case .fooGroup?: try {
-        guard case .fooGroup(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-      }()
-      case .fooLazyMessage?: try {
-        guard case .fooLazyMessage(let v)? = _storage._foo else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }()
-      case nil: break
-      }
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._bar {
-      case .barInt?: try {
-        guard case .barInt(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-      }()
-      case .barString?: try {
-        guard case .barString(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-      }()
-      case .barCord?: try {
-        guard case .barCord(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-      }()
-      case .barStringPiece?: try {
-        guard case .barStringPiece(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-      }()
-      case .barBytes?: try {
-        guard case .barBytes(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-      }()
-      case .barEnum?: try {
-        guard case .barEnum(let v)? = _storage._bar else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-      }()
-      case nil: break
-      }
-      if let v = _storage._bazInt {
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
-      }
-      if let v = _storage._bazString {
-        try visitor.visitSingularStringField(value: v, fieldNumber: 19)
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.foo {
+    case .fooInt?: try {
+      guard case .fooInt(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    }()
+    case .fooString?: try {
+      guard case .fooString(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }()
+    case .fooCord?: try {
+      guard case .fooCord(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    }()
+    case .fooStringPiece?: try {
+      guard case .fooStringPiece(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    }()
+    case .fooBytes?: try {
+      guard case .fooBytes(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+    }()
+    case .fooEnum?: try {
+      guard case .fooEnum(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    }()
+    case .fooMessage?: try {
+      guard case .fooMessage(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }()
+    case .fooGroup?: try {
+      guard case .fooGroup(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+    }()
+    case .fooLazyMessage?: try {
+      guard case .fooLazyMessage(let v)? = self.foo else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+    }()
+    case nil: break
+    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.bar {
+    case .barInt?: try {
+      guard case .barInt(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+    }()
+    case .barString?: try {
+      guard case .barString(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+    }()
+    case .barCord?: try {
+      guard case .barCord(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+    }()
+    case .barStringPiece?: try {
+      guard case .barStringPiece(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+    }()
+    case .barBytes?: try {
+      guard case .barBytes(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+    }()
+    case .barEnum?: try {
+      guard case .barEnum(let v)? = self.bar else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+    }()
+    case nil: break
+    }
+    if let v = self._bazInt {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
+    }
+    if let v = self._bazString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 19)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_TestOneof2, rhs: ProtobufUnittest_TestOneof2) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._foo != rhs_storage._foo {return false}
-        if _storage._bar != rhs_storage._bar {return false}
-        if _storage._bazInt != rhs_storage._bazInt {return false}
-        if _storage._bazString != rhs_storage._bazString {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.foo != rhs.foo {return false}
+    if lhs.bar != rhs.bar {return false}
+    if lhs._bazInt != rhs._bazInt {return false}
+    if lhs._bazString != rhs._bazString {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -316,153 +316,150 @@ struct ProtobufUnittest_OneofWellKnownTypes {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var oneofField: OneOf_OneofField? {
-    get {return _storage._oneofField}
-    set {_uniqueStorage()._oneofField = newValue}
-  }
+  var oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField? = nil
 
   var anyField: SwiftProtobuf.Google_Protobuf_Any {
     get {
-      if case .anyField(let v)? = _storage._oneofField {return v}
+      if case .anyField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Any()
     }
-    set {_uniqueStorage()._oneofField = .anyField(newValue)}
+    set {oneofField = .anyField(newValue)}
   }
 
   var apiField: SwiftProtobuf.Google_Protobuf_Api {
     get {
-      if case .apiField(let v)? = _storage._oneofField {return v}
+      if case .apiField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Api()
     }
-    set {_uniqueStorage()._oneofField = .apiField(newValue)}
+    set {oneofField = .apiField(newValue)}
   }
 
   var durationField: SwiftProtobuf.Google_Protobuf_Duration {
     get {
-      if case .durationField(let v)? = _storage._oneofField {return v}
+      if case .durationField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Duration()
     }
-    set {_uniqueStorage()._oneofField = .durationField(newValue)}
+    set {oneofField = .durationField(newValue)}
   }
 
   var emptyField: SwiftProtobuf.Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v)? = _storage._oneofField {return v}
+      if case .emptyField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Empty()
     }
-    set {_uniqueStorage()._oneofField = .emptyField(newValue)}
+    set {oneofField = .emptyField(newValue)}
   }
 
   var fieldMaskField: SwiftProtobuf.Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v)? = _storage._oneofField {return v}
+      if case .fieldMaskField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_FieldMask()
     }
-    set {_uniqueStorage()._oneofField = .fieldMaskField(newValue)}
+    set {oneofField = .fieldMaskField(newValue)}
   }
 
   var sourceContextField: SwiftProtobuf.Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v)? = _storage._oneofField {return v}
+      if case .sourceContextField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_SourceContext()
     }
-    set {_uniqueStorage()._oneofField = .sourceContextField(newValue)}
+    set {oneofField = .sourceContextField(newValue)}
   }
 
   var structField: SwiftProtobuf.Google_Protobuf_Struct {
     get {
-      if case .structField(let v)? = _storage._oneofField {return v}
+      if case .structField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Struct()
     }
-    set {_uniqueStorage()._oneofField = .structField(newValue)}
+    set {oneofField = .structField(newValue)}
   }
 
   var timestampField: SwiftProtobuf.Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v)? = _storage._oneofField {return v}
+      if case .timestampField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Timestamp()
     }
-    set {_uniqueStorage()._oneofField = .timestampField(newValue)}
+    set {oneofField = .timestampField(newValue)}
   }
 
   var typeField: SwiftProtobuf.Google_Protobuf_Type {
     get {
-      if case .typeField(let v)? = _storage._oneofField {return v}
+      if case .typeField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Type()
     }
-    set {_uniqueStorage()._oneofField = .typeField(newValue)}
+    set {oneofField = .typeField(newValue)}
   }
 
   var doubleField: SwiftProtobuf.Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v)? = _storage._oneofField {return v}
+      if case .doubleField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_DoubleValue()
     }
-    set {_uniqueStorage()._oneofField = .doubleField(newValue)}
+    set {oneofField = .doubleField(newValue)}
   }
 
   var floatField: SwiftProtobuf.Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v)? = _storage._oneofField {return v}
+      if case .floatField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_FloatValue()
     }
-    set {_uniqueStorage()._oneofField = .floatField(newValue)}
+    set {oneofField = .floatField(newValue)}
   }
 
   var int64Field: SwiftProtobuf.Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v)? = _storage._oneofField {return v}
+      if case .int64Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Int64Value()
     }
-    set {_uniqueStorage()._oneofField = .int64Field(newValue)}
+    set {oneofField = .int64Field(newValue)}
   }
 
   var uint64Field: SwiftProtobuf.Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v)? = _storage._oneofField {return v}
+      if case .uint64Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_UInt64Value()
     }
-    set {_uniqueStorage()._oneofField = .uint64Field(newValue)}
+    set {oneofField = .uint64Field(newValue)}
   }
 
   var int32Field: SwiftProtobuf.Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v)? = _storage._oneofField {return v}
+      if case .int32Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_Int32Value()
     }
-    set {_uniqueStorage()._oneofField = .int32Field(newValue)}
+    set {oneofField = .int32Field(newValue)}
   }
 
   var uint32Field: SwiftProtobuf.Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v)? = _storage._oneofField {return v}
+      if case .uint32Field(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_UInt32Value()
     }
-    set {_uniqueStorage()._oneofField = .uint32Field(newValue)}
+    set {oneofField = .uint32Field(newValue)}
   }
 
   var boolField: SwiftProtobuf.Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v)? = _storage._oneofField {return v}
+      if case .boolField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_BoolValue()
     }
-    set {_uniqueStorage()._oneofField = .boolField(newValue)}
+    set {oneofField = .boolField(newValue)}
   }
 
   var stringField: SwiftProtobuf.Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v)? = _storage._oneofField {return v}
+      if case .stringField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_StringValue()
     }
-    set {_uniqueStorage()._oneofField = .stringField(newValue)}
+    set {oneofField = .stringField(newValue)}
   }
 
   var bytesField: SwiftProtobuf.Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v)? = _storage._oneofField {return v}
+      if case .bytesField(let v)? = oneofField {return v}
       return SwiftProtobuf.Google_Protobuf_BytesValue()
     }
-    set {_uniqueStorage()._oneofField = .bytesField(newValue)}
+    set {oneofField = .bytesField(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -572,8 +569,6 @@ struct ProtobufUnittest_OneofWellKnownTypes {
   }
 
   init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 /// A map field for each well-known type. We only
@@ -1116,295 +1111,263 @@ extension ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProt
     18: .standard(proto: "bytes_field"),
   ]
 
-  fileprivate class _StorageClass {
-    var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
-
-    static let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _oneofField = source._oneofField
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try {
-          var v: SwiftProtobuf.Google_Protobuf_Any?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .anyField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .anyField(v)}
-        }()
-        case 2: try {
-          var v: SwiftProtobuf.Google_Protobuf_Api?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .apiField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .apiField(v)}
-        }()
-        case 3: try {
-          var v: SwiftProtobuf.Google_Protobuf_Duration?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .durationField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .durationField(v)}
-        }()
-        case 4: try {
-          var v: SwiftProtobuf.Google_Protobuf_Empty?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .emptyField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .emptyField(v)}
-        }()
-        case 5: try {
-          var v: SwiftProtobuf.Google_Protobuf_FieldMask?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .fieldMaskField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .fieldMaskField(v)}
-        }()
-        case 6: try {
-          var v: SwiftProtobuf.Google_Protobuf_SourceContext?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .sourceContextField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .sourceContextField(v)}
-        }()
-        case 7: try {
-          var v: SwiftProtobuf.Google_Protobuf_Struct?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .structField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .structField(v)}
-        }()
-        case 8: try {
-          var v: SwiftProtobuf.Google_Protobuf_Timestamp?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .timestampField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .timestampField(v)}
-        }()
-        case 9: try {
-          var v: SwiftProtobuf.Google_Protobuf_Type?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .typeField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .typeField(v)}
-        }()
-        case 10: try {
-          var v: SwiftProtobuf.Google_Protobuf_DoubleValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .doubleField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .doubleField(v)}
-        }()
-        case 11: try {
-          var v: SwiftProtobuf.Google_Protobuf_FloatValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .floatField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .floatField(v)}
-        }()
-        case 12: try {
-          var v: SwiftProtobuf.Google_Protobuf_Int64Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .int64Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .int64Field(v)}
-        }()
-        case 13: try {
-          var v: SwiftProtobuf.Google_Protobuf_UInt64Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .uint64Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .uint64Field(v)}
-        }()
-        case 14: try {
-          var v: SwiftProtobuf.Google_Protobuf_Int32Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .int32Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .int32Field(v)}
-        }()
-        case 15: try {
-          var v: SwiftProtobuf.Google_Protobuf_UInt32Value?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .uint32Field(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .uint32Field(v)}
-        }()
-        case 16: try {
-          var v: SwiftProtobuf.Google_Protobuf_BoolValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .boolField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .boolField(v)}
-        }()
-        case 17: try {
-          var v: SwiftProtobuf.Google_Protobuf_StringValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .stringField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .stringField(v)}
-        }()
-        case 18: try {
-          var v: SwiftProtobuf.Google_Protobuf_BytesValue?
-          if let current = _storage._oneofField {
-            try decoder.handleConflictingOneOf()
-            if case .bytesField(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {_storage._oneofField = .bytesField(v)}
-        }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try {
+        var v: SwiftProtobuf.Google_Protobuf_Any?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .anyField(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .anyField(v)}
+      }()
+      case 2: try {
+        var v: SwiftProtobuf.Google_Protobuf_Api?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .apiField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .apiField(v)}
+      }()
+      case 3: try {
+        var v: SwiftProtobuf.Google_Protobuf_Duration?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .durationField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .durationField(v)}
+      }()
+      case 4: try {
+        var v: SwiftProtobuf.Google_Protobuf_Empty?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .emptyField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .emptyField(v)}
+      }()
+      case 5: try {
+        var v: SwiftProtobuf.Google_Protobuf_FieldMask?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .fieldMaskField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .fieldMaskField(v)}
+      }()
+      case 6: try {
+        var v: SwiftProtobuf.Google_Protobuf_SourceContext?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .sourceContextField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .sourceContextField(v)}
+      }()
+      case 7: try {
+        var v: SwiftProtobuf.Google_Protobuf_Struct?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .structField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .structField(v)}
+      }()
+      case 8: try {
+        var v: SwiftProtobuf.Google_Protobuf_Timestamp?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .timestampField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .timestampField(v)}
+      }()
+      case 9: try {
+        var v: SwiftProtobuf.Google_Protobuf_Type?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .typeField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .typeField(v)}
+      }()
+      case 10: try {
+        var v: SwiftProtobuf.Google_Protobuf_DoubleValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .doubleField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .doubleField(v)}
+      }()
+      case 11: try {
+        var v: SwiftProtobuf.Google_Protobuf_FloatValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .floatField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .floatField(v)}
+      }()
+      case 12: try {
+        var v: SwiftProtobuf.Google_Protobuf_Int64Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .int64Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .int64Field(v)}
+      }()
+      case 13: try {
+        var v: SwiftProtobuf.Google_Protobuf_UInt64Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .uint64Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .uint64Field(v)}
+      }()
+      case 14: try {
+        var v: SwiftProtobuf.Google_Protobuf_Int32Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .int32Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .int32Field(v)}
+      }()
+      case 15: try {
+        var v: SwiftProtobuf.Google_Protobuf_UInt32Value?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .uint32Field(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .uint32Field(v)}
+      }()
+      case 16: try {
+        var v: SwiftProtobuf.Google_Protobuf_BoolValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .boolField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .boolField(v)}
+      }()
+      case 17: try {
+        var v: SwiftProtobuf.Google_Protobuf_StringValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .stringField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .stringField(v)}
+      }()
+      case 18: try {
+        var v: SwiftProtobuf.Google_Protobuf_BytesValue?
+        if let current = self.oneofField {
+          try decoder.handleConflictingOneOf()
+          if case .bytesField(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.oneofField = .bytesField(v)}
+      }()
+      default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch _storage._oneofField {
-      case .anyField?: try {
-        guard case .anyField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }()
-      case .apiField?: try {
-        guard case .apiField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }()
-      case .durationField?: try {
-        guard case .durationField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }()
-      case .emptyField?: try {
-        guard case .emptyField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }()
-      case .fieldMaskField?: try {
-        guard case .fieldMaskField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }()
-      case .sourceContextField?: try {
-        guard case .sourceContextField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }()
-      case .structField?: try {
-        guard case .structField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }()
-      case .timestampField?: try {
-        guard case .timestampField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }()
-      case .typeField?: try {
-        guard case .typeField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }()
-      case .doubleField?: try {
-        guard case .doubleField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }()
-      case .floatField?: try {
-        guard case .floatField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }()
-      case .int64Field?: try {
-        guard case .int64Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-      }()
-      case .uint64Field?: try {
-        guard case .uint64Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-      }()
-      case .int32Field?: try {
-        guard case .int32Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-      }()
-      case .uint32Field?: try {
-        guard case .uint32Field(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-      }()
-      case .boolField?: try {
-        guard case .boolField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-      }()
-      case .stringField?: try {
-        guard case .stringField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-      }()
-      case .bytesField?: try {
-        guard case .bytesField(let v)? = _storage._oneofField else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-      }()
-      case nil: break
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.oneofField {
+    case .anyField?: try {
+      guard case .anyField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }()
+    case .apiField?: try {
+      guard case .apiField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .durationField?: try {
+      guard case .durationField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case .emptyField?: try {
+      guard case .emptyField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }()
+    case .fieldMaskField?: try {
+      guard case .fieldMaskField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }()
+    case .sourceContextField?: try {
+      guard case .sourceContextField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .structField?: try {
+      guard case .structField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }()
+    case .timestampField?: try {
+      guard case .timestampField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }()
+    case .typeField?: try {
+      guard case .typeField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }()
+    case .doubleField?: try {
+      guard case .doubleField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    }()
+    case .floatField?: try {
+      guard case .floatField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+    }()
+    case .int64Field?: try {
+      guard case .int64Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+    }()
+    case .uint64Field?: try {
+      guard case .uint64Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+    }()
+    case .int32Field?: try {
+      guard case .int32Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+    }()
+    case .uint32Field?: try {
+      guard case .uint32Field(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    }()
+    case .boolField?: try {
+      guard case .boolField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+    }()
+    case .stringField?: try {
+      guard case .stringField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+    }()
+    case .bytesField?: try {
+      guard case .bytesField(let v)? = self.oneofField else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+    }()
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes, rhs: ProtobufUnittest_OneofWellKnownTypes) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._oneofField != rhs_storage._oneofField {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.oneofField != rhs.oneofField {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
Revise the way storage calculations are done to take into account the cost of singular message fields since those directly increase the size of the containing message. This should better cap things so Message don't get too big.

This is progress on #735.