### PR TITLE
Fix typo in BinaryDecodingOptions.swift

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
@@ -12,7 +12,7 @@
 ///
 // -----------------------------------------------------------------------------
 
-/// Options for JSONDecoding.
+/// Options for binary decoding.
 public struct BinaryDecodingOptions {
   /// The maximum nesting of message with messages.  The default is 100.
   ///


### PR DESCRIPTION
The documentation comment specified `/// Options for JSONDecoding.` even tho this is binary decoding options.