### PR TITLE
Sort map fields for TextFormat.

### DIFF
--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -50,6 +50,17 @@ public protocol FieldType {
 /// Marker protocol for types that can be used as map keys
 ///
 public protocol MapKeyType: FieldType {
+    /// A comparision function for where order is needed.  Can't use `Comparable`
+    /// because `Bool` doesn't conform, and since it is `public` there is no way
+    /// to add a conformance internal to SwiftProtobuf.
+    static func _lessThan(lhs: BaseType, rhs: BaseType) -> Bool
+}
+
+// Default impl for anything `Comparable`
+extension MapKeyType where BaseType: Comparable {
+    public static func _lessThan(lhs: BaseType, rhs: BaseType) -> Bool {
+        return lhs < rhs
+    }
 }
 
 ///
@@ -362,6 +373,14 @@ public struct ProtobufBool: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedBoolField(value: value, fieldNumber: fieldNumber)
+    }
+
+    /// Custom _lessThan since `Bool` isn't `Comparable`.
+    public static func _lessThan(lhs: BaseType, rhs: BaseType) -> Bool {
+        if !lhs {
+            return rhs
+        }
+        return false
     }
 }
 

--- a/Tests/SwiftProtobufTests/Test_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_Conformance.swift
@@ -99,4 +99,16 @@ class Test_Conformance: XCTestCase, PBTestHelpers {
             return $0.optionalString == "\u{1F601}"
         }
     }
+
+    func testMaps_TextFormatKeysSorted() {
+        assertTextFormatEncode("map_string_string {\n  key: \"a\"\n  value: \"value\"\n}\nmap_string_string {\n  key: \"b\"\n  value: \"value\"\n}\nmap_string_string {\n  key: \"c\"\n  value: \"value\"\n}\n") {(o: inout MessageTestType) in
+            o.mapStringString = ["c":"value", "b":"value", "a":"value"]
+        }
+        assertTextFormatEncode("map_int32_int32 {\n  key: 1\n  value: 0\n}\nmap_int32_int32 {\n  key: 2\n  value: 0\n}\nmap_int32_int32 {\n  key: 3\n  value: 0\n}\n") {(o: inout MessageTestType) in
+            o.mapInt32Int32 = [3:0, 2:0, 1:0]
+        }
+        assertTextFormatEncode("map_bool_bool {\n  key: false\n  value: false\n}\nmap_bool_bool {\n  key: true\n  value: false\n}\n") {(o: inout MessageTestType) in
+            o.mapBoolBool = [true: false, false: false]
+        }
+    }
 }


### PR DESCRIPTION
Since Bool isn't Comparable, add a sorting function to MapKeyType and use that
in TextFormatEncodingVisitor.