### PR TITLE
JSON Performance: Avoid quadratic encoding for maps

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -77,6 +77,8 @@ internal struct JSONEncoder {
         }
     }
 
+    internal var bytesResult: [UInt8] { return data }
+
     /// Append a `StaticString` to the JSON text.  Because
     /// `StaticString` is already UTF8 internally, this is faster
     /// than appending a regular `String`.
@@ -98,6 +100,10 @@ internal struct JSONEncoder {
     /// Append a `String` to the JSON text.
     internal mutating func append(text: String) {
         data.append(contentsOf: text.utf8)
+    }
+
+    internal mutating func append(bytes: [UInt8]) {
+        data.append(contentsOf: bytes)
     }
 
     /// Append a raw utf8 in a `Data` to the JSON text.

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -363,36 +363,36 @@ internal struct JSONEncodingVisitor: Visitor {
   mutating func visitMapField<KeyType, ValueType: MapValueType>(fieldType: _ProtobufMap<KeyType, ValueType>.Type, value: _ProtobufMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws {
     try startField(for: fieldNumber)
     encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
+    var mapVisitor = JSONMapEncodingVisitor(encoder: JSONEncoder(), options: options)
     for (k,v) in value {
         try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
         try ValueType.visitSingular(value: v, fieldNumber: 2, with: &mapVisitor)
     }
-    encoder = mapVisitor.encoder
+    encoder.append(bytes: mapVisitor.bytesResult)
     encoder.append(text: "}")
   }
 
   mutating func visitMapField<KeyType, ValueType>(fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type, value: _ProtobufEnumMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws  where ValueType.RawValue == Int {
     try startField(for: fieldNumber)
     encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
+    var mapVisitor = JSONMapEncodingVisitor(encoder: JSONEncoder(), options: options)
     for (k, v) in value {
       try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
       try mapVisitor.visitSingularEnumField(value: v, fieldNumber: 2)
     }
-    encoder = mapVisitor.encoder
+    encoder.append(bytes: mapVisitor.bytesResult)
     encoder.append(text: "}")
   }
 
   mutating func visitMapField<KeyType, ValueType>(fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type, value: _ProtobufMessageMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws {
     try startField(for: fieldNumber)
     encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
+    var mapVisitor = JSONMapEncodingVisitor(encoder: JSONEncoder(), options: options)
     for (k,v) in value {
         try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
         try mapVisitor.visitSingularMessageField(value: v, fieldNumber: 2)
     }
-    encoder = mapVisitor.encoder
+    encoder.append(bytes: mapVisitor.bytesResult)
     encoder.append(text: "}")
   }
 

--- a/Sources/SwiftProtobuf/JSONMapEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONMapEncodingVisitor.swift
@@ -30,6 +30,12 @@ internal struct JSONMapEncodingVisitor: SelectiveVisitor {
       self.options = options
   }
 
+  internal var bytesResult: [UInt8] {
+      get {
+          return encoder.bytesResult
+      }
+  }
+
   private mutating func startKey() {
       if let s = separator {
           encoder.append(staticText: s)

--- a/Tests/SwiftProtobufTests/Test_JSON_Performance.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Performance.swift
@@ -1,0 +1,137 @@
+// Tests/SwiftProtobufTests/Test_JSON_Performance.swift - JSON performance checks
+//
+// Copyright (c) 2022 - 2022 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// This is a set of tests for JSON format protobuf files.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+import SwiftProtobuf
+
+class Test_JSON_Performance: XCTestCase, PBTestHelpers {
+    typealias MessageTestType = Fuzz_Testing_Message
+
+    // Each of the following should be under 1s on a reasonably
+    // fast machine (originally developed on an M1 MacBook Pro).
+    // If they are significantly slower than that, then something
+    // may be amiss.
+
+    func testEncoding_manyIntMapsEncoding_shouldBeUnder1s() {
+        let rawPadding = Array<Int32>(repeating: 1000000000, count: 150000)
+        let mapRepeats = 60000
+
+        let pad = rawPadding.map({$0.description}).joined(separator: ",")
+        let child = "{\"mapFixed64Sint64\":{\"30\":\"4\"}}"
+        let children = Array<String>(repeating: child, count: mapRepeats).joined(separator: ",")
+        let expected = (
+            "{"
+            + "\"repeatedInt32\":["
+            + pad
+            + "],"
+            + "\"repeatedMessage\":["
+            + children
+            + "]}"
+        )
+
+        let msg = Fuzz_Testing_Message.with {
+            $0.repeatedInt32 = rawPadding
+            let child = Fuzz_Testing_Message.with {
+               $0.mapFixed64Sint64[30] = 4
+            }
+            let array = Array<Fuzz_Testing_Message>(repeating: child, count: mapRepeats)
+            $0.repeatedMessage = array
+        }
+
+        // Map fields used to trigger quadratic behavior, which meant
+        // this encoding could take over 30s, but now it should
+        // consistently take a fraction of a second. I've skipped
+        // decoding here because decoding is much slower -- due to the
+        // need to create a lot of objects -- which makes it much less
+        // obvious when the encoding goes awry.
+        let encoded = try! msg.jsonString()
+        XCTAssertEqual(expected, encoded)
+    }
+
+    func testEncoding_manyEnumMapsEncoding_shouldBeUnder1s() {
+        let rawPadding = Array<Int32>(repeating: 1000000000, count: 150000)
+        let mapRepeats = 60000
+
+        let pad = rawPadding.map({$0.description}).joined(separator: ",")
+        let child = "{\"mapInt32AnEnum\":{\"30\":\"TWO\"}}"
+        let children = Array<String>(repeating: child, count: mapRepeats).joined(separator: ",")
+        let expected = (
+            "{"
+            + "\"repeatedInt32\":["
+            + pad
+            + "],"
+            + "\"repeatedMessage\":["
+            + children
+            + "]}"
+        )
+
+        let msg = Fuzz_Testing_Message.with {
+            $0.repeatedInt32 = rawPadding
+            let child = Fuzz_Testing_Message.with {
+               $0.mapInt32AnEnum[30] = Fuzz_Testing_AnEnum.two
+            }
+            let array = Array<Fuzz_Testing_Message>(repeating: child, count: mapRepeats)
+            $0.repeatedMessage = array
+        }
+
+        // Map fields used to trigger quadratic behavior, which meant
+        // this encoding could take over 30s, but now it should
+        // consistently take a fraction of a second. I've skipped
+        // decoding here because decoding is much slower -- due to the
+        // need to create a lot of objects -- which makes it much less
+        // obvious when the encoding goes awry.
+        let encoded = try! msg.jsonString()
+        XCTAssertEqual(expected, encoded)
+    }
+
+
+    func testEncoding_manyMessageMapsEncoding_shouldBeUnder1s() {
+        let rawPadding = Array<Int32>(repeating: 1000000000, count: 150000)
+        let mapRepeats = 50000
+
+        let pad = rawPadding.map({$0.description}).joined(separator: ",")
+        let child = "{\"mapInt32Message\":{\"30\":{\"singularInt32\":8}}}"
+        let children = Array<String>(repeating: child, count: mapRepeats).joined(separator: ",")
+        let expected = (
+            "{"
+            + "\"repeatedInt32\":["
+            + pad
+            + "],"
+            + "\"repeatedMessage\":["
+            + children
+            + "]}"
+        )
+
+        let msg = Fuzz_Testing_Message.with {
+            $0.repeatedInt32 = rawPadding
+            let child = Fuzz_Testing_Message.with {
+               let grandchild = Fuzz_Testing_Message.with {
+                   $0.singularInt32 = 8
+               }
+               $0.mapInt32Message[30] = grandchild
+            }
+            let array = Array<Fuzz_Testing_Message>(repeating: child, count: mapRepeats)
+            $0.repeatedMessage = array
+        }
+
+        // Map fields used to trigger quadratic behavior, which meant
+        // this encoding could take over 30s, but now it should
+        // consistently take a fraction of a second. I've skipped
+        // decoding here because decoding is much slower -- due to the
+        // need to create a lot of objects -- which makes it much less
+        // obvious when the encoding goes awry.
+        let encoded = try! msg.jsonString()
+        XCTAssertEqual(expected, encoded)
+    }
+}


### PR DESCRIPTION
OSS-Fuzz found that TextFormat encoding could degenerate into quadratic behavior for certain cases.  This fixes a similar issue with the JSON encoder.

Specifically, when encoding map fields, the JSON encoding visitor would construct a child visitor using the same underlying encoder. This results in multiple references to the backing byte array which triggers copy-on-write for that array.

To avoid that, we modify the JSON encoding visitor to construct a child visitor with a new empty encoder, and then append the contents of that encoder back to the parent.  This avoids the quadratic behavior in this case.

To try to prevent this from regressing, I've added tests that are tuned to take less than 1s on an M1 MacBook Pro with the new code and more than 30s with the old code. If this does regress, that should be a dramatic enough slowdown to attract someone's attention.