### PR TITLE
Add Package.resolved to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ xcbaselines
 /build
 mined_words.txt
 /DescriptorTestData.bin
+/Package.resolved
 
 # Intermediate conformance test outputs
 failing_tests.txt


### PR DESCRIPTION
Now that there is another package reference (for docc), it causes a
Package.resolved to get created, so ignore it since there probably isn't a
reason to pin that information.