### PR TITLE
Add SPM plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,29 +14,61 @@ import PackageDescription
 let package = Package(
   name: "SwiftProtobuf",
   products: [
-    .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
-    .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"]),
-    .library(name: "SwiftProtobufPluginLibrary", targets: ["SwiftProtobufPluginLibrary"]),
+    .executable(
+        name: "protoc-gen-swift",
+        targets: ["protoc-gen-swift"]
+    ),
+    .library(
+        name: "SwiftProtobuf",
+        targets: ["SwiftProtobuf"]
+    ),
+    .library(
+        name: "SwiftProtobufPluginLibrary",
+        targets: ["SwiftProtobufPluginLibrary"]
+    ),
+    .plugin(
+        name: "SwiftProtobufPlugin",
+        targets: ["SwiftProtobufPlugin"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
-    .target(name: "SwiftProtobuf",
-            exclude: ["CMakeLists.txt"]),
-    .target(name: "SwiftProtobufPluginLibrary",
-            dependencies: ["SwiftProtobuf"],
-            exclude: ["CMakeLists.txt"]),
-    .executableTarget(name: "protoc-gen-swift",
-            dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"],
-            exclude: ["CMakeLists.txt"]),
-    .executableTarget(name: "Conformance",
-            dependencies: ["SwiftProtobuf"],
-            exclude: ["failure_list_swift.txt", "text_format_failure_list_swift.txt"]),
-    .testTarget(name: "SwiftProtobufTests",
-                dependencies: ["SwiftProtobuf"]),
-    .testTarget(name: "SwiftProtobufPluginLibraryTests",
-                dependencies: ["SwiftProtobufPluginLibrary"]),
+    .target(
+        name: "SwiftProtobuf",
+            exclude: ["CMakeLists.txt"]
+    ),
+    .target(
+        name: "SwiftProtobufPluginLibrary",
+        dependencies: ["SwiftProtobuf"],
+        exclude: ["CMakeLists.txt"]
+    ),
+    .executableTarget(
+        name: "protoc-gen-swift",
+        dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"],
+        exclude: ["CMakeLists.txt"]
+    ),
+    .executableTarget(
+        name: "Conformance",
+        dependencies: ["SwiftProtobuf"],
+        exclude: ["failure_list_swift.txt", "text_format_failure_list_swift.txt"]
+    ),
+    .plugin(
+        name: "SwiftProtobufPlugin",
+        capability: .buildTool(),
+        dependencies: [
+            "protoc-gen-swift"
+        ]
+    ),
+    .testTarget(
+        name: "SwiftProtobufTests",
+        dependencies: ["SwiftProtobuf"]
+    ),
+    .testTarget(
+        name: "SwiftProtobufPluginLibraryTests",
+        dependencies: ["SwiftProtobufPluginLibrary"]
+    ),
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -1,0 +1,139 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftProtobufPlugin: BuildToolPlugin {
+    /// Errors thrown by the `SwiftProtobufPlugin`
+    enum PluginError: Error {
+        /// Indicates that the target where the plugin was applied to was not `SourceModuleTarget`.
+        case invalidTarget
+        /// Indicates that no config file was present in the root of the target directory.
+        case noConfigFile
+    }
+
+    /// The configuration of the plugin.
+    struct Configuration: Codable {
+        /// Encapsulates a single invocation of protoc.
+        struct Invocation: Codable {
+            /// The visibility of the generated files.
+            enum Visibility: String, Codable {
+                /// The generated files should have `internal` access level.
+                case `internal`
+                /// The generated files should have `public` access level.
+                case `public`
+            }
+
+            /// An array of paths to `.proto` files for this invocation.
+            var protoFiles: [String]
+            /// The visibility of the generated files.
+            var visibility: Visibility?
+        }
+
+        /// The path to the `protoc` binary.
+        ///
+        /// If this is not set, SPM will try to find the tool itself.
+        var protocPath: String?
+
+        /// A list of invocations of `protoc` with the `SwiftProtobuf` plugin.
+        var invocations: [Invocation]
+    }
+
+    static let configurationFileName = "swift-protobuf-config.json"
+
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        print("Creating build commands (\(UUID()))")
+
+        // Let's check that this is a source target
+        guard let target = target as? SourceModuleTarget else {
+            throw PluginError.invalidTarget
+        }
+
+        // We need to find the configuration file at the root of the target
+        guard let configurationFilePath = target.sourceFiles.first(where: { $0.path.lastComponent == Self.configurationFileName }) else {
+            throw PluginError.noConfigFile
+        }
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: "\(configurationFilePath.path)"))
+        let configuration = try JSONDecoder().decode(Configuration.self, from: data)
+
+        // We need to find the path of protoc and protoc-gen-swift
+        let protocPath: Path
+        if let configuredProtocPath = configuration.protocPath {
+            protocPath = Path(configuredProtocPath)
+        } else {
+            protocPath = try context.tool(named: "protoc").path
+        }
+        let protocGenSwiftPath = try context.tool(named: "protoc-gen-swift").path
+
+        // This plugin generates its output into GeneratedSources
+        let outputDirectory = context.pluginWorkDirectory
+
+        return configuration.invocations.map { invocation in
+            self.invokeProtoc(
+                target: target,
+                invocation: invocation,
+                protocPath: protocPath,
+                protocGenSwiftPath: protocGenSwiftPath,
+                outputDirectory: outputDirectory
+            )
+        }
+    }
+
+    /// Invokes `protoc` with the given inputs
+    ///
+    /// - Parameters:
+    ///   - target: The plugin's target.
+    ///   - invocation: The `protoc` invocation.
+    ///   - protocPath: The path to the `protoc` binary.
+    ///   - protocGenSwiftPath: The path to the `protoc-gen-swift` binary.
+    ///   - outputDirectory: The output directory for the generated files.
+    /// - Returns: The build command.
+    private func invokeProtoc(
+        target: Target,
+        invocation: Configuration.Invocation,
+        protocPath: Path,
+        protocGenSwiftPath: Path,
+        outputDirectory: Path
+    ) -> Command {
+        // Construct the `protoc` arguments.
+        var protocArgs = [
+            "--plugin=protoc-gen-swift=\(protocGenSwiftPath)",
+            "--swift_out=\(outputDirectory)",
+            // We include the target directory as a proto search path
+            "-I",
+            "\(target.directory)",
+        ]
+
+        // Add the visibility if it was set
+        if let visibility = invocation.visibility {
+            protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue.capitalized)")
+        }
+
+        var inputFiles = [Path]()
+        var outputFiles = [Path]()
+
+        for file in invocation.protoFiles {
+            // Append the file to the protoc args so that it is used for generating
+            protocArgs.append("\(file)")
+            inputFiles.append(target.directory.appending(file))
+
+            // The name of the output file is based on the name of the input file.
+            let protobufOutputName = file.replacingOccurrences(of: ".proto", with: ".pb.swift")
+            let protobufOutputPath = outputDirectory.appending(protobufOutputName)
+
+            // Add the outputPath as an output file
+            outputFiles.append(protobufOutputPath)
+        }
+
+        // Construct the command. Specifying the input and output paths lets the build
+        // system know when to invoke the command. The output paths are passed on to
+        // the rule engine in the build system.
+        return Command.buildCommand(
+            displayName: "Generating swift files from proto files",
+            executable: protocPath,
+            arguments: protocArgs,
+            inputFiles: inputFiles + [protocGenSwiftPath],
+            outputFiles: outputFiles
+        )
+    }
+}

