### PR TITLE
updating to non-deprecated SwiftPM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,13 @@ the plugin above:
 
 ```swift
 dependencies: [
-    .package(name: "SwiftProtobuf", url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
+    .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
 ],
 targets: [
-    .target(name: "MyTarget", dependencies: ["SwiftProtobuf"]),
+    .target(
+      name: "MyTarget", 
+      dependencies: [.product(name: "SwiftProtobuf", package: "swift-protobuf")]
+    ),
 ]
 ```
 


### PR DESCRIPTION
When following the README documentation, the code example for adding the dependencies to a `Package.swift` reported as being deprecated (I was using Swift 5.7 - beta release). The updates were simple and minimal, so I wanted to provide them back to prevent someone else from stumbling over the same.

The change updates the dependencies to use enumeration structures in SwiftPM instead of the strings mechanism which was prevalent in earlier Swift versions.