### PR TITLE
Tweak generation for messages with only extension ranges.

### DIFF
--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -1331,8 +1331,13 @@ extension SDTMsgExtensionRangeOrdering: SwiftProtobuf.Message, SwiftProtobuf._Me
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
-      if (1 <= fieldNumber && fieldNumber < 5) || (7 == fieldNumber) || (9 == fieldNumber) || (100 <= fieldNumber && fieldNumber < 121) || (126 <= fieldNumber && fieldNumber < 131) {
-        try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: SDTMsgExtensionRangeOrdering.self, fieldNumber: fieldNumber)
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1..<5, 7, 9, 100..<121, 126..<131:
+        try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: SDTMsgExtensionRangeOrdering.self, fieldNumber: fieldNumber) }()
+      default: break
       }
     }
   }


### PR DESCRIPTION
If a message has no fields, `decodeMessage` would generate an `if` instead of a
`swift..case`. If there were a lot of extension ranges, the `if` would be very
complex, and it used raw integers in the source. With enough ranges, this
becomes a problem for compilation. All the the range values could instead use
explicit casts:

  ```
  Int(100) <= fieldNumber && fieldNumer < Int(201)
  ```

But to generally keep the code slightly more readable, just use the
`switch..case` instead of there are more then a few ranges, thus avoiding the
compilation performance issue.

Note: It may be worth revisiting the general fact that extension ranges are
enforced as a gate before doing extension lookup, as removing these gates might
shrink the generated code (and compiled) sizes, but it would have to be
evaluated against the potential costs of extension lookups for what are
otherwise known to be unknown fields.