### PR TITLE
Make it easier to compile the SwiftProtobufCore with a different module name.

### DIFF
--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -173,7 +173,7 @@ struct Google_Protobuf_Any {
     set {_uniqueStorage()._value = newValue}
   }
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -188,9 +188,9 @@ extension Google_Protobuf_Any: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Any"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "type_url"),
     2: .same(proto: "value"),
   ]
@@ -204,7 +204,7 @@ extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     return _storage
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -220,7 +220,7 @@ extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       try _storage.preTraverse()
       if !_storage._typeURL.isEmpty {

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -111,7 +111,7 @@ struct Google_Protobuf_Api {
   /// The source syntax of the service.
   var syntax: Google_Protobuf_Syntax = .proto2
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -145,7 +145,7 @@ struct Google_Protobuf_Method {
   /// The source syntax of this method.
   var syntax: Google_Protobuf_Syntax = .proto2
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -240,7 +240,7 @@ struct Google_Protobuf_Mixin {
   /// are rooted.
   var root: String = String()
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -255,9 +255,9 @@ extension Google_Protobuf_Mixin: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Api: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Api"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "methods"),
     3: .same(proto: "options"),
@@ -267,7 +267,7 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     7: .same(proto: "syntax"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -285,7 +285,7 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -327,9 +327,9 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
   }
 }
 
-extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Method: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Method"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .standard(proto: "request_type_url"),
     3: .standard(proto: "request_streaming"),
@@ -339,7 +339,7 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
     7: .same(proto: "syntax"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -357,7 +357,7 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -395,14 +395,14 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
   }
 }
 
-extension Google_Protobuf_Mixin: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Mixin: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Mixin"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "root"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -415,7 +415,7 @@ extension Google_Protobuf_Mixin: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -52,8 +52,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -66,7 +66,7 @@ struct Google_Protobuf_FileDescriptorSet {
 
   var file: [Google_Protobuf_FileDescriptorProto] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -161,7 +161,7 @@ struct Google_Protobuf_FileDescriptorProto {
   /// Clears the value of `edition`. Subsequent reads from it will return its default value.
   mutating func clearEdition() {self._edition = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -215,7 +215,7 @@ struct Google_Protobuf_DescriptorProto {
   /// A given name may only be reserved once.
   var reservedName: [String] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   struct ExtensionRange {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -251,7 +251,7 @@ struct Google_Protobuf_DescriptorProto {
     /// Clears the value of `options`. Subsequent reads from it will return its default value.
     mutating func clearOptions() {self._options = nil}
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     init() {}
 
@@ -288,7 +288,7 @@ struct Google_Protobuf_DescriptorProto {
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
     mutating func clearEnd() {self._end = nil}
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     init() {}
 
@@ -302,7 +302,7 @@ struct Google_Protobuf_DescriptorProto {
   fileprivate var _options: Google_Protobuf_MessageOptions? = nil
 }
 
-struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_ExtensionRangeOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -310,11 +310,11 @@ struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.ExtensibleMessag
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
 }
 
 /// Describes a field within a message.
@@ -462,9 +462,9 @@ struct Google_Protobuf_FieldDescriptorProto {
   /// Clears the value of `proto3Optional`. Subsequent reads from it will return its default value.
   mutating func clearProto3Optional() {_uniqueStorage()._proto3Optional = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
-  enum TypeEnum: SwiftProtobufCore.Enum {
+  enum TypeEnum: Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors.
@@ -560,7 +560,7 @@ struct Google_Protobuf_FieldDescriptorProto {
 
   }
 
-  enum Label: SwiftProtobufCore.Enum {
+  enum Label: Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors
@@ -620,7 +620,7 @@ struct Google_Protobuf_OneofDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   mutating func clearOptions() {self._options = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -663,7 +663,7 @@ struct Google_Protobuf_EnumDescriptorProto {
   /// be reserved once.
   var reservedName: [String] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// Range of reserved numeric values. Reserved values may not be used by
   /// entries in the same enum. Reserved ranges may not overlap.
@@ -696,7 +696,7 @@ struct Google_Protobuf_EnumDescriptorProto {
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
     mutating func clearEnd() {self._end = nil}
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     init() {}
 
@@ -743,7 +743,7 @@ struct Google_Protobuf_EnumValueDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   mutating func clearOptions() {self._options = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -778,7 +778,7 @@ struct Google_Protobuf_ServiceDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   mutating func clearOptions() {self._options = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -850,7 +850,7 @@ struct Google_Protobuf_MethodDescriptorProto {
   /// Clears the value of `serverStreaming`. Subsequent reads from it will return its default value.
   mutating func clearServerStreaming() {self._serverStreaming = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -862,7 +862,7 @@ struct Google_Protobuf_MethodDescriptorProto {
   fileprivate var _serverStreaming: Bool? = nil
 }
 
-struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_FileOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1115,10 +1115,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
     set {_uniqueStorage()._uninterpretedOption = newValue}
   }
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  enum OptimizeMode: SwiftProtobufCore.Enum {
+  enum OptimizeMode: Enum {
     typealias RawValue = Int
 
     /// Generate complete code for parsing, serialization,
@@ -1155,11 +1155,11 @@ struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Google_Protobuf_MessageOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_MessageOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1249,18 +1249,18 @@ struct Google_Protobuf_MessageOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _messageSetWireFormat: Bool? = nil
   fileprivate var _noStandardDescriptorAccessor: Bool? = nil
   fileprivate var _deprecated: Bool? = nil
   fileprivate var _mapEntry: Bool? = nil
 }
 
-struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_FieldOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1389,9 +1389,9 @@ struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
-  enum CType: SwiftProtobufCore.Enum {
+  enum CType: Enum {
     typealias RawValue = Int
 
     /// Default mode.
@@ -1422,7 +1422,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
 
   }
 
-  enum JSType: SwiftProtobufCore.Enum {
+  enum JSType: Enum {
     typealias RawValue = Int
 
     /// Use the default type.
@@ -1459,7 +1459,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _ctype: Google_Protobuf_FieldOptions.CType? = nil
   fileprivate var _packed: Bool? = nil
   fileprivate var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
@@ -1469,7 +1469,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
   fileprivate var _weak: Bool? = nil
 }
 
-struct Google_Protobuf_OneofOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_OneofOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1477,14 +1477,14 @@ struct Google_Protobuf_OneofOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
 }
 
-struct Google_Protobuf_EnumOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_EnumOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1516,16 +1516,16 @@ struct Google_Protobuf_EnumOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _allowAlias: Bool? = nil
   fileprivate var _deprecated: Bool? = nil
 }
 
-struct Google_Protobuf_EnumValueOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_EnumValueOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1546,15 +1546,15 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
 }
 
-struct Google_Protobuf_ServiceOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_ServiceOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1575,15 +1575,15 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
 }
 
-struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage {
+struct Google_Protobuf_MethodOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1613,12 +1613,12 @@ struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  enum IdempotencyLevel: SwiftProtobufCore.Enum {
+  enum IdempotencyLevel: Enum {
     typealias RawValue = Int
     case idempotencyUnknown // = 0
 
@@ -1653,7 +1653,7 @@ struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage {
 
   init() {}
 
-  var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
   fileprivate var _idempotencyLevel: Google_Protobuf_MethodOptions.IdempotencyLevel? = nil
 }
@@ -1727,7 +1727,7 @@ struct Google_Protobuf_UninterpretedOption {
   /// Clears the value of `aggregateValue`. Subsequent reads from it will return its default value.
   mutating func clearAggregateValue() {self._aggregateValue = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// The name of the uninterpreted option.  Each string represents a segment in
   /// a dot-separated name.  is_extension is true iff a segment represents an
@@ -1757,7 +1757,7 @@ struct Google_Protobuf_UninterpretedOption {
     /// Clears the value of `isExtension`. Subsequent reads from it will return its default value.
     mutating func clearIsExtension() {self._isExtension = nil}
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     init() {}
 
@@ -1827,7 +1827,7 @@ struct Google_Protobuf_SourceCodeInfo {
   ///   be recorded in the future.
   var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   struct Location {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -1933,7 +1933,7 @@ struct Google_Protobuf_SourceCodeInfo {
 
     var leadingDetachedComments: [String] = []
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     init() {}
 
@@ -1956,7 +1956,7 @@ struct Google_Protobuf_GeneratedCodeInfo {
   /// of its generating .proto file.
   var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   struct Annotation {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -2009,11 +2009,11 @@ struct Google_Protobuf_GeneratedCodeInfo {
     /// Clears the value of `semantic`. Subsequent reads from it will return its default value.
     mutating func clearSemantic() {self._semantic = nil}
 
-    var unknownFields = SwiftProtobufCore.UnknownStorage()
+    var unknownFields = UnknownStorage()
 
     /// Represents the identified object's effect on the element in the original
     /// .proto file.
-    enum Semantic: SwiftProtobufCore.Enum {
+    enum Semantic: Enum {
       typealias RawValue = Int
 
       /// There is no effect or the effect is indescribable.
@@ -2093,18 +2093,18 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileDescriptorSet: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "file"),
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.file) {return false}
+    if !Internal.areAllInitialized(self.file) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2116,7 +2116,7 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftPro
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.file.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
     }
@@ -2130,9 +2130,9 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftPro
   }
 }
 
-extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "package"),
     3: .same(proto: "dependency"),
@@ -2149,15 +2149,15 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.messageType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.enumType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.service) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.`extension`) {return false}
+    if !Internal.areAllInitialized(self.messageType) {return false}
+    if !Internal.areAllInitialized(self.enumType) {return false}
+    if !Internal.areAllInitialized(self.service) {return false}
+    if !Internal.areAllInitialized(self.`extension`) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2181,7 +2181,7 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2247,9 +2247,9 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "field"),
     6: .same(proto: "extension"),
@@ -2263,17 +2263,17 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.field) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.`extension`) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.nestedType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.enumType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.extensionRange) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.oneofDecl) {return false}
+    if !Internal.areAllInitialized(self.field) {return false}
+    if !Internal.areAllInitialized(self.`extension`) {return false}
+    if !Internal.areAllInitialized(self.nestedType) {return false}
+    if !Internal.areAllInitialized(self.enumType) {return false}
+    if !Internal.areAllInitialized(self.extensionRange) {return false}
+    if !Internal.areAllInitialized(self.oneofDecl) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2294,7 +2294,7 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2348,9 +2348,9 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
   }
 }
 
-extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto.ExtensionRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ExtensionRange"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
     3: .same(proto: "options"),
@@ -2361,7 +2361,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2375,7 +2375,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2401,14 +2401,14 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
   }
 }
 
-extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto.ReservedRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2421,7 +2421,7 @@ extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Messa
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2443,19 +2443,19 @@ extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Messa
   }
 }
 
-extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ExtensionRangeOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExtensionRangeOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2469,7 +2469,7 @@ extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, Swif
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.uninterpretedOption.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.uninterpretedOption, fieldNumber: 999)
     }
@@ -2485,9 +2485,9 @@ extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, Swif
   }
 }
 
-extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     3: .same(proto: "number"),
     4: .same(proto: "label"),
@@ -2547,7 +2547,7 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2572,7 +2572,7 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every if/case branch local when no optimizations
@@ -2640,8 +2640,8 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
   }
 }
 
-extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldDescriptorProto.TypeEnum: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "TYPE_DOUBLE"),
     2: .same(proto: "TYPE_FLOAT"),
     3: .same(proto: "TYPE_INT64"),
@@ -2663,17 +2663,17 @@ extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobufCore._Prot
   ]
 }
 
-extension Google_Protobuf_FieldDescriptorProto.Label: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldDescriptorProto.Label: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "LABEL_OPTIONAL"),
     2: .same(proto: "LABEL_REQUIRED"),
     3: .same(proto: "LABEL_REPEATED"),
   ]
 }
 
-extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_OneofDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "options"),
   ]
@@ -2683,7 +2683,7 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2696,7 +2696,7 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2718,9 +2718,9 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
   }
 }
 
-extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "value"),
     3: .same(proto: "options"),
@@ -2729,12 +2729,12 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.value) {return false}
+    if !Internal.areAllInitialized(self.value) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2750,7 +2750,7 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2784,14 +2784,14 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_EnumDescriptorProto.protoMessageName + ".EnumReservedRange"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2804,7 +2804,7 @@ extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCo
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2826,9 +2826,9 @@ extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValueDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "number"),
     3: .same(proto: "options"),
@@ -2839,7 +2839,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2853,7 +2853,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2879,21 +2879,21 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
   }
 }
 
-extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ServiceDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "method"),
     3: .same(proto: "options"),
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.method) {return false}
+    if !Internal.areAllInitialized(self.method) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2907,7 +2907,7 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, Swi
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2933,9 +2933,9 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, Swi
   }
 }
 
-extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MethodDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .standard(proto: "input_type"),
     3: .standard(proto: "output_type"),
@@ -2949,7 +2949,7 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2966,7 +2966,7 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3004,9 +3004,9 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
   }
 }
 
-extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FileOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "java_package"),
     8: .standard(proto: "java_outer_classname"),
     10: .standard(proto: "java_multiple_files"),
@@ -3092,12 +3092,12 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobufCore.Internal.areAllInitialized(_storage._uninterpretedOption) {return false}
+      if !Internal.areAllInitialized(_storage._uninterpretedOption) {return false}
       return true
     }
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3134,7 +3134,7 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every if/case branch local when no optimizations
@@ -3244,17 +3244,17 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_FileOptions.OptimizeMode: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FileOptions.OptimizeMode: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "SPEED"),
     2: .same(proto: "CODE_SIZE"),
     3: .same(proto: "LITE_RUNTIME"),
   ]
 }
 
-extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MessageOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MessageOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "message_set_wire_format"),
     2: .standard(proto: "no_standard_descriptor_accessor"),
     3: .same(proto: "deprecated"),
@@ -3264,11 +3264,11 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3286,7 +3286,7 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3322,9 +3322,9 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FieldOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "ctype"),
     2: .same(proto: "packed"),
     6: .same(proto: "jstype"),
@@ -3337,11 +3337,11 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3362,7 +3362,7 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3410,35 +3410,35 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
   }
 }
 
-extension Google_Protobuf_FieldOptions.CType: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldOptions.CType: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "STRING"),
     1: .same(proto: "CORD"),
     2: .same(proto: "STRING_PIECE"),
   ]
 }
 
-extension Google_Protobuf_FieldOptions.JSType: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldOptions.JSType: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "JS_NORMAL"),
     1: .same(proto: "JS_STRING"),
     2: .same(proto: "JS_NUMBER"),
   ]
 }
 
-extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_OneofOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".OneofOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3452,7 +3452,7 @@ extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobuf
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.uninterpretedOption.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.uninterpretedOption, fieldNumber: 999)
     }
@@ -3468,9 +3468,9 @@ extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobuf
   }
 }
 
-extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EnumOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     2: .standard(proto: "allow_alias"),
     3: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
@@ -3478,11 +3478,11 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3498,7 +3498,7 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3526,20 +3526,20 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValueOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3554,7 +3554,7 @@ extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProt
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3578,20 +3578,20 @@ extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProt
   }
 }
 
-extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ServiceOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     33: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3606,7 +3606,7 @@ extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3630,9 +3630,9 @@ extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MethodOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MethodOptions"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     33: .same(proto: "deprecated"),
     34: .standard(proto: "idempotency_level"),
     999: .standard(proto: "uninterpreted_option"),
@@ -3640,11 +3640,11 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3660,7 +3660,7 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3688,17 +3688,17 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
   }
 }
 
-extension Google_Protobuf_MethodOptions.IdempotencyLevel: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_MethodOptions.IdempotencyLevel: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
     1: .same(proto: "NO_SIDE_EFFECTS"),
     2: .same(proto: "IDEMPOTENT"),
   ]
 }
 
-extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UninterpretedOption: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     2: .same(proto: "name"),
     3: .standard(proto: "identifier_value"),
     4: .standard(proto: "positive_int_value"),
@@ -3709,11 +3709,11 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.name) {return false}
+    if !Internal.areAllInitialized(self.name) {return false}
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3731,7 +3731,7 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3773,9 +3773,9 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UninterpretedOption.NamePart: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "name_part"),
     2: .standard(proto: "is_extension"),
   ]
@@ -3786,7 +3786,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
     return true
   }
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3799,7 +3799,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3821,13 +3821,13 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
   }
 }
 
-extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceCodeInfo: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "location"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3839,7 +3839,7 @@ extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.location.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.location, fieldNumber: 1)
     }
@@ -3853,9 +3853,9 @@ extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceCodeInfo.Location: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "path"),
     2: .same(proto: "span"),
     3: .standard(proto: "leading_comments"),
@@ -3863,7 +3863,7 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
     6: .standard(proto: "leading_detached_comments"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3879,7 +3879,7 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3913,13 +3913,13 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_GeneratedCodeInfo: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "annotation"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3931,7 +3931,7 @@ extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftPro
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.annotation.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.annotation, fieldNumber: 1)
     }
@@ -3945,9 +3945,9 @@ extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftPro
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_GeneratedCodeInfo.Annotation: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "path"),
     2: .standard(proto: "source_file"),
     3: .same(proto: "begin"),
