### PR TITLE
Ensure BinaryEncoder/BinaryEncoderVistor changes stay lightweight

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncoder.swift
+++ b/Sources/SwiftProtobuf/BinaryEncoder.swift
@@ -17,7 +17,7 @@ import Foundation
 
 /// Encoder for Binary Protocol Buffer format
 internal struct BinaryEncoder {
-    private var pointer: UnsafeMutableRawPointer
+    internal var pointer: UnsafeMutableRawPointer
 
     init(forWritingInto pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -30,10 +30,6 @@ internal struct BinaryEncodingVisitor: Visitor {
     encoder = BinaryEncoder(forWritingInto: pointer)
   }
 
-  init(encoder: BinaryEncoder) {
-    self.encoder = encoder
-  }
-
   mutating func visitUnknown(bytes: Data) throws {
     encoder.appendUnknown(data: bytes)
   }
@@ -342,9 +338,9 @@ extension BinaryEncodingVisitor {
       let length = try value.serializedDataSize()
       encoder.putVarInt(value: length)
       // Create the sub encoder after writing the length.
-      var subVisitor = BinaryEncodingVisitor(encoder: encoder)
+      var subVisitor = BinaryEncodingVisitor(forWritingInto: encoder.pointer)
       try value.traverse(visitor: &subVisitor)
-      encoder = subVisitor.encoder
+      encoder.pointer = subVisitor.encoder.pointer
 
       encoder.putVarInt(value: Int64(WireFormat.MessageSet.Tags.itemEnd.rawValue))
     }


### PR DESCRIPTION
Currently, `BinaryEncoder` only has one field, and it is `UnsafeMutableRawPointer`, so the cost of copying the `encoder` in `BinaryEncoderVistor` should be cheap; but to ensure that stats the case, remove the initializer that would do a full copy, and directly expose/update the `pointer` for this one case. Hopefully this will ensure this case says lightweight if the types are revised.

Follow from comments on #1323