### PR TITLE
Minimize our use of `defer` except when cleanup is needed with `throw`.

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -174,15 +174,13 @@ internal struct JSONEncodingVisitor: Visitor {
       // Preserve outer object's name and extension maps; restore them before returning
       let oldNameMap = self.nameMap
       let oldExtensions = self.extensions
-      defer {
-        self.nameMap = oldNameMap
-        self.extensions = oldExtensions
-      }
       // Install inner object's name and extension maps
       self.nameMap = newNameMap
       startObject(message: value)
       try value.traverse(visitor: &self)
       endObject()
+      self.nameMap = oldNameMap
+      self.extensions = oldExtensions
     } else {
       throw JSONEncodingError.missingFieldNames
     }
@@ -319,17 +317,15 @@ internal struct JSONEncodingVisitor: Visitor {
       // Preserve name and extension maps for outer object
       let oldNameMap = self.nameMap
       let oldExtensions = self.extensions
-      // Restore outer object's name and extension maps before returning
-      defer {
-        self.nameMap = oldNameMap
-        self.extensions = oldExtensions
-      }
       self.nameMap = newNameMap
       for v in value {
         startArrayObject(message: v)
         try v.traverse(visitor: &self)
         encoder.endObject()
       }
+      // Restore outer object's name and extension maps before returning
+      self.nameMap = oldNameMap
+      self.extensions = oldExtensions
     } else {
       throw JSONEncodingError.missingFieldNames
     }

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -288,12 +288,6 @@ internal struct TextFormatEncodingVisitor: Visitor {
       self.nameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap
       self.nameResolver = [:]
       self.extensions = (value as? ExtensibleMessage)?._protobuf_extensionFieldValues
-      // Restore state before returning
-      defer {
-        self.extensions = oldExtensions
-        self.nameResolver = oldNameResolver
-        self.nameMap = oldNameMap
-      }
       // Encode submessage
       encoder.startMessageField()
       if let any = value as? Google_Protobuf_Any {
@@ -302,6 +296,10 @@ internal struct TextFormatEncodingVisitor: Visitor {
           try! value.traverse(visitor: &self)
       }
       encoder.endMessageField()
+      // Restore state before returning
+      self.extensions = oldExtensions
+      self.nameResolver = oldNameResolver
+      self.nameMap = oldNameMap
   }
 
   // Emit the full "verbose" form of an Any.  This writes the typeURL


### PR DESCRIPTION
Most of the code does cleanup directly as needed without `defer`. In cases were
things are failing, the cleanup doesn't need to happen because the operation
failed.  There is only one success path, so `defer` doesn't add value from that
pov. And lastly, some of the same similiar codepaths to cover repeated/single
weren't consistent in usages of `defer`.