### PR TITLE
Tune the CI builds of protobuf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: make test-runtime
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: protobuf
         # NOTE: for refs that can float like 'master' the cache might be out of date!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         ./configure
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -C ./src -j "${NUM_CPUS}" protoc
-        make -C ./conformance -j "${NUM_CPUS}" conformance-test-runner
+        make -C ./conformance conformance-test-runner
     - name: Test plugin
       working-directory: main
       run: make test-plugin PROTOC=../protobuf/src/protoc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,9 @@ jobs:
       run: |
         ./autogen.sh
         ./configure
-        make -C ./src
-        make -C ./conformance
+        NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
+        make -C ./src -j "${NUM_CPUS}" protoc
+        make -C ./conformance -j "${NUM_CPUS}" conformance-test-runner
     - name: Test plugin
       working-directory: main
       run: make test-plugin PROTOC=../protobuf/src/protoc

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -55,7 +55,7 @@ jobs:
         esac
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: protobuf
         # NOTE: for refs that can float like 'master' the cache might be out of date!

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -73,8 +73,9 @@ jobs:
       run: |
         ./autogen.sh
         ./configure
-        make -C ./src
-        make -C ./conformance
+        NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
+        make -C ./src -j "${NUM_CPUS}" protoc
+        make -C ./conformance -j "${NUM_CPUS}" conformance-test-runner
     - name: Test conformance
       working-directory: main
       run: make test-conformance

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -75,7 +75,7 @@ jobs:
         ./configure
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -C ./src -j "${NUM_CPUS}" protoc
-        make -C ./conformance -j "${NUM_CPUS}" conformance-test-runner
+        make -C ./conformance conformance-test-runner
     - name: Test conformance
       working-directory: main
       run: make test-conformance


### PR DESCRIPTION
Build the explicit targets need instead of the default target (usually "all")

Add -j CPU count to the builds to build some things in parallel. Make doesn't
have a way to say scale to the CPU count, so look up the CPU count and
explicitly pass it.  The agents on github seem to all be dual core, so this
should help a little.