### PR TITLE
Don't overrun string when parsing timestamps

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -147,8 +147,10 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
   }
 
   var seconds: Int64 = 0
-  // "+" or "-" starts Timezone offset
-  if value[pos] == plus || value[pos] == dash {
+  // "Z" or "+" or "-" starts Timezone offset
+  if pos >= value.count {
+    throw JSONDecodingError.malformedTimestamp
+  } else if value[pos] == plus || value[pos] == dash {
     if pos + 6 > value.count {
       throw JSONDecodingError.malformedTimestamp
     }

--- a/Tests/SwiftProtobufTests/Test_Timestamp.swift
+++ b/Tests/SwiftProtobufTests/Test_Timestamp.swift
@@ -167,7 +167,20 @@ class Test_Timestamp: XCTestCase, PBTestHelpers {
             o.seconds = -62135596800
             o.nanos = 0
         }
+
+        // Truncated forms w/o timezone should not read past end of string
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.00000000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.0000000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.000000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.00000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.0000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.000\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.00\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.0\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00.\"")
+        assertJSONDecodeFails("\"9999-12-31T00:00:00\"")
     }
+
 
     func testJSON_range() throws {
         // Check that JSON timestamps round-trip correctly over a wide range.


### PR DESCRIPTION
The format is a fixed-length layout except for the
trailing part.  So we can optimize the initial
part with a single check to make sure the string
is long enough, but we need to be more careful
at the end.

Thanks to oss-fuzz for finding this!