@@ -3955,7 +3955,7 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
     5: .same(proto: "semantic"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3971,7 +3971,7 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -4005,8 +4005,8 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo.Annotation.Semantic: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_GeneratedCodeInfo.Annotation.Semantic: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "NONE"),
     1: .same(proto: "SET"),
     2: .same(proto: "ALIAS"),

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -125,7 +125,7 @@ struct Google_Protobuf_Duration {
   /// to +999,999,999 inclusive.
   var nanos: Int32 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -138,14 +138,14 @@ extension Google_Protobuf_Duration: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Duration: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Duration: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Duration"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "seconds"),
     2: .same(proto: "nanos"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -158,7 +158,7 @@ extension Google_Protobuf_Duration: SwiftProtobufCore.Message, SwiftProtobufCore
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.seconds != 0 {
       try visitor.visitSingularInt64Field(value: self.seconds, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/empty.pb.swift
+++ b/Reference/google/protobuf/empty.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -61,7 +61,7 @@ struct Google_Protobuf_Empty {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -74,16 +74,16 @@ extension Google_Protobuf_Empty: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Empty: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Empty: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Empty"
-  static let _protobuf_nameMap = SwiftProtobufCore._NameMap()
+  static let _protobuf_nameMap = _NameMap()
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let _ = try decoder.nextFieldNumber() {
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Reference/google/protobuf/field_mask.pb.swift
+++ b/Reference/google/protobuf/field_mask.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -256,7 +256,7 @@ struct Google_Protobuf_FieldMask {
   /// The set of field mask paths.
   var paths: [String] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -269,13 +269,13 @@ extension Google_Protobuf_FieldMask: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_FieldMask: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldMask: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FieldMask"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "paths"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -287,7 +287,7 @@ extension Google_Protobuf_FieldMask: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.paths.isEmpty {
       try visitor.visitRepeatedStringField(value: self.paths, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -60,7 +60,7 @@ struct Google_Protobuf_SourceContext {
   /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
   var fileName: String = String()
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -73,13 +73,13 @@ extension Google_Protobuf_SourceContext: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_SourceContext: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceContext: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SourceContext"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "file_name"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -91,7 +91,7 @@ extension Google_Protobuf_SourceContext: SwiftProtobufCore.Message, SwiftProtobu
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.fileName.isEmpty {
       try visitor.visitSingularStringField(value: self.fileName, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -53,7 +53,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.Protob
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-enum Google_Protobuf_NullValue: SwiftProtobufCore.Enum {
+enum Google_Protobuf_NullValue: Enum {
   typealias RawValue = Int
 
   /// Null value.
@@ -101,7 +101,7 @@ struct Google_Protobuf_Struct {
   /// Unordered map of dynamically typed values.
   var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -174,7 +174,7 @@ struct Google_Protobuf_Value {
     set {kind = .listValue(newValue)}
   }
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// The kind of value.
   enum OneOf_Kind: Equatable {
@@ -207,7 +207,7 @@ struct Google_Protobuf_ListValue {
   /// Repeated field of dynamically typed values.
   var values: [Google_Protobuf_Value] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -223,33 +223,33 @@ extension Google_Protobuf_ListValue: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_NullValue: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_NullValue: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "NULL_VALUE"),
   ]
 }
 
-extension Google_Protobuf_Struct: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Struct: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Struct"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "fields"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeMapField(fieldType: SwiftProtobufCore._ProtobufMessageMap<SwiftProtobufCore.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields) }()
+      case 1: try { try decoder.decodeMapField(fieldType: _ProtobufMessageMap<ProtobufString,Google_Protobuf_Value>.self, value: &self.fields) }()
       default: break
       }
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.fields.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobufCore._ProtobufMessageMap<SwiftProtobufCore.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
+      try visitor.visitMapField(fieldType: _ProtobufMessageMap<ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -261,9 +261,9 @@ extension Google_Protobuf_Struct: SwiftProtobufCore.Message, SwiftProtobufCore._
   }
 }
 
-extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Value"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "null_value"),
     2: .standard(proto: "number_value"),
     3: .standard(proto: "string_value"),
@@ -272,7 +272,7 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
     6: .standard(proto: "list_value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -341,7 +341,7 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -383,13 +383,13 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
   }
 }
 
-extension Google_Protobuf_ListValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ListValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ListValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "values"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -401,7 +401,7 @@ extension Google_Protobuf_ListValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.values.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/timestamp.pb.swift
+++ b/Reference/google/protobuf/timestamp.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -154,7 +154,7 @@ struct Google_Protobuf_Timestamp {
   /// inclusive.
   var nanos: Int32 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -167,14 +167,14 @@ extension Google_Protobuf_Timestamp: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Timestamp: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Timestamp: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Timestamp"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "seconds"),
     2: .same(proto: "nanos"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -187,7 +187,7 @@ extension Google_Protobuf_Timestamp: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.seconds != 0 {
       try visitor.visitSingularInt64Field(value: self.seconds, fieldNumber: 1)
     }

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -44,13 +44,13 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
 /// The syntax in which a protocol buffer element is defined.
-enum Google_Protobuf_Syntax: SwiftProtobufCore.Enum {
+enum Google_Protobuf_Syntax: Enum {
   typealias RawValue = Int
 
   /// Syntax `proto2`.
@@ -119,7 +119,7 @@ struct Google_Protobuf_Type {
   /// The source syntax.
   var syntax: Google_Protobuf_Syntax = .proto2
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -164,10 +164,10 @@ struct Google_Protobuf_Field {
   /// The string value of the default value of this field. Proto2 syntax only.
   var defaultValue: String = String()
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   /// Basic field types.
-  enum Kind: SwiftProtobufCore.Enum {
+  enum Kind: Enum {
     typealias RawValue = Int
 
     /// Field type unknown.
@@ -308,7 +308,7 @@ struct Google_Protobuf_Field {
   }
 
   /// Whether a field is optional, required, or repeated.
-  enum Cardinality: SwiftProtobufCore.Enum {
+  enum Cardinality: Enum {
     typealias RawValue = Int
 
     /// For fields with unknown cardinality.
@@ -389,7 +389,7 @@ struct Google_Protobuf_Enum {
   /// The source syntax.
   var syntax: Google_Protobuf_Syntax = .proto2
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -411,7 +411,7 @@ struct Google_Protobuf_EnumValue {
   /// Protocol buffer options.
   var options: [Google_Protobuf_Option] = []
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -442,7 +442,7 @@ struct Google_Protobuf_Option {
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
   mutating func clearValue() {self._value = nil}
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 
@@ -461,16 +461,16 @@ extension Google_Protobuf_Option: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Syntax: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Syntax: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "SYNTAX_PROTO2"),
     1: .same(proto: "SYNTAX_PROTO3"),
   ]
 }
 
-extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Type: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Type"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "fields"),
     3: .same(proto: "oneofs"),
@@ -479,7 +479,7 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     6: .same(proto: "syntax"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -496,7 +496,7 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -534,9 +534,9 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
   }
 }
 
-extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Field: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Field"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "kind"),
     2: .same(proto: "cardinality"),
     3: .same(proto: "number"),
@@ -549,7 +549,7 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
     11: .standard(proto: "default_value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -570,7 +570,7 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.kind != .typeUnknown {
       try visitor.visitSingularEnumField(value: self.kind, fieldNumber: 1)
     }
@@ -620,8 +620,8 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
   }
 }
 
-extension Google_Protobuf_Field.Kind: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Field.Kind: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "TYPE_UNKNOWN"),
     1: .same(proto: "TYPE_DOUBLE"),
     2: .same(proto: "TYPE_FLOAT"),
@@ -644,8 +644,8 @@ extension Google_Protobuf_Field.Kind: SwiftProtobufCore._ProtoNameProviding {
   ]
 }
 
-extension Google_Protobuf_Field.Cardinality: SwiftProtobufCore._ProtoNameProviding {
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Field.Cardinality: _ProtoNameProviding {
+  static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "CARDINALITY_UNKNOWN"),
     1: .same(proto: "CARDINALITY_OPTIONAL"),
     2: .same(proto: "CARDINALITY_REQUIRED"),
@@ -653,9 +653,9 @@ extension Google_Protobuf_Field.Cardinality: SwiftProtobufCore._ProtoNameProvidi
   ]
 }
 
-extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Enum: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Enum"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "enumvalue"),
     3: .same(proto: "options"),
@@ -663,7 +663,7 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     5: .same(proto: "syntax"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -679,7 +679,7 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -713,15 +713,15 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
   }
 }
 
-extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EnumValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "number"),
     3: .same(proto: "options"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -735,7 +735,7 @@ extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -757,14 +757,14 @@ extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCor
   }
 }
 
-extension Google_Protobuf_Option: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Option: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Option"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -777,7 +777,7 @@ extension Google_Protobuf_Option: SwiftProtobufCore.Message, SwiftProtobufCore._
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -54,8 +54,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -70,7 +70,7 @@ struct Google_Protobuf_DoubleValue {
   /// The double value.
   var value: Double = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -86,7 +86,7 @@ struct Google_Protobuf_FloatValue {
   /// The float value.
   var value: Float = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -102,7 +102,7 @@ struct Google_Protobuf_Int64Value {
   /// The int64 value.
   var value: Int64 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -118,7 +118,7 @@ struct Google_Protobuf_UInt64Value {
   /// The uint64 value.
   var value: UInt64 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -134,7 +134,7 @@ struct Google_Protobuf_Int32Value {
   /// The int32 value.
   var value: Int32 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -150,7 +150,7 @@ struct Google_Protobuf_UInt32Value {
   /// The uint32 value.
   var value: UInt32 = 0
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -166,7 +166,7 @@ struct Google_Protobuf_BoolValue {
   /// The bool value.
   var value: Bool = false
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -182,7 +182,7 @@ struct Google_Protobuf_StringValue {
   /// The string value.
   var value: String = String()
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -198,7 +198,7 @@ struct Google_Protobuf_BytesValue {
   /// The bytes value.
   var value: Data = Data()
 
-  var unknownFields = SwiftProtobufCore.UnknownStorage()
+  var unknownFields = UnknownStorage()
 
   init() {}
 }
@@ -219,13 +219,13 @@ extension Google_Protobuf_BytesValue: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DoubleValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -237,7 +237,7 @@ extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 1)
     }
@@ -251,13 +251,13 @@ extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FloatValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -269,7 +269,7 @@ extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularFloatField(value: self.value, fieldNumber: 1)
     }
@@ -283,13 +283,13 @@ extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Int64Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Int64Value"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -301,7 +301,7 @@ extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularInt64Field(value: self.value, fieldNumber: 1)
     }
@@ -315,13 +315,13 @@ extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UInt64Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UInt64Value"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -333,7 +333,7 @@ extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularUInt64Field(value: self.value, fieldNumber: 1)
     }
@@ -347,13 +347,13 @@ extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Int32Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Int32Value"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -365,7 +365,7 @@ extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularInt32Field(value: self.value, fieldNumber: 1)
     }
@@ -379,13 +379,13 @@ extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UInt32Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UInt32Value"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -397,7 +397,7 @@ extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularUInt32Field(value: self.value, fieldNumber: 1)
     }
@@ -411,13 +411,13 @@ extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_BoolValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BoolValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -429,7 +429,7 @@ extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != false {
       try visitor.visitSingularBoolField(value: self.value, fieldNumber: 1)
     }
@@ -443,13 +443,13 @@ extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCor
   }
 }
 
-extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_StringValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".StringValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -461,7 +461,7 @@ extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.value.isEmpty {
       try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
     }
@@ -475,13 +475,13 @@ extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_BytesValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_BytesValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".BytesValue"
-  static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -493,7 +493,7 @@ extension Google_Protobuf_BytesValue: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.value.isEmpty {
       try visitor.visitSingularBytesField(value: self.value, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/any.pb.swift
+++ b/Sources/SwiftProtobufCore/any.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -173,7 +173,7 @@ public struct Google_Protobuf_Any {
     set {_uniqueStorage()._value = newValue}
   }
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -188,9 +188,9 @@ extension Google_Protobuf_Any: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Any"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "type_url"),
     2: .same(proto: "value"),
   ]
@@ -204,7 +204,7 @@ extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     return _storage
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -220,7 +220,7 @@ extension Google_Protobuf_Any: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       try _storage.preTraverse()
       if !_storage._typeURL.isEmpty {

--- a/Sources/SwiftProtobufCore/api.pb.swift
+++ b/Sources/SwiftProtobufCore/api.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -111,7 +111,7 @@ public struct Google_Protobuf_Api {
   /// The source syntax of the service.
   public var syntax: Google_Protobuf_Syntax = .proto2
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -145,7 +145,7 @@ public struct Google_Protobuf_Method {
   /// The source syntax of this method.
   public var syntax: Google_Protobuf_Syntax = .proto2
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -240,7 +240,7 @@ public struct Google_Protobuf_Mixin {
   /// are rooted.
   public var root: String = String()
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -255,9 +255,9 @@ extension Google_Protobuf_Mixin: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Api: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Api"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "methods"),
     3: .same(proto: "options"),
@@ -267,7 +267,7 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     7: .same(proto: "syntax"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -285,7 +285,7 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -327,9 +327,9 @@ extension Google_Protobuf_Api: SwiftProtobufCore.Message, SwiftProtobufCore._Mes
   }
 }
 
-extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Method: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Method"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .standard(proto: "request_type_url"),
     3: .standard(proto: "request_streaming"),
@@ -339,7 +339,7 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
     7: .same(proto: "syntax"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -357,7 +357,7 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -395,14 +395,14 @@ extension Google_Protobuf_Method: SwiftProtobufCore.Message, SwiftProtobufCore._
   }
 }
 
-extension Google_Protobuf_Mixin: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Mixin: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Mixin"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "root"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -415,7 +415,7 @@ extension Google_Protobuf_Mixin: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/descriptor.pb.swift
+++ b/Sources/SwiftProtobufCore/descriptor.pb.swift
@@ -52,8 +52,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -66,7 +66,7 @@ public struct Google_Protobuf_FileDescriptorSet {
 
   public var file: [Google_Protobuf_FileDescriptorProto] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -161,7 +161,7 @@ public struct Google_Protobuf_FileDescriptorProto {
   /// Clears the value of `edition`. Subsequent reads from it will return its default value.
   public mutating func clearEdition() {self._edition = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -215,7 +215,7 @@ public struct Google_Protobuf_DescriptorProto {
   /// A given name may only be reserved once.
   public var reservedName: [String] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public struct ExtensionRange {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -251,7 +251,7 @@ public struct Google_Protobuf_DescriptorProto {
     /// Clears the value of `options`. Subsequent reads from it will return its default value.
     public mutating func clearOptions() {self._options = nil}
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     public init() {}
 
@@ -288,7 +288,7 @@ public struct Google_Protobuf_DescriptorProto {
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
     public mutating func clearEnd() {self._end = nil}
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     public init() {}
 
@@ -302,7 +302,7 @@ public struct Google_Protobuf_DescriptorProto {
   fileprivate var _options: Google_Protobuf_MessageOptions? = nil
 }
 
-public struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_ExtensionRangeOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -310,11 +310,11 @@ public struct Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Extensibl
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
 }
 
 /// Describes a field within a message.
@@ -462,9 +462,9 @@ public struct Google_Protobuf_FieldDescriptorProto {
   /// Clears the value of `proto3Optional`. Subsequent reads from it will return its default value.
   public mutating func clearProto3Optional() {_uniqueStorage()._proto3Optional = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
-  public enum TypeEnum: SwiftProtobufCore.Enum {
+  public enum TypeEnum: Enum {
     public typealias RawValue = Int
 
     /// 0 is reserved for errors.
@@ -560,7 +560,7 @@ public struct Google_Protobuf_FieldDescriptorProto {
 
   }
 
-  public enum Label: SwiftProtobufCore.Enum {
+  public enum Label: Enum {
     public typealias RawValue = Int
 
     /// 0 is reserved for errors
@@ -620,7 +620,7 @@ public struct Google_Protobuf_OneofDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   public mutating func clearOptions() {self._options = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -663,7 +663,7 @@ public struct Google_Protobuf_EnumDescriptorProto {
   /// be reserved once.
   public var reservedName: [String] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// Range of reserved numeric values. Reserved values may not be used by
   /// entries in the same enum. Reserved ranges may not overlap.
@@ -696,7 +696,7 @@ public struct Google_Protobuf_EnumDescriptorProto {
     /// Clears the value of `end`. Subsequent reads from it will return its default value.
     public mutating func clearEnd() {self._end = nil}
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     public init() {}
 
@@ -743,7 +743,7 @@ public struct Google_Protobuf_EnumValueDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   public mutating func clearOptions() {self._options = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -778,7 +778,7 @@ public struct Google_Protobuf_ServiceDescriptorProto {
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
   public mutating func clearOptions() {self._options = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -850,7 +850,7 @@ public struct Google_Protobuf_MethodDescriptorProto {
   /// Clears the value of `serverStreaming`. Subsequent reads from it will return its default value.
   public mutating func clearServerStreaming() {self._serverStreaming = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -862,7 +862,7 @@ public struct Google_Protobuf_MethodDescriptorProto {
   fileprivate var _serverStreaming: Bool? = nil
 }
 
-public struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_FileOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1115,10 +1115,10 @@ public struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
     set {_uniqueStorage()._uninterpretedOption = newValue}
   }
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  public enum OptimizeMode: SwiftProtobufCore.Enum {
+  public enum OptimizeMode: Enum {
     public typealias RawValue = Int
 
     /// Generate complete code for parsing, serialization,
@@ -1155,11 +1155,11 @@ public struct Google_Protobuf_FileOptions: SwiftProtobufCore.ExtensibleMessage {
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct Google_Protobuf_MessageOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_MessageOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1249,18 +1249,18 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobufCore.ExtensibleMessag
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _messageSetWireFormat: Bool? = nil
   fileprivate var _noStandardDescriptorAccessor: Bool? = nil
   fileprivate var _deprecated: Bool? = nil
   fileprivate var _mapEntry: Bool? = nil
 }
 
-public struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_FieldOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1389,9 +1389,9 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage 
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
-  public enum CType: SwiftProtobufCore.Enum {
+  public enum CType: Enum {
     public typealias RawValue = Int
 
     /// Default mode.
@@ -1422,7 +1422,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage 
 
   }
 
-  public enum JSType: SwiftProtobufCore.Enum {
+  public enum JSType: Enum {
     public typealias RawValue = Int
 
     /// Use the default type.
@@ -1459,7 +1459,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage 
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _ctype: Google_Protobuf_FieldOptions.CType? = nil
   fileprivate var _packed: Bool? = nil
   fileprivate var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
@@ -1469,7 +1469,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobufCore.ExtensibleMessage 
   fileprivate var _weak: Bool? = nil
 }
 
-public struct Google_Protobuf_OneofOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_OneofOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1477,14 +1477,14 @@ public struct Google_Protobuf_OneofOptions: SwiftProtobufCore.ExtensibleMessage 
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
 }
 
-public struct Google_Protobuf_EnumOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_EnumOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1516,16 +1516,16 @@ public struct Google_Protobuf_EnumOptions: SwiftProtobufCore.ExtensibleMessage {
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _allowAlias: Bool? = nil
   fileprivate var _deprecated: Bool? = nil
 }
 
-public struct Google_Protobuf_EnumValueOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_EnumValueOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1546,15 +1546,15 @@ public struct Google_Protobuf_EnumValueOptions: SwiftProtobufCore.ExtensibleMess
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
 }
 
-public struct Google_Protobuf_ServiceOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_ServiceOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1575,15 +1575,15 @@ public struct Google_Protobuf_ServiceOptions: SwiftProtobufCore.ExtensibleMessag
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
 }
 
-public struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage {
+public struct Google_Protobuf_MethodOptions: ExtensibleMessage {
   // SwiftProtobufCore.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1613,12 +1613,12 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage
   /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  public enum IdempotencyLevel: SwiftProtobufCore.Enum {
+  public enum IdempotencyLevel: Enum {
     public typealias RawValue = Int
     case idempotencyUnknown // = 0
 
@@ -1653,7 +1653,7 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobufCore.ExtensibleMessage
 
   public init() {}
 
-  public var _protobuf_extensionFieldValues = SwiftProtobufCore.ExtensionFieldValueSet()
+  public var _protobuf_extensionFieldValues = ExtensionFieldValueSet()
   fileprivate var _deprecated: Bool? = nil
   fileprivate var _idempotencyLevel: Google_Protobuf_MethodOptions.IdempotencyLevel? = nil
 }
@@ -1727,7 +1727,7 @@ public struct Google_Protobuf_UninterpretedOption {
   /// Clears the value of `aggregateValue`. Subsequent reads from it will return its default value.
   public mutating func clearAggregateValue() {self._aggregateValue = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// The name of the uninterpreted option.  Each string represents a segment in
   /// a dot-separated name.  is_extension is true iff a segment represents an
@@ -1757,7 +1757,7 @@ public struct Google_Protobuf_UninterpretedOption {
     /// Clears the value of `isExtension`. Subsequent reads from it will return its default value.
     public mutating func clearIsExtension() {self._isExtension = nil}
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     public init() {}
 
@@ -1827,7 +1827,7 @@ public struct Google_Protobuf_SourceCodeInfo {
   ///   be recorded in the future.
   public var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public struct Location {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -1933,7 +1933,7 @@ public struct Google_Protobuf_SourceCodeInfo {
 
     public var leadingDetachedComments: [String] = []
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     public init() {}
 
@@ -1956,7 +1956,7 @@ public struct Google_Protobuf_GeneratedCodeInfo {
   /// of its generating .proto file.
   public var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public struct Annotation {
     // SwiftProtobufCore.Message conformance is added in an extension below. See the
@@ -2009,11 +2009,11 @@ public struct Google_Protobuf_GeneratedCodeInfo {
     /// Clears the value of `semantic`. Subsequent reads from it will return its default value.
     public mutating func clearSemantic() {self._semantic = nil}
 
-    public var unknownFields = SwiftProtobufCore.UnknownStorage()
+    public var unknownFields = UnknownStorage()
 
     /// Represents the identified object's effect on the element in the original
     /// .proto file.
-    public enum Semantic: SwiftProtobufCore.Enum {
+    public enum Semantic: Enum {
       public typealias RawValue = Int
 
       /// There is no effect or the effect is indescribable.
@@ -2093,18 +2093,18 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileDescriptorSet: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "file"),
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.file) {return false}
+    if !Internal.areAllInitialized(self.file) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2116,7 +2116,7 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.file.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.file, fieldNumber: 1)
     }
@@ -2130,9 +2130,9 @@ extension Google_Protobuf_FileDescriptorSet: SwiftProtobufCore.Message, SwiftPro
   }
 }
 
-extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "package"),
     3: .same(proto: "dependency"),
@@ -2149,15 +2149,15 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.messageType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.enumType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.service) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.`extension`) {return false}
+    if !Internal.areAllInitialized(self.messageType) {return false}
+    if !Internal.areAllInitialized(self.enumType) {return false}
+    if !Internal.areAllInitialized(self.service) {return false}
+    if !Internal.areAllInitialized(self.`extension`) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2181,7 +2181,7 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2247,9 +2247,9 @@ extension Google_Protobuf_FileDescriptorProto: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "field"),
     6: .same(proto: "extension"),
@@ -2263,17 +2263,17 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.field) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.`extension`) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.nestedType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.enumType) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.extensionRange) {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.oneofDecl) {return false}
+    if !Internal.areAllInitialized(self.field) {return false}
+    if !Internal.areAllInitialized(self.`extension`) {return false}
+    if !Internal.areAllInitialized(self.nestedType) {return false}
+    if !Internal.areAllInitialized(self.enumType) {return false}
+    if !Internal.areAllInitialized(self.extensionRange) {return false}
+    if !Internal.areAllInitialized(self.oneofDecl) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2294,7 +2294,7 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2348,9 +2348,9 @@ extension Google_Protobuf_DescriptorProto: SwiftProtobufCore.Message, SwiftProto
   }
 }
 
-extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto.ExtensionRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ExtensionRange"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
     3: .same(proto: "options"),
@@ -2361,7 +2361,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2375,7 +2375,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2401,14 +2401,14 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: SwiftProtobufCore.Mess
   }
 }
 
-extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DescriptorProto.ReservedRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2421,7 +2421,7 @@ extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Messa
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2443,19 +2443,19 @@ extension Google_Protobuf_DescriptorProto.ReservedRange: SwiftProtobufCore.Messa
   }
 }
 
-extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ExtensionRangeOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ExtensionRangeOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2469,7 +2469,7 @@ extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, Swif
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.uninterpretedOption.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.uninterpretedOption, fieldNumber: 999)
     }
@@ -2485,9 +2485,9 @@ extension Google_Protobuf_ExtensionRangeOptions: SwiftProtobufCore.Message, Swif
   }
 }
 
-extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     3: .same(proto: "number"),
     4: .same(proto: "label"),
@@ -2547,7 +2547,7 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -2572,7 +2572,7 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every if/case branch local when no optimizations
@@ -2640,8 +2640,8 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobufCore.Message, Swift
   }
 }
 
-extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldDescriptorProto.TypeEnum: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "TYPE_DOUBLE"),
     2: .same(proto: "TYPE_FLOAT"),
     3: .same(proto: "TYPE_INT64"),
@@ -2663,17 +2663,17 @@ extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobufCore._Prot
   ]
 }
 
-extension Google_Protobuf_FieldDescriptorProto.Label: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldDescriptorProto.Label: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "LABEL_OPTIONAL"),
     2: .same(proto: "LABEL_REQUIRED"),
     3: .same(proto: "LABEL_REPEATED"),
   ]
 }
 
-extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_OneofDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "options"),
   ]
@@ -2683,7 +2683,7 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2696,7 +2696,7 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2718,9 +2718,9 @@ extension Google_Protobuf_OneofDescriptorProto: SwiftProtobufCore.Message, Swift
   }
 }
 
-extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "value"),
     3: .same(proto: "options"),
@@ -2729,12 +2729,12 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.value) {return false}
+    if !Internal.areAllInitialized(self.value) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2750,7 +2750,7 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2784,14 +2784,14 @@ extension Google_Protobuf_EnumDescriptorProto: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_EnumDescriptorProto.protoMessageName + ".EnumReservedRange"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "start"),
     2: .same(proto: "end"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2804,7 +2804,7 @@ extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCo
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2826,9 +2826,9 @@ extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValueDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "number"),
     3: .same(proto: "options"),
@@ -2839,7 +2839,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2853,7 +2853,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2879,21 +2879,21 @@ extension Google_Protobuf_EnumValueDescriptorProto: SwiftProtobufCore.Message, S
   }
 }
 
-extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ServiceDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "method"),
     3: .same(proto: "options"),
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.method) {return false}
+    if !Internal.areAllInitialized(self.method) {return false}
     if let v = self._options, !v.isInitialized {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2907,7 +2907,7 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, Swi
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2933,9 +2933,9 @@ extension Google_Protobuf_ServiceDescriptorProto: SwiftProtobufCore.Message, Swi
   }
 }
 
-extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MethodDescriptorProto: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .standard(proto: "input_type"),
     3: .standard(proto: "output_type"),
@@ -2949,7 +2949,7 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2966,7 +2966,7 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3004,9 +3004,9 @@ extension Google_Protobuf_MethodDescriptorProto: SwiftProtobufCore.Message, Swif
   }
 }
 
-extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FileOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "java_package"),
     8: .standard(proto: "java_outer_classname"),
     10: .standard(proto: "java_multiple_files"),
@@ -3092,12 +3092,12 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
     return withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if !SwiftProtobufCore.Internal.areAllInitialized(_storage._uninterpretedOption) {return false}
+      if !Internal.areAllInitialized(_storage._uninterpretedOption) {return false}
       return true
     }
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     _ = _uniqueStorage()
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3134,7 +3134,7 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every if/case branch local when no optimizations
@@ -3244,17 +3244,17 @@ extension Google_Protobuf_FileOptions: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_FileOptions.OptimizeMode: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FileOptions.OptimizeMode: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "SPEED"),
     2: .same(proto: "CODE_SIZE"),
     3: .same(proto: "LITE_RUNTIME"),
   ]
 }
 
-extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MessageOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MessageOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "message_set_wire_format"),
     2: .standard(proto: "no_standard_descriptor_accessor"),
     3: .same(proto: "deprecated"),
@@ -3264,11 +3264,11 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3286,7 +3286,7 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3322,9 +3322,9 @@ extension Google_Protobuf_MessageOptions: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FieldOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "ctype"),
     2: .same(proto: "packed"),
     6: .same(proto: "jstype"),
@@ -3337,11 +3337,11 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3362,7 +3362,7 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3410,35 +3410,35 @@ extension Google_Protobuf_FieldOptions: SwiftProtobufCore.Message, SwiftProtobuf
   }
 }
 
