### PR TITLE
[WiP] Improve the performance when serializing very large objects to TextFormat

### DIFF
--- a/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
@@ -51,7 +51,7 @@ extension Message {
       // missing required fields); TextEncoding never actually does throw.
       try! traverse(visitor: &visitor)
     }
-    return visitor.result
+    return visitor.constructFinalResult()
   }
 
   /// Creates a new message by decoding the given string containing a

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -26,8 +26,8 @@ internal struct TextFormatEncodingVisitor: Visitor {
   private let options: TextFormatEncodingOptions
 
   /// The protobuf text produced by the visitor.
-  var result: String {
-    return encoder.stringResult
+  internal mutating func constructFinalResult() -> String {
+    return encoder.constructFinalResult()
   }
 
   /// Creates a new visitor that serializes the given message to protobuf text


### PR DESCRIPTION
The TextFormatEncoder relies on appending a few bytes at a time to an `Array<UInt8>`.  For large objects, this seems to result in a lot more calls to memmove than expected.

To mitigate this, the TextFormateEncoder now uses two arrays: all bytes are first appended to a smaller (4096 byte) fixed-size array; when that fills up, it is appended to the larger array as a block.

This was found by OSS-Fuzz:  It found an input of ~1MB that would decode successfully but took more than 60s to re-encode.  The example it found now encodes in just over 1s.

Resolves https://oss-fuzz.com/testcase?key=6026353006215168