### PR TITLE
Add missing argument for plugin usage

### DIFF
--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -48,7 +48,7 @@ let package = Package(
     .executableTarget(
         name: "YourTarget",
         plugins: [
-            .plugin(name: "SwiftProtobufPlugin")
+            .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
         ]
     ),
     ...


### PR DESCRIPTION
Building silently fails without adding package to plugin