### PR TITLE
Track recursion depth for nested JSON ListValue structures

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
@@ -44,6 +44,8 @@ extension Google_Protobuf_ListValue: _CustomJSONCodable {
       return
     }
     try decoder.scanner.skipRequiredArrayStart()
+    // Since we override the JSON decoding, we can't rely
+    // on the default recursion depth tracking.
     try decoder.scanner.incrementRecursionDepth()
     if decoder.scanner.skipOptionalArrayEnd() {
       decoder.scanner.decrementRecursionDepth()

--- a/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
@@ -44,7 +44,9 @@ extension Google_Protobuf_ListValue: _CustomJSONCodable {
       return
     }
     try decoder.scanner.skipRequiredArrayStart()
+    try decoder.scanner.incrementRecursionDepth()
     if decoder.scanner.skipOptionalArrayEnd() {
+      decoder.scanner.decrementRecursionDepth()
       return
     }
     while true {
@@ -52,6 +54,7 @@ extension Google_Protobuf_ListValue: _CustomJSONCodable {
       try v.decodeJSON(from: &decoder)
       values.append(v)
       if decoder.scanner.skipOptionalArrayEnd() {
+        decoder.scanner.decrementRecursionDepth()
         return
       }
       try decoder.scanner.skipRequiredComma()

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -410,14 +410,14 @@ internal struct JSONScanner {
     self.extensions = extensions ?? SimpleExtensionMap()
   }
 
-  private mutating func incrementRecursionDepth() throws {
+  internal mutating func incrementRecursionDepth() throws {
     recursionBudget -= 1
     if recursionBudget < 0 {
       throw JSONDecodingError.messageDepthLimit
     }
   }
 
-  private mutating func decrementRecursionDepth() {
+  internal mutating func decrementRecursionDepth() {
     recursionBudget += 1
     // This should never happen, if it does, something is probably corrupting memory, and
     // simply throwing doesn't make much sense.

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -991,6 +991,7 @@ extension Test_JSON_ListValue {
     static var allTests = [
         ("testProtobuf", testProtobuf),
         ("testJSON", testJSON),
+        ("test_JSON_nested_list", test_JSON_nested_list),
         ("test_equality", test_equality)
     ]
 }

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -149,9 +149,9 @@ class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
             // Small lists
             1,2,3,4,5,
             // Little less than default messageDepthLimit, should succeed
-	    limit - 3, limit - 2, limit - 1, limit,
+            limit - 3, limit - 2, limit - 1, limit,
             // Little bigger than default messageDepthLimit, should fail
-	    limit + 1, limit + 2, limit + 3, limit + 4,
+            limit + 1, limit + 2, limit + 3, limit + 4,
             // Really big, should fail cleanly (not crash)
             1000,10000,100000,1000000
         ]

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -144,13 +144,14 @@ class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
     }
 
     func test_JSON_nested_list() throws {
+        let limit = JSONDecodingOptions().messageDepthLimit
         let depths = [
             // Small lists
             1,2,3,4,5,
             // Little less than default messageDepthLimit, should succeed
-            95,96,97,98,99,100,
+	    limit - 3, limit - 2, limit - 1, limit,
             // Little bigger than default messageDepthLimit, should fail
-            101,102,103,104,
+	    limit + 1, limit + 2, limit + 3, limit + 4,
             // Really big, should fail cleanly (not crash)
             1000,10000,100000,1000000
         ]
@@ -170,7 +171,7 @@ class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
             }
             // Recursion limits should cause this to
             // fail cleanly without crashing
-            if depth <= JSONDecodingOptions().messageDepthLimit {
+            if depth <= limit {
                 assertJSONDecodeSucceeds(s) {_ in true}
             } else {
                 assertJSONDecodeFails(s)


### PR DESCRIPTION
This prevents stack overrun for inputs like

   [[[[[[....[[[[[[]]]]]]....]]]]]]

Test case exercises direct nesting up to a million
levels.

Thanks to oss-fuzz for finding this!