### PR TITLE
Fix warning in new package.swift

### DIFF
--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -26,9 +26,9 @@ let package = Package(
     .target(name: "SwiftProtobuf"),
     .target(name: "SwiftProtobufPluginLibrary",
             dependencies: ["SwiftProtobuf"]),
-    .target(name: "protoc-gen-swift",
+    .executableTarget(name: "protoc-gen-swift",
             dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"]),
-    .target(name: "Conformance",
+    .executableTarget(name: "Conformance",
             dependencies: ["SwiftProtobuf"]),
     .plugin(
         name: "SwiftProtobufPlugin",

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -26,9 +26,9 @@ let package = Package(
     .target(name: "SwiftProtobuf"),
     .target(name: "SwiftProtobufPluginLibrary",
             dependencies: ["SwiftProtobuf"]),
-    .target(name: "protoc-gen-swift",
+    .executableTarget(name: "protoc-gen-swift",
             dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"]),
-    .target(name: "Conformance",
+    .executableTarget(name: "Conformance",
             dependencies: ["SwiftProtobuf"]),
     .plugin(
         name: "SwiftProtobufPlugin",


### PR DESCRIPTION
We have created two new `Package.swift` manifests for landing the SPM plugin on the 1.x branch. While doing this we introduced a new warning, since the manifest now uses `executableTarget` for executable targets.