### PR TITLE
CI followups/tweaks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,14 +114,15 @@ jobs:
       run: make test-conformance
 
   sanitizer_testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         sanitizer: ["address", "thread"]
         swiftpm_config: ["debug", "release"]
     container:
-      # Test on the latest Swift release
+      # Test on the latest Swift release. https://hub.docker.com/_/swift says
+      # swift:latest is still bionic, so explicitly use swift:focal.
       image: swift:focal
     steps:
     - uses: actions/checkout@v2
@@ -144,13 +145,14 @@ jobs:
         swift test -c ${{ matrix.swiftpm_config }} --sanitize=${{ matrix.sanitizer }} ${EXTRAS:-}
 
   fuzzing_regressions:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         swiftpm_config: ["debug", "release"]
     container:
-      # Test on the latest Swift release
+      # Test on the latest Swift release. https://hub.docker.com/_/swift says
+      # swift:latest is still bionic, so explicitly use swift:focal.
       image: swift:focal
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -20,17 +20,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["5.6-focal"]
+        swift: ["5.6.2"]
+        ubuntu: ["focal"]
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"
         # branch: "ref/heads/main"
         protobuf_git: ["ref/heads/main"]
     container:
-      image: swift:${{ matrix.swift }}
+      image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
- Use "ubuntu-latest" for all `runs-on` since the swift image ends up
  controlling the actual os run on.
- Document the use of "swift:focal" vs. "swift:latest" for some of the tests.
- Bring regular_conformance.yml back in line with build.yml, this should get
  them sharing cache keys again for the protobuf build to share those
  intermediate results.