--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -1,0 +1,109 @@
+# Using the Swift Package Manager plugin
+
+The Swift Package Manager introduced new plugin capabilities in Swift 5.6, enabling the extension of
+the build process with custom build tools. Learn how to use the SwiftProtobuf plugin for the
+Swift Package Manager.
+
+## Overview
+
+> Warning: Due to limitations of binary executable discovery with Xcode we only recommend using the Swift Package Manager
+plugin in leaf packages. For more information, read the `Defining the path to the protoc binary` section of
+this article.
+
+The plugin works by running the system installed `protoc` compiler with the `protoc-gen-swift` plugin
+for specified `.proto` files in your targets source folder. Furthermore, the plugin allows defining a
+configuration file which will be used to customize the invocation of `protoc`.
+
+### Installing the protoc compiler
+
+First, you must ensure that you have the `protoc` compiler installed.
+There are multiple ways to do this. Some of the easiest are:
+
+1. If you are on MacOS, installing it via `brew install protoc`
+2. Download the binary from [Google's github repository](https://github.com/protocolbuffers/protobuf).
+
+### Adding the proto files to your target
+
+Next, you need to add the `.proto` files for which you want to generate your Swift types to your target's
+source directory. You should also commit these files to your git repository since the generated types
+are now generated on demand.
+
+### Adding the plugin to your manifest
+
+After adding the `.proto` files you can now add the plugin to the target inside your `Package.swift` manifest.
+First, you need to add a dependency on `swift-protobuf`. Afterwards, you can declare the usage of the plugin
+for your target. Here is an example snippet of a `Package.swift` manifest:
+
+```swift
+let package = Package(
+  name: "YourPackage",
+  products: [...],
+  dependencies: [
+    ...
+    .package(url: "https://github.com/apple/swift-protobuf", from: "2.0.0"),
+    ...
+  ],
+  targets: [
+    ...
+    .executableTarget(
+        name: "YourTarget",
+        plugins: [
+            .plugin(name: "SwiftProtobufPlugin")
+        ]
+    ),
+    ...
+)
+
+```
+
+### Configuring the plugin
+
+Lastly, after you have added the `.proto` files and modified your `Package.swift` manifest, you can now
+configure the plugin to invoke the `protoc` compiler. This is done by adding a `swift-protobuf-config.json`
+to the root of your target's source folder. An example configuration file looks like this:
+
+```json
+{
+    "invocations": [
+        {
+            "protoFiles": [
+                "Foo.proto",
+            ],
+            "visibility": "internal"
+        },
+        {
+            "protoFiles": [
+                "Bar.proto"
+            ],
+            "visibility": "public"
+        }
+    ]
+}
+
+```
+
+In the above configuration, you declared two invocations to the `protoc` compiler. The first invocation
+is generating Swift types for the `Foo.proto` file with `internal` visibility. The second invocation
+is generating Swift types for the `Bar.proto` file with the `public` visibility.
+
+### Defining the path to the protoc binary
+
+The plugin needs to be able to invoke the `protoc` binary to generate the Swift types. 
+There are two ways how this can be achieved. First, by default, the package manager looks into
+the `$PATH` to find binaries named `protoc`. This works immediately if you use `swift build` to build
+your package and `protoc` is installed in the `$PATH` (`brew` is adding it to your `$PATH` automatically).
+However, this doesn't work if you want to compile from Xcode since Xcode is not passed the `$PATH`.
+To still make this work from Xcode you can point the plugin to the concrete location of the `protoc`
+compiler by changing the configuration file like this:
+
+```json
+{
+    "protoCPath": "/path/to/protoc",
+    "invocations": [...]
+}
+
+```
+
+> Warning: This only solves the problem for leaf packages that are using the Swift package manager
+plugin since there you can point the package manager to the right binary. If your package is **NOT** a
+leaf package and should build with Xcode, we advise not to adopt the plugin yet!


### PR DESCRIPTION
# Motivation
SPM is providing new capabilities for tools to expose themselves as plugins which allows them to generate build commands. This allows us to create a plugin for `SwiftProtobuf` which invokes the `protoc` compiler and generates the Swift code. Creating such a plugin is greatly wanted since it improves the usage of the `protoc-gen-swift` plugin dramatically. Fixes https://github.com/apple/swift-protobuf/issues/1207

# Modification
This PR adds a new SPM plugin which generates build commands for generating Swift files from proto files. Since users of the plugin might have complex setups, I introduced a new `swift-protobuf-config.json` file that adopters have to put into the root of their target which wants to use the new plugin. The format of this configuration file is quite simple:

```json
{
    "invocations": [
        {
            "protoFiles": [
                "Foo.proto"
            ],
            "visibility": "internal"
        }
    ]
}

```

It allows you to configure multiple invocations to the `protoc` compiler. For each invocation you have to pass the relative path from the target source to the proto file. Additionally, you have to decide which visibility the generated symbols should have. In my opinion, this configuration files gives us the most flexibility and more complex setups to be covered as well.

# Open topics

## Hosting of the protoc binary
Hosting of the protoc binary is the last open thing to figure out before we can release a plugin for `SwiftProtobuf`. From my point of view, there are three possible routes we can take:

1. Include the `artifactbundle` inside the `SwiftProtobuf` repository
2. Include the `artifactebundle` as an artifact on the GH releases in the protobuf repo
3. Extend the the artifact bundle manifest to allow inclusion of URLs. This would require a Swift evolution pitch most likely.

However, with all three of the above we would still need to release a new version of `SwiftProtobuf` with every new release of `protoc`.

# Future work

## Proto dependencies between modules
With the current shape of the PR one can already use dependencies between proto files inside a single target. However, it might be desirable to be able to build dependency chains of Swift targets where each target includes proto files which depend on protoc files from the dependencies of the Swift target. I punted this from the initial plugin because this requires a bit more work and thinking. Firstly, how would you even spell such an import? Secondly, the current way of doing `ProtoPathModuleMapping` files is not super ideal for this approach. It might make sense to introduce a proto option to set the Swift module name inside the proto files already.

# Result
We now have a SPM plugin that can generate Swift code from proto files. To use it, it provides a configuration file format to declare different invocations to the `protoc` compiler.

TODOs:
- As soon as we agreed on the binary problem, I am going to write documentation how to use the plugin