### PR TITLE
Add the file naming option

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -18,9 +18,9 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
             /// The visibility of the generated files.
             enum Visibility: String, Codable {
                 /// The generated files should have `internal` access level.
-                case `internal` = "Public"
+                case `internal` = "Internal"
                 /// The generated files should have `public` access level.
-                case `public` = "Internal"
+                case `public` = "Public"
 
                 init?(rawValue: String) {
                     switch rawValue.lowercased() {
@@ -143,12 +143,12 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
 
         // Add the visibility if it was set
         if let visibility = invocation.visibility {
-            protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue.capitalized)")
+            protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue)")
         }
 
         // Add the file naming if it was set
         if let fileNaming = invocation.fileNaming {
-            protocArgs.append("--swift_opt=FileNaming=\(fileNaming.rawValue.capitalized)")
+            protocArgs.append("--swift_opt=FileNaming=\(fileNaming.rawValue)")
         }
 
         var inputFiles = [Path]()

--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -78,7 +78,8 @@ to the root of your target's source folder. An example configuration file looks 
             "protoFiles": [
                 "Bar.proto"
             ],
-            "visibility": "public"
+            "visibility": "public",
+            "fileNaming": "pathToUnderscores"
         }
     ]
 }
@@ -90,7 +91,9 @@ to the root of your target's source folder. An example configuration file looks 
 
 In the above configuration, you declared two invocations to the `protoc` compiler. The first invocation
 is generating Swift types for the `Foo.proto` file with `internal` visibility. The second invocation
-is generating Swift types for the `Bar.proto` file with the `public` visibility.
+is generating Swift types for the `Bar.proto` file with the `public` visibility. Furthermore, the second
+invocation is using the `pathToUnderscores` file naming option. This option can be used to solve
+problems where a single target contains two or more proto files with the same name.
 
 ### Defining the path to the protoc binary
 


### PR DESCRIPTION
# Motivation
In some cases, it might be that the proto files in a single target have duplicate file names. This would result in a compilation failure since Swift does not allow duplicate files names in a single module. To resolve this `protoc-gen-swift` has a `FileNaming` option called `PathToUnderscore` to avoid this. We should expose this as an option in the SPM plugin.

# Modification
This PR extends the SPM plugin config to set a `fileNaming` strategy. It defaults to the `FullPath` strategy if none is set.

# Result
Fixes: https://github.com/apple/swift-protobuf/issues/1310