### PR TITLE
Drop some unneeded checks about syntax.

### DIFF
--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -206,7 +206,6 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
         } else {
             // At this point, the fields would be a primative type, and should only
             // be visted if it is the non default value.
-            assert(fieldDescriptor.file.syntax == .proto3)
             switch fieldDescriptor.type {
             case .string, .bytes:
                 conditional = ("!\(varName).isEmpty")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -424,12 +424,9 @@ class MessageGenerator {
     // faster without recursing through the message fields to ensure they are
     // initialized.
 
-    if descriptor.file.syntax == .proto2 {
-      // Only proto2 syntax can have required fields; ensure required fields
-      // have values.
-      for f in fields {
-        f.generateRequiredFieldCheck(printer: &fieldCheckPrinter)
-      }
+    // Ensure required fields are set.
+    for f in fields {
+      f.generateRequiredFieldCheck(printer: &fieldCheckPrinter)
     }
 
     for f in fields {


### PR DESCRIPTION
One was a slight optimization, but generally shouldn't make assumptions about syntax vs fields. Let things always call through to check the explicit methods on the field descriptors instead.