### PR TITLE
Use actions/checkout@v3 and actions/cache@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
     - name: Update and install dependencies
@@ -97,14 +97,14 @@ jobs:
       run: make test-runtime
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: protobuf
         # NOTE: for refs that can float like 'main' the cache might be out of date!
         key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
     - name: Checkout protobuf repo
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: protocolbuffers/protobuf
         ref: ${{ steps.get-sha.outputs.sha }}
@@ -143,7 +143,7 @@ jobs:
       # swift:latest is still bionic, so explicitly use swift:focal.
       image: swift:focal
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         set -eu
@@ -173,6 +173,6 @@ jobs:
       # swift:latest is still bionic, so explicitly use swift:focal.
       image: swift:focal
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: FuzzTesting/do_build.sh --${{ matrix.swiftpm_config }}-only --run-regressions

--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
     - name: Checkout protobufbuffers/protobuf
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: protocolbuffers/protobuf
         path: protobuf

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -36,7 +36,7 @@ jobs:
       image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: main
     - name: Update and install dependencies
@@ -58,14 +58,14 @@ jobs:
         esac
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: protobuf
         # NOTE: for refs that can float like 'main' the cache might be out of date!
         key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
     - name: Checkout protobuf repo
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: protocolbuffers/protobuf
         ref: ${{ steps.get-sha.outputs.sha }}


### PR DESCRIPTION
This should remove the warnings in the logs about node versions.