### PR TITLE
Conformance JSON.OneofFieldNullSecond

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -585,32 +585,40 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.payload = .protobufPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .protobufPayload(v)
+        }
       }()
       case 2: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jsonPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jsonPayload(v)
+        }
       }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self.messageType) }()
       case 5: try { try decoder.decodeSingularEnumField(value: &self.testCategory) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions) }()
       case 7: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jspbPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .textPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .textPayload(v)
+        }
       }()
       case 9: try { try decoder.decodeSingularBoolField(value: &self.printUnknownFields) }()
       default: break
@@ -697,52 +705,68 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .parseError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .parseError(v)
+        }
       }()
       case 2: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .runtimeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .runtimeError(v)
+        }
       }()
       case 3: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.result = .protobufPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .protobufPayload(v)
+        }
       }()
       case 4: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jsonPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jsonPayload(v)
+        }
       }()
       case 5: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .skipped(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .skipped(v)
+        }
       }()
       case 6: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .serializeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .serializeError(v)
+        }
       }()
       case 7: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jspbPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .textPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .textPayload(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -312,28 +312,36 @@ extension Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Google_Protobuf_NullValue?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.kind = .nullValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .nullValue(v)
+        }
       }()
       case 2: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Double?
         try decoder.decodeSingularDoubleField(value: &v)
-        if let v = v {self.kind = .numberValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .numberValue(v)
+        }
       }()
       case 3: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.kind = .stringValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .stringValue(v)
+        }
       }()
       case 4: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.kind = .boolValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .boolValue(v)
+        }
       }()
       case 5: try {
         var v: Google_Protobuf_Struct?

--- a/Reference/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto2.pb.swift
@@ -1817,10 +1817,12 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         case 101: try { try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool) }()
         case 102: try { try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedMessage?
@@ -1832,46 +1834,60 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBool(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBool(v)
+          }
         }()
         case 116: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint64(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint64(v)
+          }
         }()
         case 117: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._oneofField = .oneofFloat(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofFloat(v)
+          }
         }()
         case 118: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._oneofField = .oneofDouble(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofDouble(v)
+          }
         }()
         case 119: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         case 201: try { try decoder.decodeSingularGroupField(value: &_storage._data) }()
         case 401: try { try decoder.decodeSingularInt32Field(value: &_storage._fieldname1) }()

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1752,10 +1752,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 101: try { try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool) }()
         case 102: try { try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedMessage?
@@ -1767,52 +1769,68 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBool(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBool(v)
+          }
         }()
         case 116: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint64(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint64(v)
+          }
         }()
         case 117: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._oneofField = .oneofFloat(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofFloat(v)
+          }
         }()
         case 118: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._oneofField = .oneofDouble(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofDouble(v)
+          }
         }()
         case 119: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         case 120: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: SwiftProtobuf.Google_Protobuf_NullValue?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofNullValue(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofNullValue(v)
+          }
         }()
         case 201: try { try decoder.decodeSingularMessageField(value: &_storage._optionalBoolWrapper) }()
         case 202: try { try decoder.decodeSingularMessageField(value: &_storage._optionalInt32Wrapper) }()

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -7645,10 +7645,12 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllTypes.NestedMessage?
@@ -7660,16 +7662,20 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }
@@ -8204,10 +8210,12 @@ extension ProtobufUnittest_TestDeprecatedFields: SwiftProtobuf.Message, SwiftPro
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self._deprecatedInt32) }()
       case 2: try {
-        if self.oneofFields != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oneofFields = .deprecatedInt32InOneof(v)}
+        if let v = v {
+          if self.oneofFields != nil {try decoder.handleConflictingOneOf()}
+          self.oneofFields = .deprecatedInt32InOneof(v)
+        }
       }()
       default: break
       }
@@ -10819,16 +10827,20 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._Mess
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
         var v: ProtobufUnittest_TestAllTypes?
@@ -11041,40 +11053,52 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooCord(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooCord(v)
+        }
       }()
       case 4: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooStringPiece(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooStringPiece(v)
+        }
       }()
       case 5: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.foo = .fooBytes(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooBytes(v)
+        }
       }()
       case 6: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.foo = .fooEnum(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooEnum(v)
+        }
       }()
       case 7: try {
         var v: ProtobufUnittest_TestOneof2.NestedMessage?
@@ -11104,40 +11128,52 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
         if let v = v {self.foo = .fooLazyMessage(v)}
       }()
       case 12: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.bar = .barInt(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barInt(v)
+        }
       }()
       case 13: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barString(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barString(v)
+        }
       }()
       case 14: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barCord(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barCord(v)
+        }
       }()
       case 15: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barStringPiece(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barStringPiece(v)
+        }
       }()
       case 16: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.bar = .barBytes(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barBytes(v)
+        }
       }()
       case 17: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.bar = .barEnum(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barEnum(v)
+        }
       }()
       case 18: try { try decoder.decodeSingularInt32Field(value: &self._bazInt) }()
       case 19: try { try decoder.decodeSingularStringField(value: &self._bazString) }()
@@ -11342,16 +11378,20 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
         var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
