### PR TITLE
Update around where/when protobuf is built.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,131 +16,51 @@ jobs:
       fail-fast: false
       matrix:
         swift: ["5.7.2", "5.6.3", "5.5.3", "5.4.3", "5.3.3", "5.2.5", "5.1.5", "5.0.3"]
-        # protobuf_git can reference a commit, tag, or branch
-        # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
-        # tag: "ref/tags/v3.11.4"
-        # branch: "ref/heads/main"
-        protobuf_git: ["ref/heads/main"]
         include:
           - swift: 5.7.2
             ubuntu: focal
             generate_linux_main: false
-            build_protobuf: true
           - swift: 5.6.3
             ubuntu: focal
             generate_linux_main: false
-            build_protobuf: true
           - swift: 5.5.3
             ubuntu: focal
             generate_linux_main: false
-            build_protobuf: true
           - swift: 5.4.3
             ubuntu: focal
             generate_linux_main: false
-            build_protobuf: true
           - swift: 5.3.3
             ubuntu: focal
             generate_linux_main: true
-            build_protobuf: true
           - swift: 5.2.5
             ubuntu: focal
             generate_linux_main: true
-            build_protobuf: true
           - swift: 5.1.5
             ubuntu: bionic
             generate_linux_main: true
-            build_protobuf: false
           - swift: 5.0.3
             ubuntu: bionic
             generate_linux_main: true
-            build_protobuf: false
     container:
       image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        path: main
     - name: Update and install dependencies
-      # dependencies from https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
-      # this step is run before get-sha because we need curl and jq for get-sha
-      # NOTE: zlib1g-dev is added to fix the Swift 5.0.x builds, when those builds aren't needed
-      # that dep likely can be removed.
       run: |
         set -eu
         apt-get update
-        apt-get install -y curl make g++ cmake jq
-        [ \"${{ matrix.swift }}\" != \"5.0.3\" ] || apt-get install -y zlib1g-dev
-    - name: Install newer git for bionic
-      # bionic's git doesn't do modules via the REST api, update the git version.
-      if: matrix.ubuntu == 'bionic'
-      run: |
-        set -eu
-        apt-get install -y software-properties-common
-        add-apt-repository ppa:git-core/ppa
-        apt-get update
-        apt-get install -y git
-    - name: Get Protobuf Commit SHA
-      id: get-sha
-      run: |
-        set -eu
-        url="https://api.github.com/repos/protocolbuffers/protobuf/git/${{ matrix.protobuf_git }}"
-        case ${{ matrix.protobuf_git }} in
-        ref/*)
-          echo "sha=$( curl -s -u "u:${{ github.token }}" "${url}" | jq -r .object.sha )" >> $GITHUB_OUTPUT
-          ;;
-        commits/*)
-          echo "sha=$( curl -s -u "u:${{ github.token }}" "${url}" | jq -r .sha )" >> $GITHUB_OUTPUT
-          ;;
-        esac
+        apt-get install -y make protobuf-compiler
+        protoc --version
     - name: Generate LinuxMain.swift
       if: ${{ matrix.generate_linux_main }}
-      working-directory: main
       run: make generate-linux-main
     - name: Build
-      working-directory: main
       run: make build
     - name: Test runtime
-      working-directory: main
       run: make test-runtime
-    - name: Cache protobuf
-      if: ${{ matrix.build_protobuf }}
-      id: cache-protobuf
-      uses: actions/cache@v3
-      with:
-        path: protobuf
-        # NOTE: for refs that can float like 'main' the cache might be out of date!
-        key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
-    - name: Checkout protobuf repo
-      if: ${{ matrix.build_protobuf && steps.cache-protobuf.outputs.cache-hit != 'true' }}
-      uses: actions/checkout@v3
-      with:
-        repository: protocolbuffers/protobuf
-        ref: ${{ steps.get-sha.outputs.sha }}
-        submodules: true
-        path: protobuf
-    - name: Build protobuf
-      if: ${{ matrix.build_protobuf && steps.cache-protobuf.outputs.cache-hit != 'true' }}
-      working-directory: protobuf
-      run: |
-        mkdir cmake_build
-        cd cmake_build
-        cmake \
-          -DCMAKE_BUILD_TYPE=Release \
-          -Dprotobuf_BUILD_TESTS=OFF \
-          -Dprotobuf_INSTALL=OFF \
-          -Dprotobuf_BUILD_CONFORMANCE=ON \
-          -S ..
-        NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
-        make -j "${NUM_CPUS}" protoc conformance_test_runner
     - name: Test plugin
-      if: ${{ matrix.build_protobuf }}
-      working-directory: main
-      run: make test-plugin PROTOC=../protobuf/cmake_build/protoc
-    - name: Test conformance
-      if: ${{ matrix.build_protobuf }}
-      working-directory: main
-      run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner
+      run: make test-plugin
 
   sanitizer_testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,37 +1,48 @@
-name: Run Regular Conformance Tests
+name: Run Conformance Tests
 
-# This workflow is a subset of conformance.yml. It *only* try to run the
-# conformance checks. It is triggered weekly on a cron to catch when new
-# conformance tests are added and they don't pass.
+# This workflow is a supperset of regular_conformance.yml. It runs on ever PR &
+# commit to run the conformance checks.
 #
-# Without this workflow the new tests wouldn't be noticed until a PR was made.
+# The swift versions should stay in sync with build.yml, but can be a subset
+# because building protobuf on older images isn't always easier.
 #
 # This workflow shares the caching logic with conformance.yml. It should serve
 # to update a subset of the caches for when things do land on trunk. If that is
 # deemed not worth it in the future, this can be simplify.
 
 # NOTE: If making changes to most of the steps, please also look to update
-# conformance.yml also.
+# regular_conformance.yml also.
 
 on:
-  schedule:
-    # Every Sunday at 5am.
-    - cron: '0 5 * * 0'
-  # Also allow manual triggering from the github UX to revalidate things.
-  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["5.7.2"]
-        ubuntu: ["focal"]
+        swift: ["5.7.2", "5.6.3", "5.5.3", "5.4.3", "5.3.3", "5.2.5"]
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"
         # branch: "ref/heads/main"
         protobuf_git: ["ref/heads/main"]
+        include:
+          - swift: 5.7.2
+            ubuntu: focal
+          - swift: 5.6.3
+            ubuntu: focal
+          - swift: 5.5.3
+            ubuntu: focal
+          - swift: 5.4.3
+            ubuntu: focal
+          - swift: 5.3.3
+            ubuntu: focal
+          - swift: 5.2.5
+            ubuntu: focal
     container:
       image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:


### PR DESCRIPTION
- Update build.yml to use the currently release version of protoc and remove the conformance tests.
- Add a new conformance.yml that has all the protobuf building and conformance test running (also run the plugin tests just incase something changes on the plugin interface). This file is much more in sync with regular_conformance.yml.