### PR TITLE
Add 5.4 testing.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["5.3-bionic", "5.2.5-bionic", "5.1.5-bionic", "5.0.3-bionic", "4.2.4"]
+        swift: ["5.4-bionic", "5.3.3-bionic", "5.2.5-bionic", "5.1.5-bionic", "5.0.3-bionic", "4.2.4"]
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"
@@ -96,7 +96,11 @@ jobs:
         swiftpm_config: ["debug", "release"]
     container:
       # Test on the latest Swift release
-      image: swift:bionic
+      #image: swift:bionic
+      # Using 5.3 because 5.4 seems to have an issue with passing
+      # `-enable-testing` in a release builds:
+      #   https://bugs.swift.org/browse/SR-14550
+      image: swift:5.3.3-bionic
     steps:
     - uses: actions/checkout@v2
     - name: Test

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        swift: ["5.3-bionic"]
+        swift: ["5.4-bionic"]
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"


### PR DESCRIPTION
Move conformance test to 5.4 since it is the latest.