### PR TITLE
Only warn about `protoc` version if explicitly set to <3.2.x

### DIFF
--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -153,7 +153,6 @@ struct GeneratorPlugin {
       return 1
     }
 
-    auditProtoCVersion(request: request)
     let response = generate(request: request)
     guard sendReply(response: response) else { return 1 }
     return 0
@@ -237,16 +236,6 @@ struct GeneratorPlugin {
     }
     return Google_Protobuf_Compiler_CodeGeneratorResponse(files: responseFiles,
                                                           supportedFeatures: [.proto3Optional])
-  }
-
-  private func auditProtoCVersion(request: Google_Protobuf_Compiler_CodeGeneratorRequest) {
-    guard request.hasCompilerVersion else {
-      Stderr.print("WARNING: unknown version of protoc, use 3.2.x or later to ensure JSON support is correct.")
-      return
-    }
-    // 3.2.x is what added the compiler_version, so there is no need to
-    // ensure that the version of protoc being used is newer, if the field
-    // is there, the JSON support should be good.
   }
 
   private func sendReply(response: Google_Protobuf_Compiler_CodeGeneratorResponse) -> Bool {

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -153,6 +153,7 @@ struct GeneratorPlugin {
       return 1
     }
 
+    auditProtoCVersion(request: request)
     let response = generate(request: request)
     guard sendReply(response: response) else { return 1 }
     return 0
@@ -236,6 +237,17 @@ struct GeneratorPlugin {
     }
     return Google_Protobuf_Compiler_CodeGeneratorResponse(files: responseFiles,
                                                           supportedFeatures: [.proto3Optional])
+  }
+
+  private func auditProtoCVersion(request: Google_Protobuf_Compiler_CodeGeneratorRequest) {
+    guard request.hasCompilerVersion else {
+      // Don't warn if the compiler version is not explicitly set.
+      return
+    }
+
+    if request.compilerVersion.major < 3 || (request.compilerVersion.major == 3 && request.compilerVersion.minor < 2) {
+      Stderr.print("WARNING: unknown version of protoc, use 3.2.x or later to ensure JSON support is correct.")
+    }
   }
 
   private func sendReply(response: Google_Protobuf_Compiler_CodeGeneratorResponse) -> Bool {


### PR DESCRIPTION
There are some cases where it does not make sense to specify the `protoc` version - for example, when compiling with `buf`. (See https://github.com/bufbuild/buf/issues/1244 and https://github.com/bufbuild/buf/issues/1736). Furthermore, the compiler version is not read elsewhere right now.

This change updates the behavior to only warn _if the compiler version is explicitly set and is < 3.2.x_.