### PR TITLE
Fail to encode google.protobuf.Value number if not finite.

### DIFF
--- a/Sources/SwiftProtobufCore/Google_Protobuf_Value+Extensions.swift
+++ b/Sources/SwiftProtobufCore/Google_Protobuf_Value+Extensions.swift
@@ -152,7 +152,11 @@ extension Google_Protobuf_Value {
   ) throws {
     switch kind {
     case .nullValue?: encoder.putNullValue()
-    case .numberValue(let v)?: encoder.putDoubleValue(value: v)
+    case .numberValue(let v)?:
+      guard v.isFinite else {
+        throw JSONEncodingError.valueNumberNotFinite
+      }
+      encoder.putDoubleValue(value: v)
     case .stringValue(let v)?: encoder.putStringValue(value: v)
     case .boolValue(let v)?: encoder.putNonQuotedBoolValue(value: v)
     case .structValue(let v)?: encoder.append(text: try v.jsonString(options: options))

--- a/Sources/SwiftProtobufCore/JSONEncodingError.swift
+++ b/Sources/SwiftProtobufCore/JSONEncodingError.swift
@@ -32,4 +32,7 @@ public enum JSONEncodingError: Error {
     /// valid `kind` (that is, they represent a null value, number, boolean,
     /// string, struct, or list).
     case missingValue
+    /// google.protobuf.Value cannot encode double values for infinity or nan,
+    /// because they would be parsed as a string.
+    case valueNumberNotFinite
 }

--- a/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
@@ -281,6 +281,25 @@ class Test_JSON_Conformance: XCTestCase {
         XCTAssertEqual(try t.jsonString(), start)
     }
 
+  func testValue_DoubleNonFinite() {
+    XCTAssertThrowsError(try Google_Protobuf_Value(numberValue: .nan).jsonString()) {
+      XCTAssertEqual($0 as? JSONEncodingError,
+                     JSONEncodingError.valueNumberNotFinite,
+                     "Wrong errror? - \($0)")
+    }
+
+    XCTAssertThrowsError(try Google_Protobuf_Value(numberValue: .infinity).jsonString()) {
+      XCTAssertEqual($0 as? JSONEncodingError,
+                     JSONEncodingError.valueNumberNotFinite,
+                     "Wrong errror? - \($0)")
+    }
+
+    XCTAssertThrowsError(try Google_Protobuf_Value(numberValue: -.infinity).jsonString()) {
+      XCTAssertEqual($0 as? JSONEncodingError,
+                     JSONEncodingError.valueNumberNotFinite,
+                     "Wrong errror? - \($0)")
+    }
+  }
 
     func testNestedAny() {
         let start = ("{\n"


### PR DESCRIPTION
From https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value

> Note that attempting to serialize NaN or Infinity results in error. (We can't
> serialize these as string "NaN" or "Infinity" values like we do for regular
> fields, because they would parse as string_value, not number_value).