### PR TITLE
Provide environment variable configuration option

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -56,8 +56,13 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
         // We need to find the path of protoc and protoc-gen-swift
         let protocPath: Path
         if let configuredProtocPath = configuration.protocPath {
+            // The user set the config path in the file. So let's take that
             protocPath = Path(configuredProtocPath)
+        } else if let environmentPath = ProcessInfo.processInfo.environment["PROTOC_PATH"] {
+            // The user set the env variable. So let's take that
+            protocPath = Path(environmentPath)
         } else {
+            // The user didn't set anything so let's try see if SPM can find a binary for us
             protocPath = try context.tool(named: "protoc").path
         }
         let protocGenSwiftPath = try context.tool(named: "protoc-gen-swift").path

--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -22,7 +22,7 @@ There are multiple ways to do this. Some of the easiest are:
 1. If you are on MacOS, installing it via `brew install protoc`
 2. Download the binary from [Google's github repository](https://github.com/protocolbuffers/protobuf).
 
-### Adding the proto files to your target
+### Adding the proto files to your target
 
 Next, you need to add the `.proto` files for which you want to generate your Swift types to your target's
 source directory. You should also commit these files to your git repository since the generated types
@@ -56,7 +56,7 @@ let package = Package(
 
 ```
 
-### Configuring the plugin
+### Configuring the plugin
 
 Lastly, after you have added the `.proto` files and modified your `Package.swift` manifest, you can now
 configure the plugin to invoke the `protoc` compiler. This is done by adding a `swift-protobuf-config.json`
@@ -88,13 +88,29 @@ is generating Swift types for the `Bar.proto` file with the `public` visibility.
 
 ### Defining the path to the protoc binary
 
+
 The plugin needs to be able to invoke the `protoc` binary to generate the Swift types. 
-There are two ways how this can be achieved. First, by default, the package manager looks into
+There are three ways how this can be achieved. First, by default, the package manager looks into
 the `$PATH` to find binaries named `protoc`. This works immediately if you use `swift build` to build
 your package and `protoc` is installed in the `$PATH` (`brew` is adding it to your `$PATH` automatically).
 However, this doesn't work if you want to compile from Xcode since Xcode is not passed the `$PATH`.
-To still make this work from Xcode you can point the plugin to the concrete location of the `protoc`
-compiler by changing the configuration file like this:
+You have to options to set the path of `protoc` that the plugin is going to use. Either you can set
+an environment variable `PROTOC_PATH` that gets picked up by the plugin. Here are two example how you
+can set the variable so that it gets picked up:
+
+```shell
+# swift build
+env PROTOC_PATH=/opt/homebrew/bin/protoc swift build
+
+# To start Xcode (Xcode MUST NOT be running before invoking this)
+env PROTOC_PATH=/opt/homebrew/bin/protoc xed .
+
+# xcodebuild
+env PROTOC_PATH=/opt/homebrew/bin/protoc xcodebuild <Here goes your command>
+```
+
+The other way to point the plugin to the concrete location of the `protoc`
+compiler is by changing the configuration file like this:
 
 ```json
 {
@@ -104,6 +120,7 @@ compiler by changing the configuration file like this:
 
 ```
 
-> Warning: This only solves the problem for leaf packages that are using the Swift package manager
-plugin since there you can point the package manager to the right binary. If your package is **NOT** a
-leaf package and should build with Xcode, we advise not to adopt the plugin yet!
+> Warning: The configuration file option only solves the problem for leaf packages that are using the Swift package manager
+plugin since there you can point the package manager to the right binary. The environment variable
+does solve the problem for transitive packages as well; however, it requires your users to set
+the variable now. In general we advise against adopting the plugin as a non-leaf package!


### PR DESCRIPTION
# Motivation
We are currently providing a config option to provide a path to the `protoc` binary. This works great if your `protoc` is always the same; however, for a lot of packages you want to build them on various systems and the path to `protoc` is always different. We really can't solve this with any config file.

# Modification
This PR adds the option to set the `PROTOC_PATH` env variable and picks it up in the plugin to find the protoc binary.

# Result
We can now dynamically pass the protoc path to the plugin.