-extension Google_Protobuf_FieldOptions.CType: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldOptions.CType: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "STRING"),
     1: .same(proto: "CORD"),
     2: .same(proto: "STRING_PIECE"),
   ]
 }
 
-extension Google_Protobuf_FieldOptions.JSType: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_FieldOptions.JSType: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "JS_NORMAL"),
     1: .same(proto: "JS_STRING"),
     2: .same(proto: "JS_NUMBER"),
   ]
 }
 
-extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_OneofOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".OneofOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3452,7 +3452,7 @@ extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobuf
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.uninterpretedOption.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.uninterpretedOption, fieldNumber: 999)
     }
@@ -3468,9 +3468,9 @@ extension Google_Protobuf_OneofOptions: SwiftProtobufCore.Message, SwiftProtobuf
   }
 }
 
-extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     2: .standard(proto: "allow_alias"),
     3: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
@@ -3478,11 +3478,11 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3498,7 +3498,7 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3526,20 +3526,20 @@ extension Google_Protobuf_EnumOptions: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValueOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3554,7 +3554,7 @@ extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProt
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3578,20 +3578,20 @@ extension Google_Protobuf_EnumValueOptions: SwiftProtobufCore.Message, SwiftProt
   }
 }
 
-extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ServiceOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     33: .same(proto: "deprecated"),
     999: .standard(proto: "uninterpreted_option"),
   ]
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3606,7 +3606,7 @@ extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3630,9 +3630,9 @@ extension Google_Protobuf_ServiceOptions: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_MethodOptions: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".MethodOptions"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     33: .same(proto: "deprecated"),
     34: .standard(proto: "idempotency_level"),
     999: .standard(proto: "uninterpreted_option"),
@@ -3640,11 +3640,11 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
 
   public var isInitialized: Bool {
     if !_protobuf_extensionFieldValues.isInitialized {return false}
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.uninterpretedOption) {return false}
+    if !Internal.areAllInitialized(self.uninterpretedOption) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3660,7 +3660,7 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3688,17 +3688,17 @@ extension Google_Protobuf_MethodOptions: SwiftProtobufCore.Message, SwiftProtobu
   }
 }
 
-extension Google_Protobuf_MethodOptions.IdempotencyLevel: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_MethodOptions.IdempotencyLevel: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
     1: .same(proto: "NO_SIDE_EFFECTS"),
     2: .same(proto: "IDEMPOTENT"),
   ]
 }
 
-extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UninterpretedOption: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     2: .same(proto: "name"),
     3: .standard(proto: "identifier_value"),
     4: .standard(proto: "positive_int_value"),
@@ -3709,11 +3709,11 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
   ]
 
   public var isInitialized: Bool {
-    if !SwiftProtobufCore.Internal.areAllInitialized(self.name) {return false}
+    if !Internal.areAllInitialized(self.name) {return false}
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3731,7 +3731,7 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3773,9 +3773,9 @@ extension Google_Protobuf_UninterpretedOption: SwiftProtobufCore.Message, SwiftP
   }
 }
 
-extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UninterpretedOption.NamePart: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "name_part"),
     2: .standard(proto: "is_extension"),
   ]
@@ -3786,7 +3786,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
     return true
   }
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3799,7 +3799,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3821,13 +3821,13 @@ extension Google_Protobuf_UninterpretedOption.NamePart: SwiftProtobufCore.Messag
   }
 }
 
-extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceCodeInfo: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "location"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3839,7 +3839,7 @@ extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtob
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.location.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.location, fieldNumber: 1)
     }
@@ -3853,9 +3853,9 @@ extension Google_Protobuf_SourceCodeInfo: SwiftProtobufCore.Message, SwiftProtob
   }
 }
 
-extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceCodeInfo.Location: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "path"),
     2: .same(proto: "span"),
     3: .standard(proto: "leading_comments"),
@@ -3863,7 +3863,7 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
     6: .standard(proto: "leading_detached_comments"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3879,7 +3879,7 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -3913,13 +3913,13 @@ extension Google_Protobuf_SourceCodeInfo.Location: SwiftProtobufCore.Message, Sw
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_GeneratedCodeInfo: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "annotation"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3931,7 +3931,7 @@ extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.annotation.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.annotation, fieldNumber: 1)
     }
@@ -3945,9 +3945,9 @@ extension Google_Protobuf_GeneratedCodeInfo: SwiftProtobufCore.Message, SwiftPro
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_GeneratedCodeInfo.Annotation: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "path"),
     2: .standard(proto: "source_file"),
     3: .same(proto: "begin"),
@@ -3955,7 +3955,7 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
     5: .same(proto: "semantic"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -3971,7 +3971,7 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -4005,8 +4005,8 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: SwiftProtobufCore.Messag
   }
 }
 
-extension Google_Protobuf_GeneratedCodeInfo.Annotation.Semantic: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_GeneratedCodeInfo.Annotation.Semantic: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "NONE"),
     1: .same(proto: "SET"),
     2: .same(proto: "ALIAS"),

