### PR TITLE
Update CocoaPods support.

### DIFF
--- a/DevTools/LibraryVersions.py
+++ b/DevTools/LibraryVersions.py
@@ -18,6 +18,8 @@ import sys
 _VERSION_RE = re.compile(r'^(?P<major>\d+)\.(?P<minor>\d+)(.(?P<revision>\d+))?$')
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_CORE_PODSPEC_PATH = os.path.join(_PROJECT_ROOT, 'SwiftProtobufCore.podspec')
+_FOUNDATION_PODSPEC_PATH = os.path.join(_PROJECT_ROOT, 'SwiftProtobufFoundationCompat.podspec')
 _PODSPEC_PATH = os.path.join(_PROJECT_ROOT, 'SwiftProtobuf.podspec')
 _VERSION_SWIFT_PATH = os.path.join(_PROJECT_ROOT, 'Sources/SwiftProtobufCore/Version.swift')
 
@@ -39,6 +41,13 @@ def ValidateFiles():
     Fail('Failed to extract a version from SwiftProtobuf.podspec')
   (major, minor, revision) = ExtractVersion(match.group(1))
 
+  # Test the other two podspecs.
+  expected_version = 'version = \'%s.%s.%s\'' % (major, minor, revision)
+  for p in (_FOUNDATION_PODSPEC_PATH, _CORE_PODSPEC_PATH):
+    pod_content = open(p).read()
+    if expected_version not in open(p).read():
+      Fail('Version in %s did not match SwiftProtobuf.podspec' % os.path.basename(p))
+
   # Test Sources/SwiftProtobuf/Version.swift
   version_swift_content = open(_VERSION_SWIFT_PATH).read()
   major_line = 'public static let major = %s\n' % major
@@ -54,12 +63,13 @@ def ValidateFiles():
 def UpdateFiles(version_string):
   (major, minor, revision) = ExtractVersion(version_string)
 
-  # Update SwiftProtobuf.podspec
-  pod_content = open(_PODSPEC_PATH).read()
-  pod_content = re.sub(r'version = \'(\d+\.\d+\.\d+)\'',
-                       'version = \'%s.%s.%s\'' % (major, minor, revision),
-                       pod_content)
-  open(_PODSPEC_PATH, 'w').write(pod_content)
+  # Update *.podspec
+  for p in (_FOUNDATION_PODSPEC_PATH, _CORE_PODSPEC_PATH, _PODSPEC_PATH):
+    pod_content = open(p).read()
+    pod_content = re.sub(r'version = \'(\d+\.\d+\.\d+)\'',
+                         'version = \'%s.%s.%s\'' % (major, minor, revision),
+                         pod_content)
+    open(p, 'w').write(pod_content)
 
   # Update Sources/SwiftProtobuf/Version.swift
   version_swift_content = open(_VERSION_SWIFT_PATH).read()

--- a/Documentation/INTERNALS.md
+++ b/Documentation/INTERNALS.md
@@ -34,7 +34,7 @@ When the minimum Swift version gets updated, update:
 - Audit all the `#if` directives in the code and tests that use at
   `swift(...)` to check the version being compiled against, and
   remove the ones that are no longer needed.
-- Update `Package.swift` and `SwiftProtobuf.podspec` files to list the
+- Update `Package.swift` and `SwiftProtobuf*.podspec` files to list the
   versions supported. Eventually the version specific `Package@*.swift`
   files will go away.
 

--- a/Documentation/RELEASING.md
+++ b/Documentation/RELEASING.md
@@ -48,32 +48,40 @@ When doing a release:
    For the description call out any major things in that release.  Usually a short summary and
    then a reference to the pull request for more info is enough.
 
-1. Publish the CocoaPod
+1. Publish the CocoaPods
 
-   1. Do a final sanity check that CocoaPods is happy with the release you just made, in the project
-      directory:
+   CocoaPods only does one Swift Module per podspec, so the current three modules can be modeled
+   via three podspec files that have dependencies: SwiftProtobufCore.podspec ->
+   SwiftProtobufFoundationCompat.podspec -> SwiftProtobuf.podspec. So they end up having to
+   be published in that order:
+
+   1. Publish the `SwiftProtobufCore.podspec`:
 
       ```
-      $ pod spec lint SwiftProtobuf.podspec
+      $ pod trunk push SwiftProtobufCore.podspec
       ```
 
-      _Note:_ This uses that local copy of the podspec, but pulls the code off the tag on github.
+      _Note:_ This uses that local copy of the podspec, but checks against the sources on
+      github.
 
-      If this doesn't pass, you have two options:
+   1. Publish the `SwiftProtobufFoundationCompat.podspec`:
 
