### PR TITLE
Build protobuf into an output directory.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,20 +114,22 @@ jobs:
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
       working-directory: protobuf
       run: |
+        mkdir cmake_build
+        cd cmake_build
         cmake \
           -DCMAKE_BUILD_TYPE=Release \
           -Dprotobuf_BUILD_TESTS=OFF \
           -Dprotobuf_INSTALL=OFF \
           -Dprotobuf_BUILD_CONFORMANCE=ON \
-          .
+          -S ..
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -j "${NUM_CPUS}" protoc conformance_test_runner
     - name: Test plugin
       working-directory: main
-      run: make test-plugin PROTOC=../protobuf/protoc
+      run: make test-plugin PROTOC=../protobuf/cmake_build/protoc
     - name: Test conformance
       working-directory: main
-      run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/conformance_test_runner
+      run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner
 
   sanitizer_testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -75,14 +75,16 @@ jobs:
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
       working-directory: protobuf
       run: |
+        mkdir cmake_build
+        cd cmake_build
         cmake \
           -DCMAKE_BUILD_TYPE=Release \
           -Dprotobuf_BUILD_TESTS=OFF \
           -Dprotobuf_INSTALL=OFF \
           -Dprotobuf_BUILD_CONFORMANCE=ON \
-          .
+          -S ..
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -j "${NUM_CPUS}" protoc conformance_test_runner
     - name: Test conformance
       working-directory: main
-      run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/conformance_test_runner
+      run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/issues/10749 opened for the break, seems like cmake can no longer build in place.