### PR TITLE
Deal with malformed UTF8 while parsing a field name.

### DIFF
--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1265,7 +1265,11 @@ internal struct JSONScanner {
         if let fieldNumber = names.number(forJSONName: key) {
           return fieldNumber
         }
-        fieldName = utf8ToString(bytes: key.baseAddress!, count: key.count)!
+        if let s = utf8ToString(bytes: key.baseAddress!, count: key.count) {
+          fieldName = s
+        } else {
+          throw JSONDecodingError.invalidUTF8
+        }
       } else {
         // Slow path:  We parsed a String; lookups from String are slower.
         fieldName = try nextQuotedString()


### PR DESCRIPTION
When parsing from a `Data`, nothing says the UTF8 payload is valid, all the
other codepaths properly handle checking for valid UTF8, but this one case was
force unwrapping instead of allowing for the failure.