### PR TITLE
Allow the two regular workflows to get github UX for manual triggering.

### DIFF
--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Every Sunday at 4am.
     - cron: '0 4 * * 0'
+  # Also allow manual triggering from the github UX to revalidate things.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -17,6 +17,8 @@ on:
   schedule:
     # Every Sunday at 5am.
     - cron: '0 5 * * 0'
+  # Also allow manual triggering from the github UX to revalidate things.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Should provide an easier way to doublecheck things when we notice upstream has
major landings rather than waiting for the regular runs to catch things.