### PR TITLE
Reject fieldmasks that have non-ASCII characters for JSON

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -20,6 +20,9 @@ private func ProtoToJSON(name: String) -> String? {
   var jsonPath = String()
   var chars = name.makeIterator()
   while let c = chars.next() {
+    if !c.isASCII {
+        return nil // Reject anything with a non-ASCII character
+    }
     switch c {
     case "_":
       if let toupper = chars.next() {
@@ -44,6 +47,9 @@ private func ProtoToJSON(name: String) -> String? {
 private func JSONToProto(name: String) -> String? {
   var path = String()
   for c in name {
+    if !c.isASCII {
+        return nil // Reject anything with a non-ASCII character
+    }
     switch c {
     case "_":
       return nil

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -15,14 +15,27 @@
 
 // TODO: We should have utilities to apply a fieldmask to an arbitrary
 // message, intersect two fieldmasks, etc.
+// Google's C++ implementation does this by having utilities
+// to build a tree of field paths that can be easily intersected,
+// unioned, traversed to apply to submessages, etc.
+
+// True if the string only contains printable (non-control)
+// ASCII characters.  Note: This follows the ASCII standard;
+// space is not a "printable" character.
+private func isPrintableASCII(_ s: String) -> Bool {
+  for u in s.utf8 {
+    if u <= 0x20 || u >= 0x7f {
+      return false
+    }
+  }
+  return true
+}
 
 private func ProtoToJSON(name: String) -> String? {
+  guard isPrintableASCII(name) else { return nil }
   var jsonPath = String()
   var chars = name.makeIterator()
   while let c = chars.next() {
-    if !c.isASCII {
-        return nil // Reject anything with a non-ASCII character
-    }
     switch c {
     case "_":
       if let toupper = chars.next() {
@@ -45,11 +58,9 @@ private func ProtoToJSON(name: String) -> String? {
 }
 
 private func JSONToProto(name: String) -> String? {
+  guard isPrintableASCII(name) else { return nil }
   var path = String()
   for c in name {
-    if !c.isASCII {
-        return nil // Reject anything with a non-ASCII character
-    }
     switch c {
     case "_":
       return nil

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -50,7 +50,12 @@ private func ProtoToJSON(name: String) -> String? {
       }
     case "A"..."Z":
       return nil
+    case "a"..."z","0"..."9",".","(",")":
+      jsonPath.append(c)
     default:
+      // TODO: Change this to `return nil`
+      // once we know everything legal is handled
+      // above.
       jsonPath.append(c)
     }
   }
@@ -67,7 +72,12 @@ private func JSONToProto(name: String) -> String? {
     case "A"..."Z":
       path.append(Character("_"))
       path.append(String(c).lowercased())
+    case "a"..."z","0"..."9",".","(",")":
+      path.append(c)
     default:
+      // TODO: Change to `return nil` once
+      // we know everything legal is being
+      // handled above
       path.append(c)
     }
   }


### PR DESCRIPTION
Fieldmasks refer to proto fields which can only have ASCII
names, so any fieldmask with a non-ASCII character is
necessarily ill-formed.

This rejects such field masks when encoding and decoding JSON.
In particular, this fixes a round-trip decode/encode failure
that occurred when certain accented Unicode characters appeared
in JSON fieldmask arguments.

Resolves #1184 