### PR TITLE
Descriptor improvements

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
@@ -85,12 +85,6 @@ extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
     }
   }
 
-  /// Is this field packable.
-  var isPackable: Bool {
-    // This logic comes from the C++ FieldDescriptor::is_packable() impl.
-    return label == .repeated && FieldDescriptor.isPackable(type: type)
-  }
-
   /// Helper to return the name to as the "base" for naming of generated fields.
   ///
   /// Groups use the underlying message's name. The way groups are declared in

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -68,6 +68,7 @@ public final class DescriptorSet {
   ///
   /// This is a legacy api since it requires the file to be found or it aborts.
   /// Mainly kept for grpc-swift compatibility.
+  @available(*, deprecated, renamed: "fileDescriptor(named:)")
   public func lookupFileDescriptor(protoName name: String) -> FileDescriptor {
     return registry.fileDescriptor(named: name)!
   }
@@ -906,6 +907,12 @@ public final class MethodDescriptor {
   // Whether the server streams multiple responses.
   public let serverStreaming: Bool
 
+  /// The proto version of the descriptor that defines this method.
+  @available(*, deprecated,
+             message: "Use the properties directly or open a GitHub issue for something missing")
+  public var proto: Google_Protobuf_MethodDescriptorProto { return _proto }
+  private let _proto: Google_Protobuf_MethodDescriptorProto
+
   fileprivate init(proto: Google_Protobuf_MethodDescriptorProto,
                    index: Int,
                    registry: Registry) {
@@ -916,6 +923,8 @@ public final class MethodDescriptor {
     // Can look these up because all the Descriptors are already registered
     self.inputType = registry.descriptor(named: proto.inputType)!
     self.outputType = registry.descriptor(named: proto.outputType)!
+
+    self._proto = proto
   }
 
   fileprivate func bind(service: ServiceDescriptor, registry: Registry) {

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -683,10 +683,14 @@ public final class FieldDescriptor {
     // This logic comes from the C++ FieldDescriptor::is_packed() impl.
     // NOTE: It does not match what is in the C++ header for is_packed().
     guard isPackable else { return false }
+    // The C++ imp also checks if the `options_` are null, but that is only for
+    // their placeholder descriptor support, as once the FieldDescriptor is
+    // fully wired it gets a default FileOptions instance, rendering nullptr
+    // meaningless.
     if file.syntax == .proto2 {
-      return proto.hasOptions && proto.options.packed
+      return options.packed
     } else {
-      return !proto.hasOptions || !proto.options.hasPacked || proto.options.packed
+      return !options.hasPacked || options.packed
     }
   }
   /// True if this field is a map.

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -639,12 +639,7 @@ public final class FieldDescriptor {
     return "\(prefix).\(name)"
   }
   /// JSON name of this field.
-  public var jsonName: String? {
-    // TODO(TVL): Revisit, doesn't seem like we should have this fallback since
-    // protoc is always supposed to provide it.
-    guard proto.hasJsonName else { return nil }
-    return proto.jsonName
-  }
+  public let jsonName: String
 
   /// File in which this field was defined.
   public private(set) weak var file: FileDescriptor!
@@ -780,6 +775,8 @@ public final class FieldDescriptor {
                    isExtension: Bool = false) {
     self.name = proto.name
     self.index = index
+    assert(proto.hasJsonName)  // protoc should always set the name
+    self.jsonName = proto.jsonName
     self.isExtension = isExtension
     self.number = proto.number
     self.type = proto.type

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -310,18 +310,22 @@ public final class Descriptor {
   /// the order they are defined in the .proto file.
   public let extensionRanges: [Google_Protobuf_DescriptorProto.ExtensionRange]
 
+  // TODO(TVL): These next two aren't part of the C++ descriptor api, but since
+  // they cache for performance, they currently need to be here; should likely
+  // revisit this and potentilally move them into the plugin in some way.
+
   /// The `extensionRanges` are in the order they appear in the original .proto
   /// file; this orders them and then merges any ranges that are actually
   /// contiguious (i.e. - [(21,30),(10,20)] -> [(10,30)])
   ///
-  /// NOTE: The `options` are no longer valid to use as multiple ranges could
-  /// have been merged and nothing is done with their options.
-  public private(set) lazy var normalizedExtensionRanges: [Google_Protobuf_DescriptorProto.ExtensionRange] = {
-    var ordered = self.extensionRanges.sorted(by: { return $0.start < $1.start })
+  /// This also uses Range<> since the options that could be on
+  /// `extensionRanges` no longer can apply as the things have been merged.
+  public private(set) lazy var normalizedExtensionRanges: [Range<Int32>] = {
+    var ordered: [Range<Int32>] = self.extensionRanges.sorted(by: { return $0.start < $1.start }).map { return $0.start ..< $0.end }
     if ordered.count > 1 {
       for i in (0..<(ordered.count - 1)).reversed() {
-        if ordered[i].end == ordered[i+1].start {
-          ordered[i].end = ordered[i+1].end
+        if ordered[i].upperBound == ordered[i+1].lowerBound {
+          ordered[i] = ordered[i].lowerBound ..< ordered[i+1].upperBound
           ordered.remove(at: i + 1)
         }
       }
@@ -334,28 +338,28 @@ public final class Descriptor {
   /// are also merged together. These can then be used in context where it is
   /// ok to include field numbers that have to be extension or unknown fields.
   ///
-  /// NOTE: The `options` are no longer valid to use as multiple ranges could
-  /// have been merged and nothing is done with their options.
-  public private(set) lazy var ambitiousExtensionRanges: [Google_Protobuf_DescriptorProto.ExtensionRange] = {
+  /// This also uses Range<> since the options that could be on
+  /// `extensionRanges` no longer can apply as the things have been merged.
+  public private(set) lazy var ambitiousExtensionRanges: [Range<Int32>] = {
     var merged = self.normalizedExtensionRanges
     var sortedFields = self.fields.sorted {$0.number < $1.number}
     if merged.count > 1 {
       var fieldNumbersReversedIterator =
         self.fields.map({ Int($0.number) }).sorted(by: { $0 > $1 }).makeIterator()
       var nextFieldNumber = fieldNumbersReversedIterator.next()
-      while nextFieldNumber != nil && merged.last!.start < nextFieldNumber! {
+      while nextFieldNumber != nil && merged.last!.lowerBound < nextFieldNumber! {
         nextFieldNumber = fieldNumbersReversedIterator.next()
       }
 
       for i in (0..<(merged.count - 1)).reversed() {
-        if nextFieldNumber == nil || merged[i].start > nextFieldNumber! {
+        if nextFieldNumber == nil || merged[i].lowerBound > nextFieldNumber! {
           // No fields left or range starts after the next field, merge it with
           // the previous one.
-          merged[i].end = merged[i+1].end
+          merged[i] = merged[i].lowerBound ..< merged[i+1].upperBound
           merged.remove(at: i + 1)
         } else {
           // can't merge, find the next field number below this range.
-          while nextFieldNumber != nil && merged[i].start < nextFieldNumber! {
+          while nextFieldNumber != nil && merged[i].lowerBound < nextFieldNumber! {
             nextFieldNumber = fieldNumbersReversedIterator.next()
           }
         }

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -724,16 +724,13 @@ public final class FieldDescriptor {
   /// extension scope's extensions.
   public let index: Int
 
-  /// Does this field have an explicitly-declared default value?
-  public var hasDefaultValue: Bool { return proto.hasDefaultValue }
-  // TODO(TVL): C++ FieldDescriptor doesn't have explicitDefaultValue, instead
-  // it has a bunch of apis to do the transforms, should there be apis like
-  // that?
-  /// The default value (string) set in the proto file.
-  public var explicitDefaultValue: String? {
-    guard hasDefaultValue else { return nil }
-    return proto.defaultValue
-  }
+  /// The explicitly declared default value for this field.
+  ///
+  /// This is the *raw* string value from the .proto file that was listed as
+  /// the default, it is up to the consumer to convert it correctly for the
+  /// type of this field. The C++ FieldDescriptor does offer some apis to
+  /// help with that, but at this time, that is not provided here.
+  public let defaultValue: String?
 
   /// The `Descriptor` of the message which this is a field of. For extensions,
   /// this is the extended type.
@@ -775,6 +772,7 @@ public final class FieldDescriptor {
                    isExtension: Bool = false) {
     self.name = proto.name
     self.index = index
+    self.defaultValue = proto.hasDefaultValue ? proto.defaultValue : nil
     assert(proto.hasJsonName)  // protoc should always set the name
     self.jsonName = proto.jsonName
     self.isExtension = isExtension

--- a/Sources/SwiftProtobufPluginLibrary/ProvidesLocationPath.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProvidesLocationPath.swift
@@ -10,7 +10,13 @@
 
 import Foundation
 
+/// Protocol that all the Descriptors conform to for original .proto file
+/// location lookup.
 public protocol ProvidesLocationPath {
+  /// Updates `path` to the source location of the complete extent of
+  /// the object conforming to this protocol. This is a replacement for
+  /// `GetSourceLocation()` in the C++ Descriptor apis.
   func getLocationPath(path: inout IndexPath)
+  /// Returns the File this conforming object is in.
   var file: FileDescriptor! { get }
 }

--- a/Sources/SwiftProtobufPluginLibrary/ProvidesSourceCodeLocation.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProvidesSourceCodeLocation.swift
@@ -11,11 +11,14 @@
 import Foundation
 import SwiftProtobuf
 
+/// Protocol that all the Descriptors conform to for original .proto file
+/// location lookup.
 public protocol ProvidesSourceCodeLocation {
+  /// Returns the Location of a given object (Descriptor).
   var sourceCodeInfoLocation: Google_Protobuf_SourceCodeInfo.Location? { get }
 }
 
-// Default implementation for things that support ProvidesLocationPath.
+/// Default implementation for things that support ProvidesLocationPath.
 extension ProvidesSourceCodeLocation where Self: ProvidesLocationPath {
   public var sourceCodeInfoLocation: Google_Protobuf_SourceCodeInfo.Location? {
     var path = IndexPath()
@@ -24,14 +27,12 @@ extension ProvidesSourceCodeLocation where Self: ProvidesLocationPath {
   }
 }
 
-// Helper to get source comments out of ProvidesSourceCodeLocation
 extension ProvidesSourceCodeLocation {
+  /// Helper to get a source comments as a string.
   public func protoSourceComments(commentPrefix: String = "///",
                                   leadingDetachedPrefix: String? = nil) -> String {
-    if let loc = sourceCodeInfoLocation {
-      return loc.asSourceComment(commentPrefix: commentPrefix,
-                                 leadingDetachedPrefix: leadingDetachedPrefix)
-    }
-    return String()
+    guard let loc = sourceCodeInfoLocation else { return String() }
+    return loc.asSourceComment(commentPrefix: commentPrefix,
+                               leadingDetachedPrefix: leadingDetachedPrefix)
   }
 }

--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufInfo.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufInfo.swift
@@ -15,7 +15,7 @@
 import Foundation
 import SwiftProtobuf
 
-/// Scope for helpers about the library.
+/// Helpers about the library.
 public enum SwiftProtobufInfo {
   /// Proto Files that ship with the library.
   public static let bundledProtoFiles: Set<String> = [
@@ -35,8 +35,14 @@ public enum SwiftProtobufInfo {
     "google/protobuf/wrappers.proto",
   ]
 
-  // Checks if a FileDescriptor is a library bundled proto file.
+  /// Checks if a `Google_Protobuf_FileDescriptorProto` is a library bundled proto file.
+  @available(*, deprecated, message: "Use the version that takes a FileDescriptor instead.")
   public static func isBundledProto(file: Google_Protobuf_FileDescriptorProto) -> Bool {
+    return file.package == "google.protobuf" && bundledProtoFiles.contains(file.name)
+  }
+
+  /// Checks if a `FileDescriptor` is a library bundled proto file.
+  public static func isBundledProto(file: FileDescriptor) -> Bool {
     return file.package == "google.protobuf" && bundledProtoFiles.contains(file.name)
   }
 }

--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -332,7 +332,7 @@ public final class SwiftProtobufNamer {
     }
 
     let result = NamingUtils.typePrefix(protoPackage: file.package,
-                                        fileOptions: file.fileOptions)
+                                        fileOptions: file.options)
     filePrefixCache[file.name] = result
     return result
   }

--- a/Sources/protoc-gen-swift/CMakeLists.txt
+++ b/Sources/protoc-gen-swift/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(protoc-gen-swift
   FileIo.swift
   GenerationError.swift
   GeneratorOptions.swift
-  Google_Protobuf_DescriptorProto+Extensions.swift
   Google_Protobuf_FileDescriptorProto+Extensions.swift
   main.swift
   MessageFieldGenerator.swift
@@ -16,6 +15,7 @@ add_executable(protoc-gen-swift
   MessageStorageClassGenerator.swift
   MessageStorageDecision.swift
   OneofGenerator.swift
+  Range+Extensions.swift
   StringUtils.swift
   Version.swift)
 target_link_libraries(protoc-gen-swift PRIVATE

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -178,7 +178,7 @@ extension FieldDescriptor {
       return "[]"
     }
 
-    if let defaultValue = explicitDefaultValue {
+    if let defaultValue = defaultValue {
       switch type {
       case .double:
         switch defaultValue {

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -69,7 +69,7 @@ class EnumGenerator {
     p.print("\n")
     p.print("\(visibility)init() {\n")
     p.indent()
-    let dottedDefault = namer.dottedRelativeName(enumValue: enumDescriptor.defaultValue)
+    let dottedDefault = namer.dottedRelativeName(enumValue: enumDescriptor.values.first!)
     p.print("self = \(dottedDefault)\n")
     p.outdent()
     p.print("}\n")

--- a/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
@@ -76,8 +76,6 @@ class ExtensionSetGenerator {
             } else {
                 fieldNamePath = fieldDescriptor.fullName
             }
-            assert(fieldNamePath.hasPrefix("."))
-            fieldNamePath.remove(at: fieldNamePath.startIndex)  // Remove the leading '.'
 
             p.print(
               comments,

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -76,7 +76,7 @@ class FieldGeneratorBase {
       protoName = fieldDescriptor.name
     }
 
-    let jsonName = fieldDescriptor.jsonName ?? protoName
+    let jsonName = fieldDescriptor.jsonName
     if jsonName == protoName {
       /// The proto and JSON names are identical:
       return ".same(proto: \"\(protoName)\")"

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -50,10 +50,10 @@ class FileGenerator {
     /// Generate, if `errorString` gets filled in, then report error instead of using
     /// what written into `printer`.
     func generateOutputFile(printer p: inout CodePrinter, errorString: inout String?) {
-        guard fileDescriptor.fileOptions.swiftPrefix.isEmpty ||
-            isValidSwiftIdentifier(fileDescriptor.fileOptions.swiftPrefix,
+        guard fileDescriptor.options.swiftPrefix.isEmpty ||
+            isValidSwiftIdentifier(fileDescriptor.options.swiftPrefix,
                                    allowQuoted: false) else {
-          errorString = "\(fileDescriptor.name) has an 'swift_prefix' that isn't a valid Swift identifier (\(fileDescriptor.fileOptions.swiftPrefix))."
+          errorString = "\(fileDescriptor.name) has an 'swift_prefix' that isn't a valid Swift identifier (\(fileDescriptor.options.swiftPrefix))."
           return
         }
         p.print(

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -38,7 +38,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
     private var isPacked: Bool { return fieldDescriptor.isPacked }
 
     // Note: this could still be a map (since those are repeated message fields
-    private var isRepeated: Bool {return fieldDescriptor.label == .repeated}
+    private var isRepeated: Bool {return fieldDescriptor.isRepeated}
     private var isGroupOrMessage: Bool {
       switch fieldDescriptor.type {
       case .group, .message:
@@ -53,13 +53,13 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
          namer: SwiftProtobufNamer,
          usesHeapStorage: Bool)
     {
-        precondition(descriptor.realOneof == nil)
+        precondition(descriptor.realContainingOneof == nil)
 
         self.generatorOptions = generatorOptions
         self.usesHeapStorage = usesHeapStorage
         self.namer = namer
 
-        hasFieldPresence = descriptor.hasPresence && descriptor.realOneof == nil
+        hasFieldPresence = descriptor.hasPresence
         let names = namer.messagePropertyNames(field: descriptor,
                                                prefixed: "_",
                                                includeHasAndClear: hasFieldPresence)
@@ -155,7 +155,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
     }
 
    func generateRequiredFieldCheck(printer p: inout CodePrinter) {
-       guard fieldDescriptor.label == .required else { return }
+       guard fieldDescriptor.isRequired else { return }
        p.print("if \(storedProperty) == nil {return false}\n")
     }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -356,14 +356,14 @@ class MessageGenerator {
       var ranges = descriptor.ambitiousExtensionRanges.makeIterator()
       var nextRange = ranges.next()
       for f in fieldsSortedByNumber {
-        while nextRange != nil && Int(nextRange!.start) < f.number {
-          p.print("try visitor.\(visitExtensionsName)(fields: _protobuf_extensionFieldValues, start: \(nextRange!.start), end: \(nextRange!.end))\n")
+        while nextRange != nil && Int(nextRange!.lowerBound) < f.number {
+          p.print("try visitor.\(visitExtensionsName)(fields: _protobuf_extensionFieldValues, start: \(nextRange!.lowerBound), end: \(nextRange!.upperBound))\n")
           nextRange = ranges.next()
         }
         f.generateTraverse(printer: &p)
       }
       while nextRange != nil {
-        p.print("try visitor.\(visitExtensionsName)(fields: _protobuf_extensionFieldValues, start: \(nextRange!.start), end: \(nextRange!.end))\n")
+        p.print("try visitor.\(visitExtensionsName)(fields: _protobuf_extensionFieldValues, start: \(nextRange!.lowerBound), end: \(nextRange!.upperBound))\n")
         nextRange = ranges.next()
       }
     }

--- a/Sources/protoc-gen-swift/MessageStorageDecision.swift
+++ b/Sources/protoc-gen-swift/MessageStorageDecision.swift
@@ -92,7 +92,7 @@ fileprivate struct AnalyzeResult {
 /// times.
 fileprivate var analysisCache: Dictionary<String,AnalyzeResult> = [
   // google.protobuf.Any can be seeded.
-  ".google.protobuf.Any": .useStorage,
+  "google.protobuf.Any": .useStorage,
 ]
 
 /// Analyze the given descriptor to decide if it should use storage and what

--- a/Sources/protoc-gen-swift/MessageStorageDecision.swift
+++ b/Sources/protoc-gen-swift/MessageStorageDecision.swift
@@ -41,7 +41,7 @@ fileprivate enum FieldCost {
   static let singleMessageFieldUsingStorage = 1
 
   static func estimate(_ field: FieldDescriptor) -> Int {
-    guard field.label != .repeated else {
+    guard !field.isRepeated else {
       // Repeated fields don't count the exact types, just fixed costs.
       return field.isMap ? FieldCost.map : FieldCost.repeated
     }
@@ -109,7 +109,7 @@ fileprivate func analyze(descriptor: Descriptor) -> AnalyzeResult {
       var messageStack = messageStack
       messageStack.append(descriptor)
       return descriptor.fields.contains {
-        guard $0.label != .repeated else { return false }
+        guard !$0.isRepeated else { return false }
         // Ignore fields that aren’t messages or groups.
         guard $0.type == .message || $0.type == .group else { return false }
         guard let messageType = $0.messageType else { return false }

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -154,7 +154,7 @@ class OneofGenerator {
         // from each extension range as an easy way to check for them being
         // mixed in between the fields.
         var parentNumbers = descriptor.containingType.fields.map { Int($0.number) }
-        parentNumbers.append(contentsOf: descriptor.containingType.normalizedExtensionRanges.map { Int($0.start) })
+        parentNumbers.append(contentsOf: descriptor.containingType.normalizedExtensionRanges.map { Int($0.lowerBound) })
         var parentNumbersIterator = parentNumbers.sorted(by: { $0 < $1 }).makeIterator()
         var nextParentFieldNumber = parentNumbersIterator.next()
         var grouped = [[MemberFieldGenerator]]()

--- a/Sources/protoc-gen-swift/Range+Extensions.swift
+++ b/Sources/protoc-gen-swift/Range+Extensions.swift
@@ -1,4 +1,4 @@
-// Sources/protoc-gen-swift/Google_Protobuf_DescriptorProto+Extensions.swift - Descriptor extensions
+// Sources/protoc-gen-swift/Range+Extensions.swift - Descriptor extensions
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `DescriptorProto` that provide Swift-generation-specific
+/// Extensions to `Range` that provide Swift-generation-specific
 /// functionality.
 ///
 // -----------------------------------------------------------------------------
@@ -17,26 +17,27 @@ import Foundation
 import SwiftProtobufPluginLibrary
 import SwiftProtobuf
 
-extension Google_Protobuf_DescriptorProto.ExtensionRange {
+extension Range where Bound == Int32 {
 
-  /// A `String` containing the Swift expression that represents this
-  /// extension range to be used in a `case` statement.
+  /// A `String` containing the Swift expression that represents this range to
+  /// be used in a `case` statement.
   var swiftCaseExpression: String {
-    if start == end - 1 {
-      return "\(start)"
+    if lowerBound == upperBound - 1 {
+      return "\(lowerBound)"
     }
-    return "\(start)..<\(end)"
+    return "\(lowerBound)..<\(upperBound)"
   }
 
   /// A `String` containing the Swift Boolean expression that tests the given
-  /// variable for containment within this extension range.
+  /// variable for containment within this range.
   ///
   /// - Parameter variable: The name of the variable to test in the expression.
   /// - Returns: A `String` containing the Boolean expression.
   func swiftBooleanExpression(variable: String) -> String {
-    if start == end - 1 {
-      return "\(start) == \(variable)"
+    if lowerBound == upperBound - 1 {
+      return "\(lowerBound) == \(variable)"
     }
-    return "\(start) <= \(variable) && \(variable) < \(end)"
+    return "\(lowerBound) <= \(variable) && \(variable) < \(upperBound)"
   }
+
 }

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -223,7 +223,7 @@ struct GeneratorPlugin {
     var errorString: String? = nil
     var responseFiles: [Google_Protobuf_Compiler_CodeGeneratorResponse.File] = []
     for name in request.fileToGenerate {
-      let fileDescriptor = descriptorSet.lookupFileDescriptor(protoName: name)
+      let fileDescriptor = descriptorSet.fileDescriptor(named: name)!
       let fileGenerator = FileGenerator(fileDescriptor: fileDescriptor, generatorOptions: options)
       var printer = CodePrinter()
       fileGenerator.generateOutputFile(printer: &printer, errorString: &errorString)

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -354,22 +354,22 @@ class Test_Descriptor: XCTestCase {
 
     // Check sorting/merging
     XCTAssertEqual(msgDescriptor.normalizedExtensionRanges.count, 5)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[0].start, 1)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[0].end, 5)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[1].start, 7)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[1].end, 8)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[2].start, 9)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[2].end, 10)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[3].start, 100)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[3].end, 121)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[4].start, 126)
-    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[4].end, 131)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[0].lowerBound, 1)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[0].upperBound, 5)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[1].lowerBound, 7)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[1].upperBound, 8)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[2].lowerBound, 9)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[2].upperBound, 10)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[3].lowerBound, 100)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[3].upperBound, 121)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[4].lowerBound, 126)
+    XCTAssertEqual(msgDescriptor.normalizedExtensionRanges[4].upperBound, 131)
 
 
     // Check the "ambitious" merging.
     XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges.count, 1)
-    XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].start, 1)
-    XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].end, 131)
+    XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].lowerBound, 1)
+    XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].upperBound, 131)
 
     let msgDescriptor2 = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.MsgExtensionRangeOrderingWithFields")
     // Quick check of what should be in the proto file
@@ -386,26 +386,26 @@ class Test_Descriptor: XCTestCase {
 
     // Check sorting/merging
     XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges.count, 5)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[0].start, 1)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[0].end, 5)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[1].start, 7)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[1].end, 8)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[2].start, 9)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[2].end, 10)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[3].start, 100)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[3].end, 121)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[4].start, 126)
-    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[4].end, 131)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[0].lowerBound, 1)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[0].upperBound, 5)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[1].lowerBound, 7)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[1].upperBound, 8)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[2].lowerBound, 9)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[2].upperBound, 10)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[3].lowerBound, 100)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[3].upperBound, 121)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[4].lowerBound, 126)
+    XCTAssertEqual(msgDescriptor2.normalizedExtensionRanges[4].upperBound, 131)
 
 
     // Check the "ambitious" merging.
     XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges.count, 3)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[0].start, 1)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[0].end, 5)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[1].start, 7)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[1].end, 121)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].start, 126)