@@ -12392,10 +12432,12 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
       case 536870008: try { try decoder.decodeSingularGroupField(value: &self._optionalGroup) }()
       case 536870010: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap) }()
       case 536870011: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 536870012: try {
         var v: ProtobufUnittest_TestAllTypes?
@@ -12407,16 +12449,20 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
         if let v = v {self.oneofField = .oneofTestAllTypes(v)}
       }()
       case 536870013: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 536870014: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 536860000..<536870000:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber) }()

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1918,10 +1918,12 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, 
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self._field1) }()
       case 2: try {
-        if self.anOneof != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.anOneof = .oneofField(v)}
+        if let v = v {
+          if self.anOneof != nil {try decoder.handleConflictingOneOf()}
+          self.anOneof = .oneofField(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -4155,10 +4155,12 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobu
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllTypesLite.NestedMessage?
@@ -4170,16 +4172,20 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobu
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
           var v: ProtobufUnittest_TestAllTypesLite.NestedMessage?
@@ -5502,10 +5508,12 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
       case 536870008: try { try decoder.decodeSingularGroupField(value: &self._optionalGroup) }()
       case 536870010: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap) }()
       case 536870011: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 536870012: try {
         var v: ProtobufUnittest_TestAllTypesLite?
@@ -5517,16 +5525,20 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
         if let v = v {self.oneofField = .oneofTestAllTypes(v)}
       }()
       case 536870013: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 536870014: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 536860000..<536870000:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber) }()
@@ -5663,10 +5675,12 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofInt32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofInt32(v)
+        }
       }()
       case 2: try {
         var v: ProtobufUnittest_TestAllTypesLite?
@@ -5678,46 +5692,60 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
         if let v = v {self.oneofField = .oneofSubmessage(v)}
       }()
       case 3: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 4: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 5: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofStringCord(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofStringCord(v)
+        }
       }()
       case 6: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytesCord(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytesCord(v)
+        }
       }()
       case 7: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofStringStringPiece(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofStringStringPiece(v)
+        }
       }()
       case 8: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytesStringPiece(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytesStringPiece(v)
+        }
       }()
       case 9: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_V2EnumLite?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.oneofField = .oneofEnum(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofEnum(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -758,10 +758,12 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, Swi
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
@@ -773,16 +775,20 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, Swi
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         default: break
         }

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -270,16 +270,20 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftPro
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self._i) }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .integerField(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .integerField(v)
+        }
       }()
       case 3: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .stringField(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .stringField(v)
+        }
       }()
       case 19: try { try decoder.decodeSingularMessageField(value: &self._msg) }()
       case 1000..<536870912:

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -306,16 +306,20 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }
@@ -385,16 +389,20 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Me
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -191,16 +191,20 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -996,10 +996,12 @@ extension Proto3Unittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mes
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3Unittest_TestAllTypes.NestedMessage?
@@ -1011,16 +1013,20 @@ extension Proto3Unittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mes
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try { try decoder.decodeSingularMessageField(value: &_storage._optionalLazyImportMessage) }()
         default: break
@@ -1694,10 +1700,12 @@ extension Proto3Unittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 6: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3Unittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.foo = .fooEnum(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooEnum(v)
+        }
       }()
       default: break
       }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -933,10 +933,12 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
@@ -948,16 +950,20 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try { try decoder.decodeSingularMessageField(value: &_storage._optionalLazyImportMessage) }()
         default: break

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -881,10 +881,12 @@ extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProt
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage?
@@ -896,16 +898,20 @@ extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProt
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -881,10 +881,12 @@ extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3LiteUnittest_TestAllTypes.NestedMessage?
@@ -896,16 +898,20 @@ extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -640,16 +640,20 @@ extension SDTTopLevelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
         case 1: try { try decoder.decodeSingularStringField(value: &_storage._field1) }()
         case 2: try { try decoder.decodeSingularInt32Field(value: &_storage._field2) }()
         case 3: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: SDTTopLevelEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .field3(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .field3(v)
+          }
         }()
         case 4: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: SDTTopLevelMessage.SubEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .field4(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .field4(v)
+          }
         }()
         case 5: try {
           var v: SDTTopLevelMessage.SubMessage?
@@ -1032,22 +1036,28 @@ extension SDTProto2MessageForPresence: SwiftProtobuf.Message, SwiftProtobuf._Mes
       case 23: try { try decoder.decodeRepeatedEnumField(value: &self.repeatEnumField) }()
       case 24: try { try decoder.decodeRepeatedMessageField(value: &self.repeatMessageField) }()
       case 31: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.o = .oneofStrField(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofStrField(v)
+        }
       }()
       case 32: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.o = .oneofInt32Field(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofInt32Field(v)
+        }
       }()
       case 33: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: SDTTopLevelEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofEnumField(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofEnumField(v)
+        }
       }()
       case 34: try {
         var v: SDTTopLevelMessage?

--- a/Reference/pluginlib_descriptor_test2.pb.swift
+++ b/Reference/pluginlib_descriptor_test2.pb.swift
@@ -279,22 +279,28 @@ extension SwiftDescriptorTest_Proto3MessageForPresence: SwiftProtobuf.Message, S
       case 23: try { try decoder.decodeRepeatedEnumField(value: &self.repeatEnumField) }()
       case 24: try { try decoder.decodeRepeatedMessageField(value: &self.repeatMessageField) }()
       case 31: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.o = .oneofStrField(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofStrField(v)
+        }
       }()
       case 32: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.o = .oneofInt32Field(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofInt32Field(v)
+        }
       }()
       case 33: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: SwiftDescriptorTest_Proto3MessageForPresence.SubEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofEnumField(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofEnumField(v)
+        }
       }()
       case 34: try {
         var v: SwiftDescriptorTest_OtherMessage?

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -1030,10 +1030,12 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
@@ -1045,16 +1047,20 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -486,30 +486,38 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt64Field(value: &self._myInt) }()
       case 9: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.options = .oneofBool(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofBool(v)
+        }
       }()
       case 10: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.options = .oneofInt32(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofInt32(v)
+        }
       }()
       case 11: try { try decoder.decodeSingularStringField(value: &self._myString) }()
       case 60: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Int64?
         try decoder.decodeSingularInt64Field(value: &v)
-        if let v = v {self.options = .oneofInt64(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofInt64(v)
+        }
       }()
       case 101: try { try decoder.decodeSingularFloatField(value: &self._myFloat) }()
       case 150: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.options = .oneofString(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofString(v)
+        }
       }()
       case 200: try { try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage) }()
       case 2..<9, 12..<56:
@@ -633,53 +641,69 @@ extension Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftP
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.oGood != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oGood = .a(v)}
+        if let v = v {
+          if self.oGood != nil {try decoder.handleConflictingOneOf()}
+          self.oGood = .a(v)
+        }
       }()
       case 26: try {
-        if self.oGood != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oGood = .b(v)}
+        if let v = v {
+          if self.oGood != nil {try decoder.handleConflictingOneOf()}
+          self.oGood = .b(v)
+        }
       }()
       case 101: try {
-        if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictField = .a2(v)}
+        if let v = v {
+          if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictField = .a2(v)
+        }
       }()
       case 113: try { try decoder.decodeSingularInt32Field(value: &self._m) }()
       case 126: try {
-        if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictField = .b2(v)}
+        if let v = v {
+          if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictField = .b2(v)
+        }
       }()
       case 201: try {
-        if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsStart = .a3(v)}
+        if let v = v {
+          if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsStart = .a3(v)
+        }
       }()
       case 226: try {
-        if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsStart = .b3(v)}
+        if let v = v {
+          if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsStart = .b3(v)
+        }
       }()
       case 301: try {
-        if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsEnd = .a4(v)}
+        if let v = v {
+          if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsEnd = .a4(v)
+        }
       }()
       case 326: try {
-        if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsEnd = .b4(v)}
+        if let v = v {
+          if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsEnd = .b4(v)
+        }
       }()
       case 202..<203, 325..<326:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_OneofTraversalGeneration.self, fieldNumber: fieldNumber) }()

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -26797,16 +26797,20 @@ extension SwiftUnittest_Names_ValidIdentifiers: SwiftProtobuf.Message, SwiftProt
       case 2: try { try decoder.decodeSingularInt32Field(value: &self._field) }()
       case 3: try { try decoder.decodeSingularInt32Field(value: &self.__3Field3) }()
       case 4: try {
-        if self._2Of != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self._2Of = ._4(v)}
+        if let v = v {
+          if self._2Of != nil {try decoder.handleConflictingOneOf()}
+          self._2Of = ._4(v)
+        }
       }()
       case 5: try {
-        if self._2Of != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self._2Of = ._5Field(v)}
+        if let v = v {
+          if self._2Of != nil {try decoder.handleConflictingOneOf()}
+          self._2Of = ._5Field(v)
+        }
       }()
       case 6: try { try decoder.decodeSingularEnumField(value: &self._enumField) }()
       default: break

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -348,10 +348,12 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
         if let v = v {self.option = .option3(v)}
       }()
       case 6: try {
-        if self.option != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.option = .option4(v)}
+        if let v = v {
+          if self.option != nil {try decoder.handleConflictingOneOf()}
+          self.option = .option4(v)
+        }
       }()
       default: break
       }

--- a/Reference/unittest_swift_oneof_merging.pb.swift
+++ b/Reference/unittest_swift_oneof_merging.pb.swift
@@ -214,10 +214,12 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 111: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 112: try {
         var v: SwiftUnittest_TestMessage.NestedMessage?
@@ -229,16 +231,20 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if let v = v {self.oneofField = .oneofNestedMessage(v)}
       }()
       case 113: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 114: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       default: break
       }

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -1148,94 +1148,124 @@ extension ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 48: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage) }()
         case 49: try { try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnum) }()
         case 51: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofInt32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt32(v)
+          }
         }()
         case 52: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofInt64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt64(v)
+          }
         }()
         case 53: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofUint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint32(v)
+          }
         }()
         case 54: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofUint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint64(v)
+          }
         }()
         case 55: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofSint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint32(v)
+          }
         }()
         case 56: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofSint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint64(v)
+          }
         }()
         case 57: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed32(v)
+          }
         }()
         case 58: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed64(v)
+          }
         }()
         case 59: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed32(v)
+          }
         }()
         case 60: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed64(v)
+          }
         }()
         case 61: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._o = .oneofFloat(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFloat(v)
+          }
         }()
         case 62: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._o = .oneofDouble(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofDouble(v)
+          }
         }()
         case 63: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._o = .oneofBool(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBool(v)
+          }
         }()
         case 64: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._o = .oneofString(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofString(v)
+          }
         }()
         case 65: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._o = .oneofBytes(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBytes(v)
+          }
         }()
         case 66: try {
           var v: ProtobufUnittest_Message2.OneofGroup?
@@ -1256,10 +1286,12 @@ extension ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._Messa
           if let v = v {_storage._o = .oneofMessage(v)}
         }()
         case 69: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufUnittest_Message2.Enum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .oneofEnum(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofEnum(v)
+          }
         }()
         case 70: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_storage._mapInt32Int32) }()
         case 71: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_storage._mapInt64Int64) }()

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -946,94 +946,124 @@ extension ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 48: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage) }()
         case 49: try { try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnum) }()
         case 51: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofInt32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt32(v)
+          }
         }()
         case 52: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofInt64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt64(v)
+          }
         }()
         case 53: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofUint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint32(v)
+          }
         }()
         case 54: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofUint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint64(v)
+          }
         }()
         case 55: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofSint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint32(v)
+          }
         }()
         case 56: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofSint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint64(v)
+          }
         }()
         case 57: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed32(v)
+          }
         }()
         case 58: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed64(v)
+          }
         }()
         case 59: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed32(v)
+          }
         }()
         case 60: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed64(v)
