### PR TITLE
1_x_branch: Add the file naming option (#1312)

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -18,15 +18,50 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
             /// The visibility of the generated files.
             enum Visibility: String, Codable {
                 /// The generated files should have `internal` access level.
-                case `internal`
+                case `internal` = "Internal"
                 /// The generated files should have `public` access level.
-                case `public`
+                case `public` = "Public"
+
+                init?(rawValue: String) {
+                    switch rawValue.lowercased() {
+                    case "internal":
+                        self = .internal
+                    case "public":
+                        self = .public
+                    default:
+                        return nil
+                    }
+                }
+            }
+
+            enum FileNaming: String, Codable {
+                /// The generated Swift file paths will be using the same relative path as the input proto files.
+                case fullPath = "FullPath"
+                /// The generated Swift file paths will the the relative paths but each directory replaced with an `_`.
+                case pathToUnderscores = "PathToUnderscores"
+                /// The generated Swift files will just be using the file name and drop the rest of the relative path.
+                case dropPath = "DropPath"
+
+                init?(rawValue: String) {
+                    switch rawValue.lowercased() {
+                    case "fullpath", "full_path":
+                        self = .fullPath
+                    case "pathtounderscores", "path_to_underscores":
+                        self = .pathToUnderscores
+                    case "droppath", "drop_path":
+                        self = .dropPath
+                    default:
+                        return nil
+                    }
+                }
             }
 
             /// An array of paths to `.proto` files for this invocation.
             var protoFiles: [String]
             /// The visibility of the generated files.
             var visibility: Visibility?
+            /// The file naming strategy to use.
+            var fileNaming: FileNaming?
         }
 
         /// The path to the `protoc` binary.
@@ -51,7 +86,7 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
         let data = try Data(contentsOf: URL(fileURLWithPath: "\(configurationFilePath)"))
         let configuration = try JSONDecoder().decode(Configuration.self, from: data)
 
-        try self.validateConfiguration(configuration)
+        try validateConfiguration(configuration)
 
         // We need to find the path of protoc and protoc-gen-swift
         let protocPath: Path
@@ -108,7 +143,12 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
 
         // Add the visibility if it was set
         if let visibility = invocation.visibility {
-            protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue.capitalized)")
+            protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue)")
+        }
+
+        // Add the file naming if it was set
+        if let fileNaming = invocation.fileNaming {
+            protocArgs.append("--swift_opt=FileNaming=\(fileNaming.rawValue)")
         }
 
         var inputFiles = [Path]()

--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -75,7 +75,8 @@ to the root of your target's source folder. An example configuration file looks 
             "protoFiles": [
                 "Bar.proto"
             ],
-            "visibility": "public"
+            "visibility": "public",
+            "fileNaming": "pathToUnderscores"
         }
     ]
 }
@@ -84,7 +85,9 @@ to the root of your target's source folder. An example configuration file looks 
 
 In the above configuration, you declared two invocations to the `protoc` compiler. The first invocation
 is generating Swift types for the `Foo.proto` file with `internal` visibility. The second invocation
-is generating Swift types for the `Bar.proto` file with the `public` visibility.
+is generating Swift types for the `Bar.proto` file with the `public` visibility. Furthermore, the second
+invocation is using the `pathToUnderscores` file naming option. This option can be used to solve
+problems where a single target contains two or more proto files with the same name.
 
 ### Defining the path to the protoc binary
 


### PR DESCRIPTION
* Add the file naming option

# Motivation
In some cases, it might be that the proto files in a single target have duplicate file names. This would result in a compilation failure since Swift does not allow duplicate files names in a single module. To resolve this `protoc-gen-swift` has a `FileNaming` option called `PathToUnderscore` to avoid this. We should expose this as an option in the SPM plugin.

# Modification
This PR extends the SPM plugin config to set a `fileNaming` strategy. It defaults to the `FullPath` strategy if none is set.

# Result
Fixes: https://github.com/apple/swift-protobuf/issues/1310