### PR TITLE
Remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ More information is available in the associated documentation:
  * [API.md](Documentation/API.md) documents how to use the generated code.
    This is recommended reading for anyone using SwiftProtobuf in their
    project.
- * [cocoadocs.org](http://cocoadocs.org/docsets/SwiftProtobuf/) has the generated
-   API documentation
  * [INTERNALS.md](Documentation/INTERNALS.md) documents the internal structure
    of the generated code and the library.  This
    should only be needed by folks interested in working on SwiftProtobuf


### PR DESCRIPTION
The link to [cocoadocs.org](http://cocoadocs.org/docsets/SwiftProtobuf/) is broken. It seems that someone lost possession of the domain, and it went back to "namecheap".

<img width="1315" alt="Screen Shot 2022-08-10 at 7 57 20 PM" src="https://user-images.githubusercontent.com/71743241/184042784-c0fd4359-d0d1-47c7-b1c9-80ed561b2d04.png">

