### PR TITLE
TextFormat Performance:  Avoid quadratic behavior for map and Any fields

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -33,12 +33,6 @@ internal struct TextFormatEncodingVisitor: Visitor {
   /// Creates a new visitor that serializes the given message to protobuf text
   /// format.
   init(message: Message, options: TextFormatEncodingOptions) {
-    self.init(message: message, encoder: TextFormatEncoder(), options: options)
-  }
-
-  /// Creates a new visitor that serializes the given message to protobuf text
-  /// format, using an existing encoder.
-  private init(message: Message, encoder: TextFormatEncoder, options: TextFormatEncodingOptions) {
     let nameMap: _NameMap?
     if let nameProviding = message as? _ProtoNameProviding {
         nameMap = type(of: nameProviding)._protobuf_nameMap
@@ -46,20 +40,11 @@ internal struct TextFormatEncodingVisitor: Visitor {
         nameMap = nil
     }
     let extensions = (message as? ExtensibleMessage)?._protobuf_extensionFieldValues
-    self.init(nameMap: nameMap, nameResolver: [:], extensions: extensions, encoder: encoder, options: options)
-  }
 
-  private init(
-    nameMap: _NameMap?,
-    nameResolver: [Int:StaticString],
-    extensions: ExtensionFieldValueSet?,
-    encoder: TextFormatEncoder,
-    options: TextFormatEncodingOptions
-  ) {
     self.nameMap = nameMap
-    self.nameResolver = nameResolver
+    self.nameResolver = [:]
     self.extensions = extensions
-    self.encoder = encoder
+    self.encoder = TextFormatEncoder()
     self.options = options
   }
 

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
@@ -1,0 +1,100 @@
+// Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift - Exercise proto3 text format coding
+//
+// Copyright (c) 2022 - 2022 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// This is a set of tests for text format protobuf files.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+import SwiftProtobuf
+
+class Test_TextFormat_Performance: XCTestCase, PBTestHelpers {
+    typealias MessageTestType = Fuzz_Testing_Message
+
+    // Each of the following should be under 1s on a reasonably
+    // fast machine (originally developed on an M1 MacBook Pro).
+    // If they are significantly slower than that, then something
+    // may be amiss.
+
+    func testEncoding_manyMapsEncoding_shouldBeUnder1s() {
+        let repeats = 50000
+
+        let child = (
+            "repeated_message {\n"
+            + "  map_fixed64_sint64 {\n"
+            + "    key: 20\n"
+            + "    value: 8\n"
+            + "  }\n"
+            + "  map_fixed64_sint64 {\n"
+            + "    key: 30\n"
+            + "    value: 4\n"
+            + "  }\n"
+            + "  map_fixed64_sint64 {\n"
+            + "    key: 40\n"
+            + "    value: 2\n"
+            + "  }\n"
+            + "}\n"
+        )
+        let expected = String(repeating: child, count: repeats)
+
+        let msg = Fuzz_Testing_Message.with {
+            let child = Fuzz_Testing_Message.with {
+               $0.mapFixed64Sint64[20] = 8
+               $0.mapFixed64Sint64[30] = 4
+               $0.mapFixed64Sint64[40] = 2
+            }
+            let array = Array<Fuzz_Testing_Message>(repeating: child, count: repeats)
+            $0.repeatedMessage = array
+        }
+
+        // Map fields used to trigger quadratic behavior, which meant
+        // this encoding could take over 60s, but now it should
+        // consistently take a fraction of a second. I've skipped
+        // decoding here because decoding is much slower -- due to the
+        // need to create a lot of objects -- which makes it much less
+        // obvious when the encoding goes awry.
+        let encoded = msg.textFormatString()
+        XCTAssertEqual(expected, encoded)
+    }
+
+    func testEncoding_manyAnyEncoding_shouldBeUnder1s() {
+        let repeats = 50000
+
+        let child = (
+            "repeated_message {\n"
+            + "  wkt_any {\n"
+            + "    [type.googleapis.com/google.protobuf.Duration] {\n"
+            + "      seconds: 123\n"
+            + "      nanos: 123456789\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n"
+        )
+        let expected = String(repeating: child, count: repeats)
+
+        let msg = Fuzz_Testing_Message.with {
+            let child = Fuzz_Testing_Message.with {
+                let duration = Google_Protobuf_Duration(seconds: 123, nanos: 123456789)
+                $0.wktAny = try! Google_Protobuf_Any(message: duration)
+            }
+            let array = Array<Fuzz_Testing_Message>(repeating: child, count: repeats)
+            $0.repeatedMessage = array
+        }
+
+        // Any fields used to trigger quadratic behavior, which meant
+        // this encoding could take over 30s, but now it should
+        // consistently take a fraction of a second. I've skipped
+        // decoding here because decoding is much slower -- due to the
+        // need to create a lot of objects -- which makes it much less
+        // obvious when the encoding goes awry.
+        let encoded = msg.textFormatString()
+        XCTAssertEqual(expected, encoded)
+    }
+}


### PR DESCRIPTION
Credit: OSS-Fuzz

The TextFormat encoding visitor would create a new child visitor when traversing into map or Any fields.  This resulted in multiple references to the underlying byte array, triggered unnecessary copy-on-write operations, which led to quadratic behavior for large messages with lots of map and/or Any fields.

Regular message fields didn't have this problem because we didn't create a new visitor in that case -- instead we adjusted the configuration of the current visitor object.  This adjusts the handling of map and Any fields to work the same way.

The test case demonstrates > 100x performance improvement for a multi-megabyte text encoding of a message containing 50,000 map fields or Any fields.  The test was tuned so that on a fast machine it used to take >60s but now takes well under 1s.  Hopefully, if anything regresses here, that will be a glaring enough difference to call attention to it.