+          }
         }()
         case 61: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._o = .oneofFloat(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFloat(v)
+          }
         }()
         case 62: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._o = .oneofDouble(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofDouble(v)
+          }
         }()
         case 63: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._o = .oneofBool(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBool(v)
+          }
         }()
         case 64: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._o = .oneofString(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofString(v)
+          }
         }()
         case 65: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._o = .oneofBytes(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBytes(v)
+          }
         }()
         case 68: try {
           var v: ProtobufUnittest_Message3?
@@ -1045,10 +1075,12 @@ extension ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._Messa
           if let v = v {_storage._o = .oneofMessage(v)}
         }()
         case 69: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufUnittest_Message3.Enum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .oneofEnum(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofEnum(v)
+          }
         }()
         case 70: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_storage._mapInt32Int32) }()
         case 71: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_storage._mapInt64Int64) }()

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -585,32 +585,40 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.payload = .protobufPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .protobufPayload(v)
+        }
       }()
       case 2: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jsonPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jsonPayload(v)
+        }
       }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self.messageType) }()
       case 5: try { try decoder.decodeSingularEnumField(value: &self.testCategory) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions) }()
       case 7: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jspbPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .textPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .textPayload(v)
+        }
       }()
       case 9: try { try decoder.decodeSingularBoolField(value: &self.printUnknownFields) }()
       default: break
@@ -697,52 +705,68 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .parseError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .parseError(v)
+        }
       }()
       case 2: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .runtimeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .runtimeError(v)
+        }
       }()
       case 3: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.result = .protobufPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .protobufPayload(v)
+        }
       }()
       case 4: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jsonPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jsonPayload(v)
+        }
       }()
       case 5: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .skipped(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .skipped(v)
+        }
       }()
       case 6: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .serializeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .serializeError(v)
+        }
       }()
       case 7: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jspbPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .textPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .textPayload(v)
+        }
       }()
       default: break
       }

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -1817,10 +1817,12 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
         case 101: try { try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool) }()
         case 102: try { try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedMessage?
@@ -1832,46 +1834,60 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.Message,
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBool(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBool(v)
+          }
         }()
         case 116: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint64(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint64(v)
+          }
         }()
         case 117: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._oneofField = .oneofFloat(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofFloat(v)
+          }
         }()
         case 118: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._oneofField = .oneofDouble(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofDouble(v)
+          }
         }()
         case 119: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufTestMessages_Proto2_TestAllTypesProto2.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         case 201: try { try decoder.decodeSingularGroupField(value: &_storage._data) }()
         case 401: try { try decoder.decodeSingularInt32Field(value: &_storage._fieldname1) }()

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1752,10 +1752,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 101: try { try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool) }()
         case 102: try { try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedMessage?
@@ -1767,52 +1769,68 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBool(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBool(v)
+          }
         }()
         case 116: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint64(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint64(v)
+          }
         }()
         case 117: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._oneofField = .oneofFloat(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofFloat(v)
+          }
         }()
         case 118: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._oneofField = .oneofDouble(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofDouble(v)
+          }
         }()
         case 119: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         case 120: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: SwiftProtobuf.Google_Protobuf_NullValue?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofNullValue(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofNullValue(v)
+          }
         }()
         case 201: try { try decoder.decodeSingularMessageField(value: &_storage._optionalBoolWrapper) }()
         case 202: try { try decoder.decodeSingularMessageField(value: &_storage._optionalInt32Wrapper) }()

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -312,28 +312,36 @@ extension Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Google_Protobuf_NullValue?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.kind = .nullValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .nullValue(v)
+        }
       }()
       case 2: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Double?
         try decoder.decodeSingularDoubleField(value: &v)
-        if let v = v {self.kind = .numberValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .numberValue(v)
+        }
       }()
       case 3: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.kind = .stringValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .stringValue(v)
+        }
       }()
       case 4: try {
-        if self.kind != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.kind = .boolValue(v)}
+        if let v = v {
+          if self.kind != nil {try decoder.handleConflictingOneOf()}
+          self.kind = .boolValue(v)
+        }
       }()
       case 5: try {
         var v: Google_Protobuf_Struct?

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
 		9C4178631E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
 		9C4178641E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C41AD3027A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C41AD2F27A09E1900E027C5 /* unittest_swift_json.pb.swift */; };
+		9C41AD3127A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C41AD2F27A09E1900E027C5 /* unittest_swift_json.pb.swift */; };
+		9C41AD3227A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C41AD2F27A09E1900E027C5 /* unittest_swift_json.pb.swift */; };
 		9C5890A71DFF5FFC001CFC34 /* Test_TextFormat_proto2_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */; };
 		9C5890A81DFF6375001CFC34 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
 		9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
@@ -720,6 +723,7 @@
 		8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
 		9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
 		9C4178601E809DA2007830C3 /* ExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionMap.swift; sourceTree = "<group>"; };
+		9C41AD2F27A09E1900E027C5 /* unittest_swift_json.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_json.pb.swift; sourceTree = "<group>"; };
 		9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2_extensions.swift; sourceTree = "<group>"; };
 		9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_Map_proto3.swift; sourceTree = "<group>"; };
 		9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2.swift; sourceTree = "<group>"; };
@@ -1195,6 +1199,7 @@
 				F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */,
+				9C41AD2F27A09E1900E027C5 /* unittest_swift_json.pb.swift */,
 				F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */,
 				F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */,
@@ -1404,6 +1409,7 @@
 				F4151F671EF3197200EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
 				F47CF9A223E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
 				9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */,
+				9C41AD3127A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */,
 				F40D33EB2017ED2200ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
 				9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */,
 				9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */,
@@ -1703,6 +1709,7 @@
 				F4151F661EF3197100EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
 				F47CF9A123E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift in Sources */,
+				9C41AD3027A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */,
 				F40D33EA2017ED2100ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */,
@@ -1912,6 +1919,7 @@
 				F4151F681EF3197300EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
 				F47CF9A323E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
 				F44F93BD1DAEA8C900BC5B85 /* Test_FieldOrdering.swift in Sources */,
