### PR TITLE
Mark some new conformance tests as failing.

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -1,1 +1,4 @@
-# No known failures
+# These tests landing in protocolbuffers/protobuf#9534. Issue #972 covers this support.
+Recommended.Proto3.JsonInput.IgnoreUnknownEnumStringValueInMapValue.ProtobufOutput
+Recommended.Proto3.JsonInput.IgnoreUnknownEnumStringValueInOptionalField.ProtobufOutput
+Recommended.Proto3.JsonInput.IgnoreUnknownEnumStringValueInRepeatedField.ProtobufOutput


### PR DESCRIPTION
This is related to #972, new cases come from
https://github.com/protocolbuffers/protobuf/commit/09f4901084d7ccc9cc1371ec8b83c197711f3cbb