### PR TITLE
Add back a spi.yml file.

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,9 @@
+version: 1
+builder:
+  configs:
+  - platform: ios
+    scheme: SwiftProtobuf
+  - platform: tvos
+    scheme: SwiftProtobuf
+  - platform: watchos
+    scheme: SwiftProtobuf


### PR DESCRIPTION
For iOS, tvOS, watchOS, swiftpackageindex.com uses `xcodebuild` with the
_SwiftProtobuf-Package_ scheme, but `xcodebuild` fails silently on some sub
steps with no output and just a non zero exit code. Since it doesn't actually
run the tests in any of cases, we can cheat and just have it build the runtime
library scheme.