+				9C41AD3227A09E1900E027C5 /* unittest_swift_json.pb.swift in Sources */,
 				F40D33EC2017ED2300ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
 				F44F93C21DAEA8C900BC5B85 /* Test_Map_JSON.swift in Sources */,
 				F44F93DD1DAEA8C900BC5B85 /* unittest_lite.pb.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -647,7 +647,9 @@ extension Test_JSON_Conformance {
         ("testNullSupport_RepeatedValue", testNullSupport_RepeatedValue),
         ("testNullConformance", testNullConformance),
         ("testValueList", testValueList),
-        ("testNestedAny", testNestedAny)
+        ("testNestedAny", testNestedAny),
+        ("testConflictingOneOf", testConflictingOneOf),
+        ("testConflictingOneOf_2", testConflictingOneOf_2)
     ]
 }
 

--- a/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
@@ -299,4 +299,28 @@ class Test_JSON_Conformance: XCTestCase {
             return
         }
     }
+
+    func testConflictingOneOf() {
+        let start = "{\"oneofUint32\": null, \"oneofString\": \"test\"}"
+        let decoded: ProtobufTestMessages_Proto3_TestAllTypesProto3
+        do {
+           decoded = try ProtobufTestMessages_Proto3_TestAllTypesProto3(jsonString: start)
+        } catch {
+           XCTFail("Failed to decode: \(start)")
+           return
+        }
+        XCTAssertEqual(try decoded.jsonString(), "{\"oneofString\":\"test\"}")
+    }
+
+    func testConflictingOneOf_2() {
+        let start = "{\"oneofString\": \"test\", \"oneofUint32\": null}"
+        let decoded: ProtobufTestMessages_Proto3_TestAllTypesProto3
+        do {
+           decoded = try ProtobufTestMessages_Proto3_TestAllTypesProto3(jsonString: start)
+        } catch {
+           XCTFail("Failed to decode: \(start)")
+           return
+        }
+        XCTAssertEqual(try decoded.jsonString(), "{\"oneofString\":\"test\"}")
+    }
 }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -585,32 +585,40 @@ extension Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf._
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.payload = .protobufPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .protobufPayload(v)
+        }
       }()
       case 2: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jsonPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jsonPayload(v)
+        }
       }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.requestedOutputFormat) }()
       case 4: try { try decoder.decodeSingularStringField(value: &self.messageType) }()
       case 5: try { try decoder.decodeSingularEnumField(value: &self.testCategory) }()
       case 6: try { try decoder.decodeSingularMessageField(value: &self._jspbEncodingOptions) }()
       case 7: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .jspbPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.payload != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.payload = .textPayload(v)}
+        if let v = v {
+          if self.payload != nil {try decoder.handleConflictingOneOf()}
+          self.payload = .textPayload(v)
+        }
       }()
       case 9: try { try decoder.decodeSingularBoolField(value: &self.printUnknownFields) }()
       default: break
@@ -697,52 +705,68 @@ extension Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .parseError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .parseError(v)
+        }
       }()
       case 2: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .runtimeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .runtimeError(v)
+        }
       }()
       case 3: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.result = .protobufPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .protobufPayload(v)
+        }
       }()
       case 4: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jsonPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jsonPayload(v)
+        }
       }()
       case 5: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .skipped(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .skipped(v)
+        }
       }()
       case 6: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .serializeError(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .serializeError(v)
+        }
       }()
       case 7: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .jspbPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .jspbPayload(v)
+        }
       }()
       case 8: try {
-        if self.result != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.result = .textPayload(v)}
+        if let v = v {
+          if self.result != nil {try decoder.handleConflictingOneOf()}
+          self.result = .textPayload(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1752,10 +1752,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
         case 101: try { try decoder.decodeRepeatedBoolField(value: &_storage._unpackedBool) }()
         case 102: try { try decoder.decodeRepeatedEnumField(value: &_storage._unpackedNestedEnum) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedMessage?
@@ -1767,52 +1769,68 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBool(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBool(v)
+          }
         }()
         case 116: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint64(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint64(v)
+          }
         }()
         case 117: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._oneofField = .oneofFloat(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofFloat(v)
+          }
         }()
         case 118: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._oneofField = .oneofDouble(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofDouble(v)
+          }
         }()
         case 119: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufTestMessages_Proto3_TestAllTypesProto3.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         case 120: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: SwiftProtobuf.Google_Protobuf_NullValue?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofNullValue(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofNullValue(v)
+          }
         }()
         case 201: try { try decoder.decodeSingularMessageField(value: &_storage._optionalBoolWrapper) }()
         case 202: try { try decoder.decodeSingularMessageField(value: &_storage._optionalInt32Wrapper) }()

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -7645,10 +7645,12 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllTypes.NestedMessage?
@@ -7660,16 +7662,20 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }
@@ -8204,10 +8210,12 @@ extension ProtobufUnittest_TestDeprecatedFields: SwiftProtobuf.Message, SwiftPro
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self._deprecatedInt32) }()
       case 2: try {
-        if self.oneofFields != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oneofFields = .deprecatedInt32InOneof(v)}
+        if let v = v {
+          if self.oneofFields != nil {try decoder.handleConflictingOneOf()}
+          self.oneofFields = .deprecatedInt32InOneof(v)
+        }
       }()
       default: break
       }
@@ -10819,16 +10827,20 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._Mess
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
         var v: ProtobufUnittest_TestAllTypes?
@@ -11041,40 +11053,52 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooCord(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooCord(v)
+        }
       }()
       case 4: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooStringPiece(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooStringPiece(v)
+        }
       }()
       case 5: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.foo = .fooBytes(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooBytes(v)
+        }
       }()
       case 6: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.foo = .fooEnum(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooEnum(v)
+        }
       }()
       case 7: try {
         var v: ProtobufUnittest_TestOneof2.NestedMessage?
@@ -11104,40 +11128,52 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Mes
         if let v = v {self.foo = .fooLazyMessage(v)}
       }()
       case 12: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.bar = .barInt(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barInt(v)
+        }
       }()
       case 13: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barString(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barString(v)
+        }
       }()
       case 14: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barCord(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barCord(v)
+        }
       }()
       case 15: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.bar = .barStringPiece(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barStringPiece(v)
+        }
       }()
       case 16: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.bar = .barBytes(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barBytes(v)
+        }
       }()
       case 17: try {
-        if self.bar != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.bar = .barEnum(v)}
+        if let v = v {
+          if self.bar != nil {try decoder.handleConflictingOneOf()}
+          self.bar = .barEnum(v)
+        }
       }()
       case 18: try { try decoder.decodeSingularInt32Field(value: &self._bazInt) }()
       case 19: try { try decoder.decodeSingularStringField(value: &self._bazString) }()
@@ -11342,16 +11378,20 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtob
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .fooInt(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooInt(v)
+        }
       }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .fooString(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooString(v)
+        }
       }()
       case 3: try {
         var v: ProtobufUnittest_TestRequiredOneof.NestedMessage?
@@ -12392,10 +12432,12 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
       case 536870008: try { try decoder.decodeSingularGroupField(value: &self._optionalGroup) }()
       case 536870010: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap) }()
       case 536870011: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 536870012: try {
         var v: ProtobufUnittest_TestAllTypes?
@@ -12407,16 +12449,20 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftPro
         if let v = v {self.oneofField = .oneofTestAllTypes(v)}
       }()
       case 536870013: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 536870014: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 536860000..<536870000:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber) }()

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1918,10 +1918,12 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, 
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self._field1) }()
       case 2: try {
-        if self.anOneof != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.anOneof = .oneofField(v)}
+        if let v = v {
+          if self.anOneof != nil {try decoder.handleConflictingOneOf()}
+          self.anOneof = .oneofField(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -4155,10 +4155,12 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobu
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllTypesLite.NestedMessage?
@@ -4170,16 +4172,20 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobu
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try {
           var v: ProtobufUnittest_TestAllTypesLite.NestedMessage?
@@ -5502,10 +5508,12 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
       case 536870008: try { try decoder.decodeSingularGroupField(value: &self._optionalGroup) }()
       case 536870010: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.stringStringMap) }()
       case 536870011: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 536870012: try {
         var v: ProtobufUnittest_TestAllTypesLite?
@@ -5517,16 +5525,20 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, Swif
         if let v = v {self.oneofField = .oneofTestAllTypes(v)}
       }()
       case 536870013: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 536870014: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 536860000..<536870000:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber) }()
@@ -5663,10 +5675,12 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofInt32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofInt32(v)
+        }
       }()
       case 2: try {
         var v: ProtobufUnittest_TestAllTypesLite?
@@ -5678,46 +5692,60 @@ extension ProtobufUnittest_TestOneofParsingLite: SwiftProtobuf.Message, SwiftPro
         if let v = v {self.oneofField = .oneofSubmessage(v)}
       }()
       case 3: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 4: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       case 5: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofStringCord(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofStringCord(v)
+        }
       }()
       case 6: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytesCord(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytesCord(v)
+        }
       }()
       case 7: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofStringStringPiece(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofStringStringPiece(v)
+        }
       }()
       case 8: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytesStringPiece(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytesStringPiece(v)
+        }
       }()
       case 9: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: ProtobufUnittest_V2EnumLite?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.oneofField = .oneofEnum(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofEnum(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -758,10 +758,12 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, Swi
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
@@ -773,16 +775,20 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, Swi
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._oneofField = .oneofEnum(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofEnum(v)
+          }
         }()
         default: break
         }

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -270,16 +270,20 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftPro
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt32Field(value: &self._i) }()
       case 2: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.foo = .integerField(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .integerField(v)
+        }
       }()
       case 3: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.foo = .stringField(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .stringField(v)
+        }
       }()
       case 19: try { try decoder.decodeSingularMessageField(value: &self._msg) }()
       case 1000..<536870912:

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -306,16 +306,20 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }
@@ -385,16 +389,20 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Me
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -191,16 +191,20 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Sw
       case 3: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedE) }()
       case 4: try { try decoder.decodeRepeatedEnumField(value: &self.repeatedPackedUnexpectedE) }()
       case 5: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE1(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE1(v)
+        }
       }()
       case 6: try {
-        if self.o != nil {try decoder.handleConflictingOneOf()}
         var v: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.o = .oneofE2(v)}
+        if let v = v {
+          if self.o != nil {try decoder.handleConflictingOneOf()}
+          self.o = .oneofE2(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -996,10 +996,12 @@ extension Proto3Unittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mes
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3Unittest_TestAllTypes.NestedMessage?
@@ -1011,16 +1013,20 @@ extension Proto3Unittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mes
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try { try decoder.decodeSingularMessageField(value: &_storage._optionalLazyImportMessage) }()
         default: break
@@ -1694,10 +1700,12 @@ extension Proto3Unittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 6: try {
-        if self.foo != nil {try decoder.handleConflictingOneOf()}
         var v: Proto3Unittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &v)
-        if let v = v {self.foo = .fooEnum(v)}
+        if let v = v {
+          if self.foo != nil {try decoder.handleConflictingOneOf()}
+          self.foo = .fooEnum(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -933,10 +933,12 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
         case 55: try { try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord) }()
         case 57: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
@@ -948,16 +950,20 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         case 115: try { try decoder.decodeSingularMessageField(value: &_storage._optionalLazyImportMessage) }()
         default: break

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -1030,10 +1030,12 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
         case 84: try { try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece) }()
         case 85: try { try decoder.decodeSingularStringField(value: &_storage._defaultCord) }()
         case 111: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._oneofField = .oneofUint32(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofUint32(v)
+          }
         }()
         case 112: try {
           var v: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
@@ -1045,16 +1047,20 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPro
           if let v = v {_storage._oneofField = .oneofNestedMessage(v)}
         }()
         case 113: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._oneofField = .oneofString(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofString(v)
+          }
         }()
         case 114: try {
-          if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._oneofField = .oneofBytes(v)}
+          if let v = v {
+            if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
+            _storage._oneofField = .oneofBytes(v)
+          }
         }()
         default: break
         }

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -486,30 +486,38 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularInt64Field(value: &self._myInt) }()
       case 9: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Bool?
         try decoder.decodeSingularBoolField(value: &v)
-        if let v = v {self.options = .oneofBool(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofBool(v)
+        }
       }()
       case 10: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.options = .oneofInt32(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofInt32(v)
+        }
       }()
       case 11: try { try decoder.decodeSingularStringField(value: &self._myString) }()
       case 60: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: Int64?
         try decoder.decodeSingularInt64Field(value: &v)
-        if let v = v {self.options = .oneofInt64(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofInt64(v)
+        }
       }()
       case 101: try { try decoder.decodeSingularFloatField(value: &self._myFloat) }()
       case 150: try {
-        if self.options != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.options = .oneofString(v)}
+        if let v = v {
+          if self.options != nil {try decoder.handleConflictingOneOf()}
+          self.options = .oneofString(v)
+        }
       }()
       case 200: try { try decoder.decodeSingularMessageField(value: &self._optionalNestedMessage) }()
       case 2..<9, 12..<56:
@@ -633,53 +641,69 @@ extension Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftP
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try {
-        if self.oGood != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oGood = .a(v)}
+        if let v = v {
+          if self.oGood != nil {try decoder.handleConflictingOneOf()}
+          self.oGood = .a(v)
+        }
       }()
       case 26: try {
-        if self.oGood != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oGood = .b(v)}
+        if let v = v {
+          if self.oGood != nil {try decoder.handleConflictingOneOf()}
+          self.oGood = .b(v)
+        }
       }()
       case 101: try {
-        if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictField = .a2(v)}
+        if let v = v {
+          if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictField = .a2(v)
+        }
       }()
       case 113: try { try decoder.decodeSingularInt32Field(value: &self._m) }()
       case 126: try {
-        if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictField = .b2(v)}
+        if let v = v {
+          if self.oConflictField != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictField = .b2(v)
+        }
       }()
       case 201: try {
-        if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsStart = .a3(v)}
+        if let v = v {
+          if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsStart = .a3(v)
+        }
       }()
       case 226: try {
-        if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsStart = .b3(v)}
+        if let v = v {
+          if self.oConflictExtensionsStart != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsStart = .b3(v)
+        }
       }()
       case 301: try {
-        if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsEnd = .a4(v)}
+        if let v = v {
+          if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsEnd = .a4(v)
+        }
       }()
       case 326: try {
-        if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.oConflictExtensionsEnd = .b4(v)}
+        if let v = v {
+          if self.oConflictExtensionsEnd != nil {try decoder.handleConflictingOneOf()}
+          self.oConflictExtensionsEnd = .b4(v)
+        }
       }()
       case 202..<203, 325..<326:
         try { try decoder.decodeExtensionField(values: &_protobuf_extensionFieldValues, messageType: Swift_Protobuf_OneofTraversalGeneration.self, fieldNumber: fieldNumber) }()

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -26797,16 +26797,20 @@ extension SwiftUnittest_Names_ValidIdentifiers: SwiftProtobuf.Message, SwiftProt
       case 2: try { try decoder.decodeSingularInt32Field(value: &self._field) }()
       case 3: try { try decoder.decodeSingularInt32Field(value: &self.__3Field3) }()
       case 4: try {
-        if self._2Of != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self._2Of = ._4(v)}
+        if let v = v {
+          if self._2Of != nil {try decoder.handleConflictingOneOf()}
+          self._2Of = ._4(v)
+        }
       }()
       case 5: try {
-        if self._2Of != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self._2Of = ._5Field(v)}
+        if let v = v {
+          if self._2Of != nil {try decoder.handleConflictingOneOf()}
+          self._2Of = ._5Field(v)
+        }
       }()
       case 6: try { try decoder.decodeSingularEnumField(value: &self._enumField) }()
       default: break

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -348,10 +348,12 @@ extension ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message, SwiftProtobuf.
         if let v = v {self.option = .option3(v)}
       }()
       case 6: try {
-        if self.option != nil {try decoder.handleConflictingOneOf()}
         var v: Int32?
         try decoder.decodeSingularInt32Field(value: &v)
-        if let v = v {self.option = .option4(v)}
+        if let v = v {
+          if self.option != nil {try decoder.handleConflictingOneOf()}
+          self.option = .option4(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
@@ -214,10 +214,12 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 111: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: UInt32?
         try decoder.decodeSingularUInt32Field(value: &v)
-        if let v = v {self.oneofField = .oneofUint32(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofUint32(v)
+        }
       }()
       case 112: try {
         var v: SwiftUnittest_TestMessage.NestedMessage?
@@ -229,16 +231,20 @@ extension SwiftUnittest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
         if let v = v {self.oneofField = .oneofNestedMessage(v)}
       }()
       case 113: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: String?
         try decoder.decodeSingularStringField(value: &v)
-        if let v = v {self.oneofField = .oneofString(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofString(v)
+        }
       }()
       case 114: try {
-        if self.oneofField != nil {try decoder.handleConflictingOneOf()}
         var v: Data?
         try decoder.decodeSingularBytesField(value: &v)
-        if let v = v {self.oneofField = .oneofBytes(v)}
+        if let v = v {
+          if self.oneofField != nil {try decoder.handleConflictingOneOf()}
+          self.oneofField = .oneofBytes(v)
+        }
       }()
       default: break
       }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -1148,94 +1148,124 @@ extension ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 48: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage) }()
         case 49: try { try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnum) }()
         case 51: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofInt32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt32(v)
+          }
         }()
         case 52: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofInt64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt64(v)
+          }
         }()
         case 53: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofUint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint32(v)
+          }
         }()
         case 54: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofUint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint64(v)
+          }
         }()
         case 55: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofSint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint32(v)
+          }
         }()
         case 56: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofSint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint64(v)
+          }
         }()
         case 57: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed32(v)
+          }
         }()
         case 58: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed64(v)
+          }
         }()
         case 59: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed32(v)
+          }
         }()
         case 60: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed64(v)
+          }
         }()
         case 61: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._o = .oneofFloat(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFloat(v)
+          }
         }()
         case 62: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._o = .oneofDouble(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofDouble(v)
+          }
         }()
         case 63: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._o = .oneofBool(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBool(v)
+          }
         }()
         case 64: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._o = .oneofString(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofString(v)
+          }
         }()
         case 65: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._o = .oneofBytes(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBytes(v)
+          }
         }()
         case 66: try {
           var v: ProtobufUnittest_Message2.OneofGroup?
@@ -1256,10 +1286,12 @@ extension ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._Messa
           if let v = v {_storage._o = .oneofMessage(v)}
         }()
         case 69: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufUnittest_Message2.Enum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .oneofEnum(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofEnum(v)
+          }
         }()
         case 70: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_storage._mapInt32Int32) }()
         case 71: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_storage._mapInt64Int64) }()

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -946,94 +946,124 @@ extension ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._Messa
         case 48: try { try decoder.decodeRepeatedMessageField(value: &_storage._repeatedMessage) }()
         case 49: try { try decoder.decodeRepeatedEnumField(value: &_storage._repeatedEnum) }()
         case 51: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofInt32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt32(v)
+          }
         }()
         case 52: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofInt64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofInt64(v)
+          }
         }()
         case 53: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofUint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint32(v)
+          }
         }()
         case 54: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularUInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofUint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofUint64(v)
+          }
         }()
         case 55: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSInt32Field(value: &v)
-          if let v = v {_storage._o = .oneofSint32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint32(v)
+          }
         }()
         case 56: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSInt64Field(value: &v)
-          if let v = v {_storage._o = .oneofSint64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSint64(v)
+          }
         }()
         case 57: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt32?
           try decoder.decodeSingularFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed32(v)
+          }
         }()
         case 58: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: UInt64?
           try decoder.decodeSingularFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofFixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFixed64(v)
+          }
         }()
         case 59: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int32?
           try decoder.decodeSingularSFixed32Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed32(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed32(v)
+          }
         }()
         case 60: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Int64?
           try decoder.decodeSingularSFixed64Field(value: &v)
-          if let v = v {_storage._o = .oneofSfixed64(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofSfixed64(v)
+          }
         }()
         case 61: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Float?
           try decoder.decodeSingularFloatField(value: &v)
-          if let v = v {_storage._o = .oneofFloat(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofFloat(v)
+          }
         }()
         case 62: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Double?
           try decoder.decodeSingularDoubleField(value: &v)
-          if let v = v {_storage._o = .oneofDouble(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofDouble(v)
+          }
         }()
         case 63: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Bool?
           try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {_storage._o = .oneofBool(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBool(v)
+          }
         }()
         case 64: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: String?
           try decoder.decodeSingularStringField(value: &v)
-          if let v = v {_storage._o = .oneofString(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofString(v)
+          }
         }()
         case 65: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: Data?
           try decoder.decodeSingularBytesField(value: &v)
-          if let v = v {_storage._o = .oneofBytes(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofBytes(v)
+          }
         }()
         case 68: try {
           var v: ProtobufUnittest_Message3?
@@ -1045,10 +1075,12 @@ extension ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._Messa
           if let v = v {_storage._o = .oneofMessage(v)}
         }()
         case 69: try {
-          if _storage._o != nil {try decoder.handleConflictingOneOf()}
           var v: ProtobufUnittest_Message3.Enum?
           try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {_storage._o = .oneofEnum(v)}
+          if let v = v {
+            if _storage._o != nil {try decoder.handleConflictingOneOf()}
+            _storage._o = .oneofEnum(v)
+          }
         }()
         case 70: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_storage._mapInt32Int32) }()
         case 71: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_storage._mapInt64Int64) }()


### PR DESCRIPTION
We previously decoded oneof fields with this template:
    
```
if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
var v: UInt32?
try decoder.decodeSingularUInt32Field(value: &v)
if let v = v {
  _storage._oneofField = .oneofUint32(v)
}
```

That is, if the field was already set, treat it as a conflict.
For JSON, the conformance suite now expects the following to be
handled identically:
```
   {"oneofString":"test", "oneofUint32": null}
   {"oneofUint32": null, "oneofString":"test"}
```
This makes sense, since JSON decoding should not depend on
order.  But the template above handles these differently; the
first is treated as a conflict and the second is not.

To address this, I've changed the oneof decoding template to
look like this:
```
var v: UInt32?
try decoder.decodeSingularUInt32Field(value: &v)
if let v = v {
  if _storage._oneofField != nil {try decoder.handleConflictingOneOf()}
  _storage._oneofField = .oneofUint32(v)
}
```
With this template, we eagerly decode the field, then
consider it a conflict only if the field was already set
_and_ the field decoded to a non-nil value.