-    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].end, 131)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[0].lowerBound, 1)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[0].upperBound, 5)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[1].lowerBound, 7)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[1].upperBound, 121)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].lowerBound, 126)
+    XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].upperBound, 131)
 
     let msgDescriptor3 = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.MsgExtensionRangeOrderingNoMerging")
     // Quick check of what should be in the proto file
@@ -416,21 +416,21 @@ class Test_Descriptor: XCTestCase {
 
     // Check sorting/merging
     XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges.count, 3)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[0].start, 3)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[0].end, 6)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[1].start, 7)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[1].end, 13)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[2].start, 16)
-    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[2].end, 21)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[0].lowerBound, 3)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[0].upperBound, 6)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[1].lowerBound, 7)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[1].upperBound, 13)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[2].lowerBound, 16)
+    XCTAssertEqual(msgDescriptor3.normalizedExtensionRanges[2].upperBound, 21)
 
     // Check the "ambitious" merging.
     XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges.count, 3)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[0].start, 3)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[0].end, 6)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[1].start, 7)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[1].end, 13)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[2].start, 16)
-    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[2].end, 21)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[0].lowerBound, 3)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[0].upperBound, 6)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[1].lowerBound, 7)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[1].upperBound, 13)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[2].lowerBound, 16)
+    XCTAssertEqual(msgDescriptor3.ambitiousExtensionRanges[2].upperBound, 21)
   }
 
 }

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -79,17 +79,17 @@ class Test_Descriptor: XCTestCase {
 
     let descriptorSet = DescriptorSet(proto: fileSet)
 
-    XCTAssertTrue(descriptorSet.lookupFileDescriptor(protoName: "google/protobuf/descriptor.proto") === descriptorSet.files[0])
-    XCTAssertTrue(descriptorSet.lookupFileDescriptor(protoName: "google/protobuf/compiler/plugin.proto") === descriptorSet.files[1])
+    XCTAssertTrue(descriptorSet.fileDescriptor(named: "google/protobuf/descriptor.proto") === descriptorSet.files[0])
+    XCTAssertTrue(descriptorSet.fileDescriptor(named: "google/protobuf/compiler/plugin.proto") === descriptorSet.files[1])
 
-    XCTAssertTrue(descriptorSet.lookupDescriptor(protoName: ".google.protobuf.compiler.CodeGeneratorRequest") === descriptorSet.files[1].messages[1])
-    XCTAssertTrue(descriptorSet.lookupDescriptor(protoName: ".google.protobuf.DescriptorProto") === descriptorSet.files[0].messages[2])
-    XCTAssertTrue(descriptorSet.lookupDescriptor(protoName: ".google.protobuf.DescriptorProto.ExtensionRange") === descriptorSet.files[0].messages[2].messages[0])
+    XCTAssertTrue(descriptorSet.descriptor(named: "google.protobuf.compiler.CodeGeneratorRequest") === descriptorSet.files[1].messages[1])
+    XCTAssertTrue(descriptorSet.descriptor(named: "google.protobuf.DescriptorProto") === descriptorSet.files[0].messages[2])
+    XCTAssertTrue(descriptorSet.descriptor(named: "google.protobuf.DescriptorProto.ExtensionRange") === descriptorSet.files[0].messages[2].messages[0])
 
-    XCTAssertTrue(descriptorSet.lookupEnumDescriptor(protoName: ".google.protobuf.FieldDescriptorProto.Type") === descriptorSet.files[0].messages[4].enums[0])
-    XCTAssertTrue(descriptorSet.lookupEnumDescriptor(protoName: ".google.protobuf.FieldDescriptorProto.Label") === descriptorSet.files[0].messages[4].enums[1])
+    XCTAssertTrue(descriptorSet.enumDescriptor(named: "google.protobuf.FieldDescriptorProto.Type") === descriptorSet.files[0].messages[4].enums[0])
+    XCTAssertTrue(descriptorSet.enumDescriptor(named: "google.protobuf.FieldDescriptorProto.Label") === descriptorSet.files[0].messages[4].enums[1])
 
-    XCTAssertTrue(descriptorSet.lookupServiceDescriptor(protoName: ".swift_descriptor_test.SomeService") === descriptorSet.files[2].services[0])
+    XCTAssertTrue(descriptorSet.serviceDescriptor(named: "swift_descriptor_test.SomeService") === descriptorSet.files[2].services[0])
   }
 
   func testParents() throws {
@@ -97,18 +97,18 @@ class Test_Descriptor: XCTestCase {
 
     let descriptorSet = DescriptorSet(proto: fileSet)
 
-    let codeGenResponse = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.compiler.CodeGeneratorResponse")
+    let codeGenResponse = descriptorSet.descriptor(named: "google.protobuf.compiler.CodeGeneratorResponse")!
     XCTAssertTrue(codeGenResponse.containingType == nil)
-    let codeGenResponseFile = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.compiler.CodeGeneratorResponse.File")
+    let codeGenResponseFile = descriptorSet.descriptor(named: "google.protobuf.compiler.CodeGeneratorResponse.File")!
     XCTAssertTrue(codeGenResponseFile.containingType === codeGenResponse)
 
-    let fieldDescProto = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.FieldDescriptorProto")
-    let fieldDescType = descriptorSet.lookupEnumDescriptor(protoName: ".google.protobuf.FieldDescriptorProto.Type")
+    let fieldDescProto = descriptorSet.descriptor(named: "google.protobuf.FieldDescriptorProto")!
+    let fieldDescType = descriptorSet.enumDescriptor(named: "google.protobuf.FieldDescriptorProto.Type")!
     XCTAssertTrue(fieldDescType.containingType === fieldDescProto)
-    let fieldDescLabel = descriptorSet.lookupEnumDescriptor(protoName: ".google.protobuf.FieldDescriptorProto.Label")
+    let fieldDescLabel = descriptorSet.enumDescriptor(named: "google.protobuf.FieldDescriptorProto.Label")!
     XCTAssertTrue(fieldDescLabel.containingType === fieldDescProto)
 
-    let serviceDescProto = descriptorSet.lookupServiceDescriptor(protoName: ".swift_descriptor_test.SomeService")
+    let serviceDescProto = descriptorSet.serviceDescriptor(named: "swift_descriptor_test.SomeService")!
     let fooMethod = serviceDescProto.methods[0]
     XCTAssertTrue(fooMethod.service === serviceDescProto)
     let barMethod = serviceDescProto.methods[1]
@@ -133,11 +133,11 @@ class Test_Descriptor: XCTestCase {
 
     let descriptorSet = DescriptorSet(proto: fileSet)
 
-    let topLevelEnum = descriptorSet.lookupEnumDescriptor(protoName: ".swift_descriptor_test.TopLevelEnum")
-    let topLevelMessage = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.TopLevelMessage")
+    let topLevelEnum = descriptorSet.enumDescriptor(named: "swift_descriptor_test.TopLevelEnum")!
+    let topLevelMessage = descriptorSet.descriptor(named: "swift_descriptor_test.TopLevelMessage")!
     let subEnum = topLevelMessage.enums[0]
     let subMessage = topLevelMessage.messages[0]
-    let topLevelMessage2 = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.TopLevelMessage2")
+    let topLevelMessage2 = descriptorSet.descriptor(named: "swift_descriptor_test.TopLevelMessage2")!
 
     XCTAssertEqual(topLevelMessage.fields.count, 6)
     XCTAssertEqual(topLevelMessage.fields[0].name, "field1")
@@ -165,9 +165,9 @@ class Test_Descriptor: XCTestCase {
     XCTAssertTrue(topLevelMessage2.fields[0].messageType === topLevelMessage)
     XCTAssertTrue(topLevelMessage2.fields[1].messageType === topLevelMessage2)
 
-    let externalRefs = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.ExternalRefs")
-    let googleProtobufDescriptorProto = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.DescriptorProto")
-    let googleProtobufCompilerVersion = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.compiler.Version")
+    let externalRefs = descriptorSet.descriptor(named: "swift_descriptor_test.ExternalRefs")!
+    let googleProtobufDescriptorProto = descriptorSet.descriptor(named: "google.protobuf.DescriptorProto")!
+    let googleProtobufCompilerVersion = descriptorSet.descriptor(named: "google.protobuf.compiler.Version")!
 
     XCTAssertEqual(externalRefs.fields.count, 2)
     XCTAssertEqual(externalRefs.fields[0].name, "desc")
@@ -177,7 +177,7 @@ class Test_Descriptor: XCTestCase {
 
     // Proto2 Presence
 
-    let proto2ForPresence = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.Proto2MessageForPresence")
+    let proto2ForPresence = descriptorSet.descriptor(named: "swift_descriptor_test.Proto2MessageForPresence")!
 
     XCTAssertEqual(proto2ForPresence.fields.count, 16)
     XCTAssertEqual(proto2ForPresence.fields[0].name, "req_str_field")
@@ -239,7 +239,7 @@ class Test_Descriptor: XCTestCase {
 
     // Proto3 Presence
 
-    let proto3ForPresence = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.Proto3MessageForPresence")
+    let proto3ForPresence = descriptorSet.descriptor(named: "swift_descriptor_test.Proto3MessageForPresence")!
     XCTAssertEqual(proto3ForPresence.fields.count, 16)
     XCTAssertEqual(proto3ForPresence.fields[0].name, "str_field")
     XCTAssertEqual(proto3ForPresence.fields[1].name, "int32_field")
@@ -309,8 +309,8 @@ class Test_Descriptor: XCTestCase {
 
     let descriptorSet = DescriptorSet(proto: fileSet)
 
-    let googleProtobufFieldOptions = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.FieldOptions")
-    let googleProtobufMessageOptions = descriptorSet.lookupDescriptor(protoName: ".google.protobuf.MessageOptions")
+    let googleProtobufFieldOptions = descriptorSet.descriptor(named: "google.protobuf.FieldOptions")!
+    let googleProtobufMessageOptions = descriptorSet.descriptor(named: "google.protobuf.MessageOptions")!
 
     let descriptorTestFile = descriptorSet.files[2]
 
@@ -318,7 +318,7 @@ class Test_Descriptor: XCTestCase {
     XCTAssertNil(topLevelExt.extensionScope)
     XCTAssertTrue(topLevelExt.containingType === googleProtobufFieldOptions)
 
-    let extScoper = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.ScoperForExt")
+    let extScoper = descriptorSet.descriptor(named: "swift_descriptor_test.ScoperForExt")!
     let nestedExt1 = descriptorTestFile.messages[3].extensions[0]
     let nestedExt2 = descriptorTestFile.messages[3].extensions[1]
     XCTAssertTrue(nestedExt1.extensionScope === extScoper)
@@ -339,7 +339,7 @@ class Test_Descriptor: XCTestCase {
 
     let descriptorSet = DescriptorSet(proto: fileSet)
 
-    let msgDescriptor = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.MsgExtensionRangeOrdering")
+    let msgDescriptor = descriptorSet.descriptor(named: "swift_descriptor_test.MsgExtensionRangeOrdering")!
     // Quick check of what should be in the proto file
     XCTAssertEqual(msgDescriptor.extensionRanges.count, 9)
     XCTAssertEqual(msgDescriptor.extensionRanges[0].start, 1)
@@ -371,7 +371,7 @@ class Test_Descriptor: XCTestCase {
     XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].lowerBound, 1)
     XCTAssertEqual(msgDescriptor.ambitiousExtensionRanges[0].upperBound, 131)
 
-    let msgDescriptor2 = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.MsgExtensionRangeOrderingWithFields")
+    let msgDescriptor2 = descriptorSet.descriptor(named: "swift_descriptor_test.MsgExtensionRangeOrderingWithFields")!
     // Quick check of what should be in the proto file
     XCTAssertEqual(msgDescriptor2.extensionRanges.count, 9)
     XCTAssertEqual(msgDescriptor2.extensionRanges[0].start, 1)
@@ -407,7 +407,7 @@ class Test_Descriptor: XCTestCase {
     XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].lowerBound, 126)
     XCTAssertEqual(msgDescriptor2.ambitiousExtensionRanges[2].upperBound, 131)
 
-    let msgDescriptor3 = descriptorSet.lookupDescriptor(protoName: ".swift_descriptor_test.MsgExtensionRangeOrderingNoMerging")
+    let msgDescriptor3 = descriptorSet.descriptor(named: "swift_descriptor_test.MsgExtensionRangeOrderingNoMerging")!
     // Quick check of what should be in the proto file
     XCTAssertEqual(msgDescriptor3.extensionRanges.count, 3)
     XCTAssertEqual(msgDescriptor3.extensionRanges[0].start, 3)

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -30,31 +30,31 @@ class Test_Descriptor: XCTestCase {
     let pluginFileDescriptor = descriptorSet.files[1]
 
     XCTAssertEqual(pluginFileDescriptor.messages.count, 3)
-    XCTAssertEqual(pluginFileDescriptor.messages[0].fullName, ".google.protobuf.compiler.Version")
+    XCTAssertEqual(pluginFileDescriptor.messages[0].fullName, "google.protobuf.compiler.Version")
     XCTAssertNil(pluginFileDescriptor.messages[0].containingType)
     XCTAssertEqual(pluginFileDescriptor.messages[0].messages.count, 0)
-    XCTAssertEqual(pluginFileDescriptor.messages[1].fullName, ".google.protobuf.compiler.CodeGeneratorRequest")
+    XCTAssertEqual(pluginFileDescriptor.messages[1].fullName, "google.protobuf.compiler.CodeGeneratorRequest")
     XCTAssertNil(pluginFileDescriptor.messages[1].containingType)
     XCTAssertEqual(pluginFileDescriptor.messages[1].messages.count, 0)
-    XCTAssertEqual(pluginFileDescriptor.messages[2].fullName, ".google.protobuf.compiler.CodeGeneratorResponse")
+    XCTAssertEqual(pluginFileDescriptor.messages[2].fullName, "google.protobuf.compiler.CodeGeneratorResponse")
     XCTAssertNil(pluginFileDescriptor.messages[2].containingType)
     XCTAssertEqual(pluginFileDescriptor.messages[2].messages.count, 1)
-    XCTAssertEqual(pluginFileDescriptor.messages[2].messages[0].fullName, ".google.protobuf.compiler.CodeGeneratorResponse.File")
+    XCTAssertEqual(pluginFileDescriptor.messages[2].messages[0].fullName, "google.protobuf.compiler.CodeGeneratorResponse.File")
     XCTAssertTrue(pluginFileDescriptor.messages[2].messages[0].containingType === pluginFileDescriptor.messages[2])
 
     let descriptorFileDescriptor = descriptorSet.files[0]
 
     XCTAssertEqual(descriptorFileDescriptor.enums.count, 0)
     XCTAssertEqual(descriptorFileDescriptor.messages[4].enums.count, 2)
-    XCTAssertEqual(descriptorFileDescriptor.messages[4].enums[0].fullName, ".google.protobuf.FieldDescriptorProto.Type")
+    XCTAssertEqual(descriptorFileDescriptor.messages[4].enums[0].fullName, "google.protobuf.FieldDescriptorProto.Type")
     XCTAssertTrue(descriptorFileDescriptor.messages[4].enums[0].containingType === descriptorFileDescriptor.messages[4])
-    XCTAssertEqual(descriptorFileDescriptor.messages[4].enums[1].fullName, ".google.protobuf.FieldDescriptorProto.Label")
+    XCTAssertEqual(descriptorFileDescriptor.messages[4].enums[1].fullName, "google.protobuf.FieldDescriptorProto.Label")
     XCTAssertTrue(descriptorFileDescriptor.messages[4].enums[1].containingType === descriptorFileDescriptor.messages[4])
 
     let testFileDesciptor = descriptorSet.files[2]
 
     XCTAssertEqual(testFileDesciptor.enums.count, 1)
-    XCTAssertEqual(testFileDesciptor.enums[0].fullName, ".swift_descriptor_test.TopLevelEnum")
+    XCTAssertEqual(testFileDesciptor.enums[0].fullName, "swift_descriptor_test.TopLevelEnum")
     XCTAssertNil(testFileDesciptor.enums[0].containingType)
 
     XCTAssertEqual(testFileDesciptor.messages[0].oneofs.count, 1)
@@ -68,7 +68,7 @@ class Test_Descriptor: XCTestCase {
     XCTAssertEqual(testFileDesciptor.messages[3].extensions[1].name, "ext_msg")
 
     XCTAssertEqual(testFileDesciptor.services.count, 1)
-    XCTAssertEqual(testFileDesciptor.services[0].fullName, ".swift_descriptor_test.SomeService")
+    XCTAssertEqual(testFileDesciptor.services[0].fullName, "swift_descriptor_test.SomeService")
     XCTAssertEqual(testFileDesciptor.services[0].methods.count, 2)
     XCTAssertEqual(testFileDesciptor.services[0].methods[0].name, "Foo")
     XCTAssertEqual(testFileDesciptor.services[0].methods[1].name, "Bar")

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftProtobufNamer.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftProtobufNamer.swift
@@ -60,10 +60,10 @@ class Test_SwiftProtobufNamer: XCTestCase {
 
     let descriptorSet = DescriptorSet(protos: [fileProto])
     let namer =
-      SwiftProtobufNamer(currentFile: descriptorSet.lookupFileDescriptor(protoName: "test.proto"),
+      SwiftProtobufNamer(currentFile: descriptorSet.fileDescriptor(named: "test.proto")!,
                          protoFileToModuleMappings: ProtoFileToModuleMappings())
 
-    let e = descriptorSet.lookupEnumDescriptor(protoName: ".TestEnum")
+    let e = descriptorSet.enumDescriptor(named: "TestEnum")!
     let values = e.values
     XCTAssertEqual(values.count, 6)
 
@@ -124,10 +124,10 @@ class Test_SwiftProtobufNamer: XCTestCase {
 
     let descriptorSet = DescriptorSet(protos: [fileProto])
     let namer =
-      SwiftProtobufNamer(currentFile: descriptorSet.lookupFileDescriptor(protoName: "test.proto"),
+      SwiftProtobufNamer(currentFile: descriptorSet.fileDescriptor(named: "test.proto")!,
                          protoFileToModuleMappings: ProtoFileToModuleMappings())
 
-    let e = descriptorSet.lookupEnumDescriptor(protoName: ".TestEnum")
+    let e = descriptorSet.enumDescriptor(named: "TestEnum")!
     let values = e.values
     XCTAssertEqual(values.count, 4)
 
@@ -207,10 +207,10 @@ class Test_SwiftProtobufNamer: XCTestCase {
 
     let descriptorSet = DescriptorSet(protos: [fileProto])
     let namer =
-      SwiftProtobufNamer(currentFile: descriptorSet.lookupFileDescriptor(protoName: "test.proto"),
+      SwiftProtobufNamer(currentFile: descriptorSet.fileDescriptor(named: "test.proto")!,
                          protoFileToModuleMappings: ProtoFileToModuleMappings())
 
-    let e = descriptorSet.lookupEnumDescriptor(protoName: ".TestEnum")
+    let e = descriptorSet.enumDescriptor(named: "TestEnum")!
     let values = e.values
     XCTAssertEqual(values.count, 8)
 
@@ -293,10 +293,10 @@ class Test_SwiftProtobufNamer: XCTestCase {
 
     let descriptorSet = DescriptorSet(protos: [fileProto])
     let namer =
-      SwiftProtobufNamer(currentFile: descriptorSet.lookupFileDescriptor(protoName: "test.proto"),
+      SwiftProtobufNamer(currentFile: descriptorSet.fileDescriptor(named: "test.proto")!,
                          protoFileToModuleMappings: ProtoFileToModuleMappings())
 
-    let e = descriptorSet.lookupEnumDescriptor(protoName: ".AliasedEnum")
+    let e = descriptorSet.enumDescriptor(named: "AliasedEnum")!
     let values = e.values
     XCTAssertEqual(values.count, 6)
 


### PR DESCRIPTION
This is all within the plugin library, so it is API breaking (but we're making a 2.0 from main), I've kept the one api that would force swift-grpc to have to update, so they can hopefully not having to version lockstep around this, if something does come up we can look at adding back something to keep things simpler for them.

Generally went for consistency in naming and docs with the C++ descriptor so future things should be easier to maps and it should make new things coming in the future to upstream protobuf easier to model.
