### PR TITLE
Normalize CRLF in comments to avoid double spacing some input.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_SourceCodeInfo+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_SourceCodeInfo+Extensions.swift
@@ -34,7 +34,11 @@ extension Google_Protobuf_SourceCodeInfo.Location {
 
     func prefixLines(text: String, prefix: String) -> String {
       var result = String()
-      var lines = text.components(separatedBy: .newlines)
+      // Protoc doesn't normalize newlines in the comments, make sure CRLF
+      // doesn't insert blank lines and the generated file is hopefully then
+      // consistent in using '\n'.
+      var lines =
+        text.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: .newlines)
       // Trim any blank lines off the end.
       while !lines.isEmpty && lines.last!.trimmingCharacters(in: .whitespaces).isEmpty {
         lines.removeLast()


### PR DESCRIPTION
Fixes #1107