### PR TITLE
Simple test for recursive Any

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -248,6 +248,7 @@ extension Test_Any {
         ("test_Any_UnknownUserMessage_JSON", test_Any_UnknownUserMessage_JSON),
         ("test_Any_UnknownUserMessage_protobuf", test_Any_UnknownUserMessage_protobuf),
         ("test_Any_Any", test_Any_Any),
+        ("test_Any_recursive", test_Any_recursive),
         ("test_Any_Duration_JSON_roundtrip", test_Any_Duration_JSON_roundtrip),
         ("test_Any_Duration_transcode", test_Any_Duration_transcode),
         ("test_Any_FieldMask_JSON_roundtrip", test_Any_FieldMask_JSON_roundtrip),

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -276,6 +276,16 @@ class Test_Any: XCTestCase {
         }
     }
 
+    func test_Any_recursive() throws {
+        func nestedAny(_ i: Int) throws -> Google_Protobuf_Any {
+           guard i > 0 else { return Google_Protobuf_Any() }
+           return try Google_Protobuf_Any(message: nestedAny(i - 1))
+        }
+        let any = try nestedAny(5)
+        let encoded = try any.serializedBytes()
+        XCTAssertEqual(encoded.count, 214)
+    }
+
     func test_Any_Duration_JSON_roundtrip() throws {
         let start = "{\"optionalAny\":{\"@type\":\"type.googleapis.com/google.protobuf.Duration\",\"value\":\"99.001s\"}}"
         do {


### PR DESCRIPTION
Ideally, it would be possible to run this test
in a reasonable time with a nesting of 20 or more.

The recursion is set to only 5 for now since we
have some exponential costs in here.

Note: recursive Any should be vanishingly rare, so the
performance here probably isn't a critical short-term
concern.