### PR TITLE
Don't allow LF or CR in the middle of TextFormat string literals.

### DIFF
--- a/Sources/Conformance/text_format_failure_list_swift.txt
+++ b/Sources/Conformance/text_format_failure_list_swift.txt
@@ -1,2 +1,1 @@
-Required.Proto3.TextFormatInput.StringLiteralIncludesLFBytes
-Required.Proto3.TextFormatInput.StringLiteralIncludesLFString
+# No known failures

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -350,6 +350,9 @@ internal struct TextFormatScanner {
           return count
         }
         switch byte {
+        case asciiNewLine, asciiCarriageReturn:
+          // Can't have a newline in the middle of a bytes string.
+          throw TextFormatDecodingError.malformedText
         case asciiBackslash: //  "\\"
           sawBackslash = true
           if p != end {
@@ -575,6 +578,10 @@ internal struct TextFormatScanner {
                 }
                 sawBackslash = true
                 p += 1
+            }
+            if c == asciiNewLine || c == asciiCarriageReturn {
+                // Can't have a newline in the middle of a raw string.
+                return nil
             }
         }
         return nil // Unterminated quoted string

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -427,6 +427,7 @@ extension Test_Conformance {
         ("testString_surrogates", testString_surrogates),
         ("testBytes_unicodeEscape", testBytes_unicodeEscape),
         ("testBytes_surrogates", testBytes_surrogates),
+        ("test_LiteralIncludeLF", test_LiteralIncludeLF),
         ("testMaps_TextFormatKeysSorted", testMaps_TextFormatKeysSorted)
     ]
 }

--- a/Tests/SwiftProtobufTests/Test_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_Conformance.swift
@@ -187,6 +187,13 @@ class Test_Conformance: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeFails("optional_bytes: \"\\U0000D83D\\uDE01\"")
     }
 
+    func test_LiteralIncludeLF() {
+        assertTextFormatDecodeFails("optional_string: 'first line\nsecond line'")
+        assertTextFormatDecodeFails("optional_string: 'first line\rsecond line'")
+        assertTextFormatDecodeFails("optional_bytes: 'first line\nsecond line'")
+        assertTextFormatDecodeFails("optional_bytes: 'first line\rsecond line'")
+    }
+
     func testMaps_TextFormatKeysSorted() {
         assertTextFormatEncode("map_string_string {\n  key: \"a\"\n  value: \"value\"\n}\nmap_string_string {\n  key: \"b\"\n  value: \"value\"\n}\nmap_string_string {\n  key: \"c\"\n  value: \"value\"\n}\n") {(o: inout MessageTestType) in
             o.mapStringString = ["c":"value", "b":"value", "a":"value"]


### PR DESCRIPTION
Update the conformance failures list to match.

Fixes #1085