### PR TITLE
Fix typo in PLUGIN.md with reference to --swift_out instead of --swift_opt

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -93,7 +93,7 @@ By default, the paths to the proto files are maintained on the
 generated files.  So if you pass `foo/bar/my.proto`, you will get
 `foo/bar/my.pb.swift` in the output directory. The Swift plugin
 supports an option to control the generated file names, the option is
-given as part of the `--swift_out` argument like this:
+given as part of the `--swift_opt` argument like this:
 
 ```
 $ protoc --swift_opt=FileNaming=[value] --swift_out=. foo/bar/*.proto mumble/*.proto


### PR DESCRIPTION
Noticed this _other_ typo while familiarizing myself with `swift-protobuf`.

Hope this helps.