--- a/Sources/SwiftProtobufCore/duration.pb.swift
+++ b/Sources/SwiftProtobufCore/duration.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -125,7 +125,7 @@ public struct Google_Protobuf_Duration {
   /// to +999,999,999 inclusive.
   public var nanos: Int32 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -138,14 +138,14 @@ extension Google_Protobuf_Duration: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Duration: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Duration: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Duration"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "seconds"),
     2: .same(proto: "nanos"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -158,7 +158,7 @@ extension Google_Protobuf_Duration: SwiftProtobufCore.Message, SwiftProtobufCore
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.seconds != 0 {
       try visitor.visitSingularInt64Field(value: self.seconds, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/empty.pb.swift
+++ b/Sources/SwiftProtobufCore/empty.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -61,7 +61,7 @@ public struct Google_Protobuf_Empty {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -74,16 +74,16 @@ extension Google_Protobuf_Empty: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Empty: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Empty: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Empty"
-  public static let _protobuf_nameMap = SwiftProtobufCore._NameMap()
+  public static let _protobuf_nameMap = _NameMap()
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let _ = try decoder.nextFieldNumber() {
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Sources/SwiftProtobufCore/field_mask.pb.swift
+++ b/Sources/SwiftProtobufCore/field_mask.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -256,7 +256,7 @@ public struct Google_Protobuf_FieldMask {
   /// The set of field mask paths.
   public var paths: [String] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -269,13 +269,13 @@ extension Google_Protobuf_FieldMask: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_FieldMask: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FieldMask: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FieldMask"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "paths"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -287,7 +287,7 @@ extension Google_Protobuf_FieldMask: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.paths.isEmpty {
       try visitor.visitRepeatedStringField(value: self.paths, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/source_context.pb.swift
+++ b/Sources/SwiftProtobufCore/source_context.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -60,7 +60,7 @@ public struct Google_Protobuf_SourceContext {
   /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
   public var fileName: String = String()
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -73,13 +73,13 @@ extension Google_Protobuf_SourceContext: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_SourceContext: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_SourceContext: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SourceContext"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "file_name"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -91,7 +91,7 @@ extension Google_Protobuf_SourceContext: SwiftProtobufCore.Message, SwiftProtobu
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.fileName.isEmpty {
       try visitor.visitSingularStringField(value: self.fileName, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/struct.pb.swift
+++ b/Sources/SwiftProtobufCore/struct.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -53,7 +53,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.Protob
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-public enum Google_Protobuf_NullValue: SwiftProtobufCore.Enum {
+public enum Google_Protobuf_NullValue: Enum {
   public typealias RawValue = Int
 
   /// Null value.
@@ -101,7 +101,7 @@ public struct Google_Protobuf_Struct {
   /// Unordered map of dynamically typed values.
   public var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -174,7 +174,7 @@ public struct Google_Protobuf_Value {
     set {kind = .listValue(newValue)}
   }
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// The kind of value.
   public enum OneOf_Kind: Equatable {
@@ -207,7 +207,7 @@ public struct Google_Protobuf_ListValue {
   /// Repeated field of dynamically typed values.
   public var values: [Google_Protobuf_Value] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -223,33 +223,33 @@ extension Google_Protobuf_ListValue: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_NullValue: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_NullValue: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "NULL_VALUE"),
   ]
 }
 
-extension Google_Protobuf_Struct: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Struct: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Struct"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "fields"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeMapField(fieldType: SwiftProtobufCore._ProtobufMessageMap<SwiftProtobufCore.ProtobufString,Google_Protobuf_Value>.self, value: &self.fields) }()
+      case 1: try { try decoder.decodeMapField(fieldType: _ProtobufMessageMap<ProtobufString,Google_Protobuf_Value>.self, value: &self.fields) }()
       default: break
       }
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.fields.isEmpty {
-      try visitor.visitMapField(fieldType: SwiftProtobufCore._ProtobufMessageMap<SwiftProtobufCore.ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
+      try visitor.visitMapField(fieldType: _ProtobufMessageMap<ProtobufString,Google_Protobuf_Value>.self, value: self.fields, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -261,9 +261,9 @@ extension Google_Protobuf_Struct: SwiftProtobufCore.Message, SwiftProtobufCore._
   }
 }
 
-extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Value"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .standard(proto: "null_value"),
     2: .standard(proto: "number_value"),
     3: .standard(proto: "string_value"),
@@ -272,7 +272,7 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
     6: .standard(proto: "list_value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -341,7 +341,7 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -383,13 +383,13 @@ extension Google_Protobuf_Value: SwiftProtobufCore.Message, SwiftProtobufCore._M
   }
 }
 
-extension Google_Protobuf_ListValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_ListValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ListValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "values"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -401,7 +401,7 @@ extension Google_Protobuf_ListValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.values.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/timestamp.pb.swift
+++ b/Sources/SwiftProtobufCore/timestamp.pb.swift
@@ -44,8 +44,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -154,7 +154,7 @@ public struct Google_Protobuf_Timestamp {
   /// inclusive.
   public var nanos: Int32 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -167,14 +167,14 @@ extension Google_Protobuf_Timestamp: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Timestamp: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Timestamp: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Timestamp"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "seconds"),
     2: .same(proto: "nanos"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -187,7 +187,7 @@ extension Google_Protobuf_Timestamp: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.seconds != 0 {
       try visitor.visitSingularInt64Field(value: self.seconds, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufCore/type.pb.swift
+++ b/Sources/SwiftProtobufCore/type.pb.swift
@@ -44,13 +44,13 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
 /// The syntax in which a protocol buffer element is defined.
-public enum Google_Protobuf_Syntax: SwiftProtobufCore.Enum {
+public enum Google_Protobuf_Syntax: Enum {
   public typealias RawValue = Int
 
   /// Syntax `proto2`.
@@ -119,7 +119,7 @@ public struct Google_Protobuf_Type {
   /// The source syntax.
   public var syntax: Google_Protobuf_Syntax = .proto2
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -164,10 +164,10 @@ public struct Google_Protobuf_Field {
   /// The string value of the default value of this field. Proto2 syntax only.
   public var defaultValue: String = String()
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   /// Basic field types.
-  public enum Kind: SwiftProtobufCore.Enum {
+  public enum Kind: Enum {
     public typealias RawValue = Int
 
     /// Field type unknown.
@@ -308,7 +308,7 @@ public struct Google_Protobuf_Field {
   }
 
   /// Whether a field is optional, required, or repeated.
-  public enum Cardinality: SwiftProtobufCore.Enum {
+  public enum Cardinality: Enum {
     public typealias RawValue = Int
 
     /// For fields with unknown cardinality.
@@ -389,7 +389,7 @@ public struct Google_Protobuf_Enum {
   /// The source syntax.
   public var syntax: Google_Protobuf_Syntax = .proto2
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -411,7 +411,7 @@ public struct Google_Protobuf_EnumValue {
   /// Protocol buffer options.
   public var options: [Google_Protobuf_Option] = []
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -442,7 +442,7 @@ public struct Google_Protobuf_Option {
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
   public mutating func clearValue() {self._value = nil}
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 
@@ -461,16 +461,16 @@ extension Google_Protobuf_Option: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Syntax: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Syntax: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "SYNTAX_PROTO2"),
     1: .same(proto: "SYNTAX_PROTO3"),
   ]
 }
 
-extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Type: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Type"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "fields"),
     3: .same(proto: "oneofs"),
@@ -479,7 +479,7 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     6: .same(proto: "syntax"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -496,7 +496,7 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -534,9 +534,9 @@ extension Google_Protobuf_Type: SwiftProtobufCore.Message, SwiftProtobufCore._Me
   }
 }
 
-extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Field: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Field"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "kind"),
     2: .same(proto: "cardinality"),
     3: .same(proto: "number"),
@@ -549,7 +549,7 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
     11: .standard(proto: "default_value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -570,7 +570,7 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.kind != .typeUnknown {
       try visitor.visitSingularEnumField(value: self.kind, fieldNumber: 1)
     }
@@ -620,8 +620,8 @@ extension Google_Protobuf_Field: SwiftProtobufCore.Message, SwiftProtobufCore._M
   }
 }
 
-extension Google_Protobuf_Field.Kind: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Field.Kind: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "TYPE_UNKNOWN"),
     1: .same(proto: "TYPE_DOUBLE"),
     2: .same(proto: "TYPE_FLOAT"),
@@ -644,8 +644,8 @@ extension Google_Protobuf_Field.Kind: SwiftProtobufCore._ProtoNameProviding {
   ]
 }
 
-extension Google_Protobuf_Field.Cardinality: SwiftProtobufCore._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+extension Google_Protobuf_Field.Cardinality: _ProtoNameProviding {
+  public static let _protobuf_nameMap: _NameMap = [
     0: .same(proto: "CARDINALITY_UNKNOWN"),
     1: .same(proto: "CARDINALITY_OPTIONAL"),
     2: .same(proto: "CARDINALITY_REQUIRED"),
@@ -653,9 +653,9 @@ extension Google_Protobuf_Field.Cardinality: SwiftProtobufCore._ProtoNameProvidi
   ]
 }
 
-extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Enum: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Enum"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "enumvalue"),
     3: .same(proto: "options"),
@@ -663,7 +663,7 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     5: .same(proto: "syntax"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -679,7 +679,7 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -713,15 +713,15 @@ extension Google_Protobuf_Enum: SwiftProtobufCore.Message, SwiftProtobufCore._Me
   }
 }
 
-extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_EnumValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnumValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "number"),
     3: .same(proto: "options"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -735,7 +735,7 @@ extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -757,14 +757,14 @@ extension Google_Protobuf_EnumValue: SwiftProtobufCore.Message, SwiftProtobufCor
   }
 }
 
-extension Google_Protobuf_Option: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Option: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Option"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -777,7 +777,7 @@ extension Google_Protobuf_Option: SwiftProtobufCore.Message, SwiftProtobufCore._
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and

--- a/Sources/SwiftProtobufCore/wrappers.pb.swift
+++ b/Sources/SwiftProtobufCore/wrappers.pb.swift
@@ -54,8 +54,8 @@ import Foundation
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobufCore.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobufCore.ProtobufAPIVersion_3 {}
+fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
+  struct _3: ProtobufAPIVersion_3 {}
   typealias Version = _3
 }
 
@@ -70,7 +70,7 @@ public struct Google_Protobuf_DoubleValue {
   /// The double value.
   public var value: Double = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -86,7 +86,7 @@ public struct Google_Protobuf_FloatValue {
   /// The float value.
   public var value: Float = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -102,7 +102,7 @@ public struct Google_Protobuf_Int64Value {
   /// The int64 value.
   public var value: Int64 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -118,7 +118,7 @@ public struct Google_Protobuf_UInt64Value {
   /// The uint64 value.
   public var value: UInt64 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -134,7 +134,7 @@ public struct Google_Protobuf_Int32Value {
   /// The int32 value.
   public var value: Int32 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -150,7 +150,7 @@ public struct Google_Protobuf_UInt32Value {
   /// The uint32 value.
   public var value: UInt32 = 0
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -166,7 +166,7 @@ public struct Google_Protobuf_BoolValue {
   /// The bool value.
   public var value: Bool = false
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -182,7 +182,7 @@ public struct Google_Protobuf_StringValue {
   /// The string value.
   public var value: String = String()
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -198,7 +198,7 @@ public struct Google_Protobuf_BytesValue {
   /// The bytes value.
   public var value: Data = Data()
 
-  public var unknownFields = SwiftProtobufCore.UnknownStorage()
+  public var unknownFields = UnknownStorage()
 
   public init() {}
 }
@@ -219,13 +219,13 @@ extension Google_Protobuf_BytesValue: @unchecked Sendable {}
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".DoubleValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -237,7 +237,7 @@ extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 1)
     }
@@ -251,13 +251,13 @@ extension Google_Protobuf_DoubleValue: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FloatValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -269,7 +269,7 @@ extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularFloatField(value: self.value, fieldNumber: 1)
     }
@@ -283,13 +283,13 @@ extension Google_Protobuf_FloatValue: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Int64Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Int64Value"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -301,7 +301,7 @@ extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularInt64Field(value: self.value, fieldNumber: 1)
     }
@@ -315,13 +315,13 @@ extension Google_Protobuf_Int64Value: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UInt64Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UInt64Value"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -333,7 +333,7 @@ extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularUInt64Field(value: self.value, fieldNumber: 1)
     }
@@ -347,13 +347,13 @@ extension Google_Protobuf_UInt64Value: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_Int32Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Int32Value"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -365,7 +365,7 @@ extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularInt32Field(value: self.value, fieldNumber: 1)
     }
@@ -379,13 +379,13 @@ extension Google_Protobuf_Int32Value: SwiftProtobufCore.Message, SwiftProtobufCo
   }
 }
 
-extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_UInt32Value: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".UInt32Value"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -397,7 +397,7 @@ extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != 0 {
       try visitor.visitSingularUInt32Field(value: self.value, fieldNumber: 1)
     }
@@ -411,13 +411,13 @@ extension Google_Protobuf_UInt32Value: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_BoolValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BoolValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -429,7 +429,7 @@ extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCor
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if self.value != false {
       try visitor.visitSingularBoolField(value: self.value, fieldNumber: 1)
     }
@@ -443,13 +443,13 @@ extension Google_Protobuf_BoolValue: SwiftProtobufCore.Message, SwiftProtobufCor
   }
 }
 
-extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_StringValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".StringValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -461,7 +461,7 @@ extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufC
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.value.isEmpty {
       try visitor.visitSingularStringField(value: self.value, fieldNumber: 1)
     }
@@ -475,13 +475,13 @@ extension Google_Protobuf_StringValue: SwiftProtobufCore.Message, SwiftProtobufC
   }
 }
 
-extension Google_Protobuf_BytesValue: SwiftProtobufCore.Message, SwiftProtobufCore._MessageImplementationBase, SwiftProtobufCore._ProtoNameProviding {
+extension Google_Protobuf_BytesValue: Message, _MessageImplementationBase, _ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".BytesValue"
-  public static let _protobuf_nameMap: SwiftProtobufCore._NameMap = [
+  public static let _protobuf_nameMap: _NameMap = [
     1: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobufCore.Decoder>(decoder: inout D) throws {
+  public mutating func decodeMessage<D: Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -493,7 +493,7 @@ extension Google_Protobuf_BytesValue: SwiftProtobufCore.Message, SwiftProtobufCo
     }
   }
 
-  public func traverse<V: SwiftProtobufCore.Visitor>(visitor: inout V) throws {
+  public func traverse<V: Visitor>(visitor: inout V) throws {
     if !self.value.isEmpty {
       try visitor.visitSingularBytesField(value: self.value, fieldNumber: 1)
     }

--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -22,6 +22,13 @@ public final class SwiftProtobufNamer {
 
   public var swiftProtobufModuleName: String { return mappings.swiftProtobufModuleName }
 
+  public var swiftProtobufModulePrefix: String {
+    guard targetModule != mappings.swiftProtobufModuleName else {
+      return ""
+    }
+    return "\(mappings.swiftProtobufModuleName)."
+  }
+
   /// Initializes a a new namer, assuming everything will be in the same Swift module.
   public convenience init() {
     self.init(protoFileToModuleMappings: ProtoFileToModuleMappings(), targetModule: "")

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -250,31 +250,31 @@ extension FieldDescriptor {
       let valueTraits = valueField.traitsType(namer: namer)
       switch valueField.type {
       case .message:  // Map's can't have a group as the value
-        return "\(namer.swiftProtobufModuleName)._ProtobufMessageMap<\(keyTraits),\(valueTraits)>"
+        return "\(namer.swiftProtobufModulePrefix)_ProtobufMessageMap<\(keyTraits),\(valueTraits)>"
       case .enum:
-        return "\(namer.swiftProtobufModuleName)._ProtobufEnumMap<\(keyTraits),\(valueTraits)>"
+        return "\(namer.swiftProtobufModulePrefix)_ProtobufEnumMap<\(keyTraits),\(valueTraits)>"
       default:
-        return "\(namer.swiftProtobufModuleName)._ProtobufMap<\(keyTraits),\(valueTraits)>"
+        return "\(namer.swiftProtobufModulePrefix)_ProtobufMap<\(keyTraits),\(valueTraits)>"
       }
     }
     switch type {
-    case .double: return "\(namer.swiftProtobufModuleName).ProtobufDouble"
-    case .float: return "\(namer.swiftProtobufModuleName).ProtobufFloat"
-    case .int64: return "\(namer.swiftProtobufModuleName).ProtobufInt64"
-    case .uint64: return "\(namer.swiftProtobufModuleName).ProtobufUInt64"
-    case .int32: return "\(namer.swiftProtobufModuleName).ProtobufInt32"
-    case .fixed64: return "\(namer.swiftProtobufModuleName).ProtobufFixed64"
-    case .fixed32: return "\(namer.swiftProtobufModuleName).ProtobufFixed32"
-    case .bool: return "\(namer.swiftProtobufModuleName).ProtobufBool"
-    case .string: return "\(namer.swiftProtobufModuleName).ProtobufString"
+    case .double: return "\(namer.swiftProtobufModulePrefix)ProtobufDouble"
+    case .float: return "\(namer.swiftProtobufModulePrefix)ProtobufFloat"
+    case .int64: return "\(namer.swiftProtobufModulePrefix)ProtobufInt64"
+    case .uint64: return "\(namer.swiftProtobufModulePrefix)ProtobufUInt64"
+    case .int32: return "\(namer.swiftProtobufModulePrefix)ProtobufInt32"
+    case .fixed64: return "\(namer.swiftProtobufModulePrefix)ProtobufFixed64"
+    case .fixed32: return "\(namer.swiftProtobufModulePrefix)ProtobufFixed32"
+    case .bool: return "\(namer.swiftProtobufModulePrefix)ProtobufBool"
+    case .string: return "\(namer.swiftProtobufModulePrefix)ProtobufString"
     case .group, .message: return namer.fullName(message: messageType!)
-    case .bytes: return "\(namer.swiftProtobufModuleName).ProtobufBytes"
-    case .uint32: return "\(namer.swiftProtobufModuleName).ProtobufUInt32"
+    case .bytes: return "\(namer.swiftProtobufModulePrefix)ProtobufBytes"
+    case .uint32: return "\(namer.swiftProtobufModulePrefix)ProtobufUInt32"
     case .enum: return namer.fullName(enum: enumType!)
-    case .sfixed32: return "\(namer.swiftProtobufModuleName).ProtobufSFixed32"
-    case .sfixed64: return "\(namer.swiftProtobufModuleName).ProtobufSFixed64"
-    case .sint32: return "\(namer.swiftProtobufModuleName).ProtobufSInt32"
-    case .sint64: return "\(namer.swiftProtobufModuleName).ProtobufSInt64"
+    case .sfixed32: return "\(namer.swiftProtobufModulePrefix)ProtobufSFixed32"
+    case .sfixed64: return "\(namer.swiftProtobufModulePrefix)ProtobufSFixed64"
+    case .sint32: return "\(namer.swiftProtobufModulePrefix)ProtobufSInt32"
+    case .sint64: return "\(namer.swiftProtobufModulePrefix)ProtobufSInt64"
     }
   }
 }

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -56,7 +56,7 @@ class EnumGenerator {
 
     p.print(
       "",
-      "\(enumDescriptor.protoSourceComments())\(visibility)enum \(swiftRelativeName): \(namer.swiftProtobufModuleName).Enum {")
+      "\(enumDescriptor.protoSourceComments())\(visibility)enum \(swiftRelativeName): \(namer.swiftProtobufModulePrefix)Enum {")
     p.withIndentation { p in
       p.print("\(visibility)typealias RawValue = Int")
 
@@ -104,7 +104,7 @@ class EnumGenerator {
   func generateRuntimeSupport(printer p: inout CodePrinter) {
     p.print(
       "",
-      "extension \(swiftFullName): \(namer.swiftProtobufModuleName)._ProtoNameProviding {")
+      "extension \(swiftFullName): \(namer.swiftProtobufModulePrefix)_ProtoNameProviding {")
     p.withIndentation { p in
       generateProtoNameProviding(printer: &p)
     }
@@ -140,7 +140,7 @@ class EnumGenerator {
   private func generateProtoNameProviding(printer p: inout CodePrinter) {
     let visibility = generatorOptions.visibilitySourceSnippet
 
-    p.print("\(visibility)static let _protobuf_nameMap: \(namer.swiftProtobufModuleName)._NameMap = [")
+    p.print("\(visibility)static let _protobuf_nameMap: \(namer.swiftProtobufModulePrefix)_NameMap = [")
     p.withIndentation { p in
       for v in mainEnumValueDescriptorsSorted {
         if let aliases = aliasInfo.aliases(v) {

--- a/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
@@ -47,7 +47,7 @@ class ExtensionSetGenerator {
             default: modifier = ""
             }
 
-            return "\(namer.swiftProtobufModuleName).\(label)\(modifier)ExtensionField"
+            return "\(namer.swiftProtobufModulePrefix)\(label)\(modifier)ExtensionField"
         }
 
         init(descriptor: FieldDescriptor, generatorOptions: GeneratorOptions, namer: SwiftProtobufNamer) {
@@ -78,7 +78,7 @@ class ExtensionSetGenerator {
             }
 
             p.print(
-              "\(comments)\(visibility)\(scope)let \(swiftRelativeExtensionName) = \(namer.swiftProtobufModuleName).MessageExtension<\(extensionFieldType)<\(traitsType)>, \(containingTypeSwiftFullName)>(")
+              "\(comments)\(visibility)\(scope)let \(swiftRelativeExtensionName) = \(namer.swiftProtobufModulePrefix)MessageExtension<\(extensionFieldType)<\(traitsType)>, \(containingTypeSwiftFullName)>(")
             p.printIndented(
               "_protobuf_fieldNumber: \(fieldDescriptor.number),",
               "fieldName: \"\(fieldNamePath)\"")
@@ -216,7 +216,7 @@ class ExtensionSetGenerator {
           /// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
           /// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
           /// a larger `SwiftProtobuf.SimpleExtensionMap`.
-          \(generatorOptions.visibilitySourceSnippet)let \(filePrefix)\(filenameAsIdentifer)_Extensions: \(namer.swiftProtobufModuleName).SimpleExtensionMap = [
+          \(generatorOptions.visibilitySourceSnippet)let \(filePrefix)\(filenameAsIdentifer)_Extensions: \(namer.swiftProtobufModulePrefix)SimpleExtensionMap = [
           """)
         p.withIndentation { p in
           let lastIndex = extensions.count - 1

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -191,10 +191,10 @@ class FileGenerator {
             // incompatible with the version of SwiftProtobuf to which you are linking.
             // Please ensure that you are building against the same version of the API
             // that was used to generate this file.
-            fileprivate struct _GeneratedWithProtocGenSwiftVersion: \(namer.swiftProtobufModuleName).ProtobufAPIVersionCheck {
+            fileprivate struct _GeneratedWithProtocGenSwiftVersion: \(namer.swiftProtobufModulePrefix)ProtobufAPIVersionCheck {
             """)
         p.printIndented(
-            "struct _\(v): \(namer.swiftProtobufModuleName).ProtobufAPIVersion_\(v) {}",
+            "struct _\(v): \(namer.swiftProtobufModulePrefix)ProtobufAPIVersion_\(v) {}",
             "typealias Version = _\(v)")
         p.print("}")
     }

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -157,7 +157,7 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
         guard isGroupOrMessage && fieldDescriptor.messageType!.containsRequiredFields() else { return }
 
         if isRepeated {  // Map or Array
-            p.print("if !\(namer.swiftProtobufModuleName).Internal.areAllInitialized(\(storedProperty)) {return false}")
+            p.print("if !\(namer.swiftProtobufModulePrefix)Internal.areAllInitialized(\(storedProperty)) {return false}")
         } else {
             p.print("if let v = \(storedProperty), !v.isInitialized {return false}")
         }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -115,7 +115,7 @@ class MessageGenerator {
 
     let conformances: String
     if isExtensible {
-      conformances = ": \(namer.swiftProtobufModuleName).ExtensibleMessage"
+      conformances = ": \(namer.swiftProtobufModulePrefix)ExtensibleMessage"
     } else {
       conformances = ""
     }
@@ -135,7 +135,7 @@ class MessageGenerator {
 
       p.print(
           "",
-          "\(visibility)var unknownFields = \(namer.swiftProtobufModuleName).UnknownStorage()")
+          "\(visibility)var unknownFields = \(namer.swiftProtobufModulePrefix)UnknownStorage()")
 
       for o in oneofs {
         o.generateMainEnum(printer: &p)
@@ -162,7 +162,7 @@ class MessageGenerator {
       if isExtensible {
         p.print(
             "",
-            "\(visibility)var _protobuf_extensionFieldValues = \(namer.swiftProtobufModuleName).ExtensionFieldValueSet()")
+            "\(visibility)var _protobuf_extensionFieldValues = \(namer.swiftProtobufModulePrefix)ExtensionFieldValueSet()")
       }
       if let storage = storage {
         if !isExtensible {
@@ -205,7 +205,7 @@ class MessageGenerator {
   func generateRuntimeSupport(printer p: inout CodePrinter, file: FileGenerator, parent: MessageGenerator?) {
     p.print(
         "",
-        "extension \(swiftFullName): \(namer.swiftProtobufModuleName).Message, \(namer.swiftProtobufModuleName)._MessageImplementationBase, \(namer.swiftProtobufModuleName)._ProtoNameProviding {")
+        "extension \(swiftFullName): \(namer.swiftProtobufModulePrefix)Message, \(namer.swiftProtobufModulePrefix)_MessageImplementationBase, \(namer.swiftProtobufModulePrefix)_ProtoNameProviding {")
     p.withIndentation { p in
       if let parent = parent {
         p.print("\(visibility)static let protoMessageName: String = \(parent.swiftFullName).protoMessageName + \".\(descriptor.name)\"")
@@ -243,9 +243,9 @@ class MessageGenerator {
 
   private func generateProtoNameProviding(printer p: inout CodePrinter) {
     if fields.isEmpty {
-      p.print("\(visibility)static let _protobuf_nameMap = \(namer.swiftProtobufModuleName)._NameMap()")
+      p.print("\(visibility)static let _protobuf_nameMap = \(namer.swiftProtobufModulePrefix)_NameMap()")
     } else {
-      p.print("\(visibility)static let _protobuf_nameMap: \(namer.swiftProtobufModuleName)._NameMap = [")
+      p.print("\(visibility)static let _protobuf_nameMap: \(namer.swiftProtobufModulePrefix)_NameMap = [")
       p.withIndentation { p in
         for f in fields {
           p.print("\(f.number): \(f.fieldMapNames),")
@@ -260,7 +260,7 @@ class MessageGenerator {
   ///
   /// - Parameter p: The code printer.
   private func generateDecodeMessage(printer p: inout CodePrinter) {
-    p.print("\(visibility)mutating func decodeMessage<D: \(namer.swiftProtobufModuleName).Decoder>(decoder: inout D) throws {")
+    p.print("\(visibility)mutating func decodeMessage<D: \(namer.swiftProtobufModulePrefix)Decoder>(decoder: inout D) throws {")
     p.withIndentation { p in
       if storage != nil {
         p.print("_ = _uniqueStorage()")
@@ -329,7 +329,7 @@ class MessageGenerator {
   ///
   /// - Parameter p: The code printer.
   private func generateTraverse(printer p: inout CodePrinter) {
-    p.print("\(visibility)func traverse<V: \(namer.swiftProtobufModuleName).Visitor>(visitor: inout V) throws {")
+    p.print("\(visibility)func traverse<V: \(namer.swiftProtobufModulePrefix)Visitor>(visitor: inout V) throws {")
     p.withIndentation { p in
       generateWithLifetimeExtension(printer: &p, throws: true) { p in
         if let storage = storage {

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -388,6 +388,16 @@ extension XCTestCase {
         XCTAssertEqual(actual, expected, fmt ?? "debugDescription did not match", file: file, line: line)
         #endif
     }
+    /// Like ``assertDebugDescription``, but only checks the the ``debugDescription`` ends with
+    /// ``expectedSuffix``, mainly useful where you want to be agnotics to some preable like
+    /// the module name.
+    func assertDebugDescriptionSuffix(_ expectedSuffix: String, _ m: SwiftProtobuf.Message, fmt: String? = nil, file: XCTestFileArgType = #file, line: UInt = #line) {
+        // `assertDebugDescriptionSuffix` is a no-op in release as `debugDescription` is unavailable.
+#if DEBUG
+        let actual = m.debugDescription
+        XCTAssertTrue(actual.hasSuffix(expectedSuffix), fmt ?? "debugDescription did not match", file: file, line: line)
+#endif
+    }
 }
 
 /// Protocol to help write visitor for testing.  It provides default implementaions

--- a/Tests/SwiftProtobufTests/Test_FieldMask.swift
+++ b/Tests/SwiftProtobufTests/Test_FieldMask.swift
@@ -57,7 +57,7 @@ class Test_FieldMask: XCTestCase, PBTestHelpers {
     func testDebugDescription() {
         var m = Google_Protobuf_FieldMask()
         m.paths = ["foo", "bar"]
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_FieldMask:\npaths: \"foo\"\npaths: \"bar\"\n", m)
+        assertDebugDescriptionSuffix(".Google_Protobuf_FieldMask:\npaths: \"foo\"\npaths: \"bar\"\n", m)
     }
 
     func testConvenienceInits() {

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -247,7 +247,7 @@ class Test_JSON_Value: XCTestCase, PBTestHelpers {
             XCTFail()
         }
 
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nnull_value: NULL_VALUE\n", null)
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nnull_value: NULL_VALUE\n", null)
     }
 
     func testValue_number() throws {
@@ -265,7 +265,7 @@ class Test_JSON_Value: XCTestCase, PBTestHelpers {
         assertJSONDecodeSucceeds("  3.25  ") {$0.numberValue == 3.25}
         assertJSONDecodeFails("3.2.5")
 
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nnumber_value: 1.0\n", oneFromIntegerLiteral)
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nnumber_value: 1.0\n", oneFromIntegerLiteral)
     }
 
     func testValue_string() throws {
@@ -302,7 +302,7 @@ class Test_JSON_Value: XCTestCase, PBTestHelpers {
         // PB serialization
         XCTAssertEqual([26, 3, 97, 34, 98], try Google_Protobuf_Value(stringValue: "a\"b").serializedBytes())
 
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nstring_value: \"abcd\"\n", fromStringLiteral)
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nstring_value: \"abcd\"\n", fromStringLiteral)
     }
 
     func testValue_bool() {
@@ -322,7 +322,7 @@ class Test_JSON_Value: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("yes")
         assertJSONDecodeFails("  true false   ")
 
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nbool_value: true\n", trueFromLiteral)
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nbool_value: true\n", trueFromLiteral)
     }
 
     func testValue_struct() throws {
@@ -331,13 +331,12 @@ class Test_JSON_Value: XCTestCase, PBTestHelpers {
         }
 
         let structValue = try Google_Protobuf_Value(jsonString: "{\"a\":1.0}")
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nstruct_value {\n  fields {\n    key: \"a\"\n    value {\n      number_value: 1.0\n    }\n  }\n}\n", structValue)
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nstruct_value {\n  fields {\n    key: \"a\"\n    value {\n      number_value: 1.0\n    }\n  }\n}\n", structValue)
     }
 
     func testValue_list() throws {
         let listValue = try Google_Protobuf_Value(jsonString: "[1, true, \"abc\"]")
-        assertDebugDescription("SwiftProtobufCore.Google_Protobuf_Value:\nlist_value {\n  values {\n    number_value: 1.0\n  }\n  values {\n    bool_value: true\n  }\n  values {\n    string_value: \"abc\"\n  }\n}\n", listValue)
-
+        assertDebugDescriptionSuffix(".Google_Protobuf_Value:\nlist_value {\n  values {\n    number_value: 1.0\n  }\n  values {\n    bool_value: true\n  }\n  values {\n    string_value: \"abc\"\n  }\n}\n", listValue)
     }
 
     func testValue_complex() {


### PR DESCRIPTION
This allows one to more simply cope the module with a different name (not `-module-alias` needed) and then it updates the tests so you can run those against against a runtime that was compiled under a different name (`-module-alias` used simple to compile the tests, no edit need to make them all pass).

This is sorta a followup to #1017.