-      - If the problem is just with the `podspec`, you can edit it, and try again.  The version of
-        the podspec in the branch doesn't really matter, so just ensure things get fixed on main
-        for the future.
-      - If the problem is within the code, you'll likely need to abandon this release.  Fix the
-        code and start the process over cutting a new tag.
+      ```
+      $ pod trunk push SwiftProtobufFoundationCompat.podspec
+      ```
 
-   1. Publish the pod:
+      _Note:_ This uses that local copy of `SwiftProtobufFoundationCompat.podspec`, but checks
+      against the sources on github and the already published `SwiftProtobufCore.podspec`
+
+   1. Publish the `SwiftProtobuf.podspec`:
 
       ```
       $ pod trunk push SwiftProtobuf.podspec
       ```
 
-      _Note:_ This uses that local copy of the podspec.
+      _Note:_ This uses that local copy of `SwiftProtobuf.podspec`, but checks
+      against the sources on github and the already published `SwiftProtobufCore.podspec` and
+      `SwiftProtobufFoundationCompat.podspec`.
 
 1. Bump the version on _main_
 

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ SWIFT_PLUGIN_DESCRIPTOR_TEST_PROTOS= \
 	default \
 	docs \
 	install \
+	pod-lib-lint \
 	reference \
 	regenerate \
 	regenerate-conformance-protos \
@@ -536,3 +537,11 @@ test-conformance: build check-for-protobuf-checkout Sources/Conformance/failure_
 	  --failure_list Sources/Conformance/failure_list_swift.txt \
 	  --text_format_failure_list Sources/Conformance/text_format_failure_list_swift.txt\
 	  $(SWIFT_CONFORMANCE_PLUGIN)
+
+# Validate the CocoaPods podspecs files against the current tree state.
+pod-lib-lint:
+	@if [ `uname -s` = "Darwin" ] ; then \
+	  pod lib lint SwiftProtobufCore.podspec ; \
+	  pod lib lint --include-podspecs=SwiftProtobufCore.podspec SwiftProtobufFoundationCompat.podspec ; \
+	  pod lib lint '--include-podspecs={SwiftProtobufCore.podspec,SwiftProtobufFoundationCompat.podspec}' SwiftProtobuf.podspec ; \
+	fi

--- a/SwiftProtobufCore.podspec
+++ b/SwiftProtobufCore.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
-  s.name = 'SwiftProtobuf'
+  s.name = 'SwiftProtobufCore'
   s.version = '2.0.0'
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
-  s.summary = 'Swift Protobuf Runtime and Foundation Compatibility Library'
+  s.summary = 'Swift Protobuf Runtime Library'
   s.homepage = 'https://github.com/apple/swift-protobuf'
   s.author = 'Apple Inc.'
   s.source = { :git => 'https://github.com/apple/swift-protobuf.git', :tag => s.version }
@@ -15,12 +15,7 @@ Pod::Spec.new do |s|
 
   s.cocoapods_version = '>= 1.7.0'
 
-  s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
-
-  # Require and exact match on the dependency, since it isn't yet clear
-  # if we'll be able to support interop between minor/bugfixes.
-  s.dependency 'SwiftProtobufCore', "= #{s.version}"
-  s.dependency 'SwiftProtobufFoundationCompat', "= #{s.version}"
+  s.source_files = 'Sources/SwiftProtobufCore/**/*.swift'
 
   s.swift_versions = ['5.0']
 end

--- a/SwiftProtobufFoundationCompat.podspec
+++ b/SwiftProtobufFoundationCompat.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
-  s.name = 'SwiftProtobuf'
+  s.name = 'SwiftProtobufFoundationCompat'
   s.version = '2.0.0'
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
-  s.summary = 'Swift Protobuf Runtime and Foundation Compatibility Library'
+  s.summary = 'Swift Protobuf Foundation Compatibility Library'
   s.homepage = 'https://github.com/apple/swift-protobuf'
   s.author = 'Apple Inc.'
   s.source = { :git => 'https://github.com/apple/swift-protobuf.git', :tag => s.version }
@@ -15,12 +15,11 @@ Pod::Spec.new do |s|
 
   s.cocoapods_version = '>= 1.7.0'
 
-  s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
+  s.source_files = 'Sources/SwiftProtobufFoundationCompat/**/*.swift'
 
   # Require and exact match on the dependency, since it isn't yet clear
   # if we'll be able to support interop between minor/bugfixes.
   s.dependency 'SwiftProtobufCore', "= #{s.version}"
-  s.dependency 'SwiftProtobufFoundationCompat', "= #{s.version}"
 
   s.swift_versions = ['5.0']
 end


### PR DESCRIPTION
Model what Firebase seems to do, have a podspec for each of the modules and have dependencies between them.

Add a helper to the Makefile for running `pod lib lint`.

Update LibraryVersions.py to handle the multiple podspecs.

Update the docs on what publishing is likely going to take.

Fixes #1334