### PR TITLE
Clear previous contents before decoding Any from TextFormat

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -136,7 +136,7 @@ extension Google_Protobuf_Any {
   }
 }
 
-extension Google_Protobuf_Any: _CustomJSONCodable {
+extension Google_Protobuf_Any {
   // Custom text format decoding support for Any objects.
   // (Note: This is not a part of any protocol; it's invoked
   // directly from TextFormatDecoder whenever it sees an attempt
@@ -152,10 +152,16 @@ extension Google_Protobuf_Any: _CustomJSONCodable {
     } else {
       // This is not using the specialized encoding, so we can use the
       // standard path to decode the binary value.
+      // First, clear the fields so we don't waste time re-serializing
+      // the previous contents if a field gets repeated.
+      self.typeURL = ""
+      self.value = Data()
       try decodeMessage(decoder: &decoder)
     }
   }
+}
 
+extension Google_Protobuf_Any: _CustomJSONCodable {
   internal func encodedJSONString(options: JSONEncodingOptions) throws -> String {
     return try _storage.encodedJSONString(options: options)
   }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -153,7 +153,9 @@ extension Google_Protobuf_Any {
       // This is not using the specialized encoding, so we can use the
       // standard path to decode the binary value.
       // First, clear the fields so we don't waste time re-serializing
-      // the previous contents if a field gets repeated.
+      // the previous contents as this instances get replaced with a
+      // new value (can happen when a field name/number is repeated in
+      // the TextFormat input).
       self.typeURL = ""
       self.value = Data()
       try decodeMessage(decoder: &decoder)

--- a/Tests/SwiftProtobufTests/Test_FuzzTests.swift
+++ b/Tests/SwiftProtobufTests/Test_FuzzTests.swift
@@ -116,5 +116,9 @@ class Test_FuzzTests: XCTestCase {
     assertTextFormatFails([
       0x31, 0x35, 0x3a, 0x27, 0xa9, 0xa9, 0x5c, 0x75, 0x41, 0x62
     ])
+
+    assertTextFormatSucceeds("500<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<[google.protobuf.Any]<>>>>>>>>>>>>>>>>500<1:''\n2:''>")
+
+    assertTextFormatFails("500<[fvwzz_exobuf.Aob/google.protobuf.Any]<[oeFgb/google.protobuf.Any]<[xlob/google.protobuf.Any]<[oeee0FFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<[oglob/google.protobuf.Any]<[oogoFFFFFFFFRFfuzz.tebool_extFFFFFFFBFFFFegleeeeeeeeeeeeeeeeeeemeeeeeeeeeeeneeeeeeeekeeeeFFFFFFFFFIFFFFFFFgb/google.protobuf.Any]<>>>>>>>>>>>>>>>>>500<1:''\n1:''\n1:''\n2:''\n1:'roto")
   }
 }


### PR DESCRIPTION
The standard decoding path requires the previous byte value; when decoded
from TextFormat to a message, obtaining the byte value requires serializing
the message.  This is entirely unnecessary and can be a performance problem
if the previous value is time-consuming to serialize.

Credit: oss-fuzz project