### PR TITLE
Enforce the 2GB size limits

### DIFF
--- a/Sources/SwiftProtobufCore/BinaryDecoder.swift
+++ b/Sources/SwiftProtobufCore/BinaryDecoder.swift
@@ -1467,15 +1467,30 @@ internal struct BinaryDecoder: Decoder {
     }
 
     /// Private: Get the start and length for the body of
-    // a length-delimited field.
+    /// a length-delimited field.
     private mutating func getFieldBodyBytes(count: inout Int) throws -> UnsafeRawPointer {
         let length = try decodeVarint()
-        if length <= UInt64(available) {
-            count = Int(length)
-            let body = p
-            consume(length: count)
-            return body
+
+        // Bytes and Strings have a max size of 2GB. And since messages are on
+        // the wire as bytes/length delimited, they also have a 2GB size limit.
+        // The upstream C++ does the same sort of enforcement (see
+        // parse_context, delimited_message_util, message_lite, etc.).
+        // https://protobuf.dev/programming-guides/encoding/#cheat-sheet
+        //
+        // This function does get called in some package decode handling, but
+        // that is length delimited on the wire, so the spec would imply
+        // the limit still applies.
+        guard length < 0x7fffffff else {
+          throw BinaryDecodingError.tooLarge
         }
-        throw BinaryDecodingError.truncated
+
+        guard length <= UInt64(available) else {
+          throw BinaryDecodingError.truncated
+        }
+
+        count = Int(length)
+        let body = p
+        consume(length: count)
+        return body
     }
 }

--- a/Sources/SwiftProtobufCore/BinaryDecodingError.swift
+++ b/Sources/SwiftProtobufCore/BinaryDecodingError.swift
@@ -41,4 +41,8 @@ public enum BinaryDecodingError: Error {
 
   /// Reached the nesting limit for messages within messages while decoding.
   case messageDepthLimit
+
+  /// Bytes and Strings have a max size of 2GB. And since messages are on the
+  /// wire as bytes/length delimited, they also have a 2GB size limit.
+  case tooLarge
 }

--- a/Sources/SwiftProtobufCore/BinaryDelimited.swift
+++ b/Sources/SwiftProtobufCore/BinaryDelimited.swift
@@ -29,9 +29,9 @@ public enum BinaryDelimited {
     /// read/written.
     case truncated
 
-    /// When decoding (parsing), the length is larger than what will fit in
-    /// an Int for the compiled platform, so the message can't be parsed.
-    case decodeTooLarge
+    /// Messages are limited by the protobuf spec to 2GB; when decoding, if the
+    /// length says the payload is over 2GB, this error is raised.
+    case tooLarge
   }
 
   /// Serialize a single size-delimited message from the given stream. Delimited
@@ -164,10 +164,8 @@ public enum BinaryDelimited {
       // The message was all defaults, nothing to actually read.
       return
     }
-    guard unsignedLength <= Int.max else {
-      // Due to the trip through an Array below, it has to fit, and Array uses
-      // Int (signed) for Count.
-      throw BinaryDelimited.Error.decodeTooLarge
+    guard unsignedLength <= 0x7fffffff else {
+      throw BinaryDelimited.Error.tooLarge
     }
     let length = Int(unsignedLength)
     var data: [UInt8] = Array(repeating: 0, count: length)

--- a/Sources/SwiftProtobufCore/BinaryEncodingError.swift
+++ b/Sources/SwiftProtobufCore/BinaryEncodingError.swift
@@ -24,4 +24,7 @@ public enum BinaryEncodingError: Error {
   /// must pass `partial: true` during encoding if you wish to explicitly ignore
   /// missing required fields.
   case missingRequiredFields
+
+  /// Messages are limited to a maximum of 2GB in encoded size.
+  case tooLarge
 }

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -818,6 +818,15 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeFails([119])
         assertDecodeFails([119, 0])
 
+        // Ensure strings over 2GB fail to decode according to spec.
+        XCTAssertThrowsError(try MessageTestType(serializedBytes: [
+          114, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
+          // Don't need all the bytes, want some to let the length issue trigger.
+          0x01, 0x02, 0x03,
+        ])) {
+          XCTAssertEqual($0 as! BinaryDecodingError, BinaryDecodingError.tooLarge)
+        }
+
         let empty = MessageTestType()
         var a = empty
         a.optionalString = ""
@@ -933,6 +942,15 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeFails([127])
         assertDecodeFails([127, 0])
 
+        // Ensure bytes over 2GB fail to decode according to spec.
+        XCTAssertThrowsError(try MessageTestType(serializedBytes: [
+          122, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
+          // Don't need all the bytes, want some to let the length issue trigger.
+          0x01, 0x02, 0x03,
+        ])) {
+          XCTAssertEqual($0 as! BinaryDecodingError, BinaryDecodingError.tooLarge)
+        }
+
         let empty = MessageTestType()
         var a = empty
         a.optionalBytes = Data()
@@ -975,6 +993,15 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
 
         assertDecodeFails([146, 1, 2, 8, 128])
         assertDecodeFails([146, 1, 1, 128])
+
+        // Ensure message field over 2GB fail to decode according to spec.
+        XCTAssertThrowsError(try MessageTestType(serializedBytes: [
+          146, 1, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
+          // Don't need all the bytes, want some to let the length issue trigger.
+          0x01, 0x02, 0x03,
+        ])) {
+          XCTAssertEqual($0 as! BinaryDecodingError, BinaryDecodingError.tooLarge)
+        }
 
         // Ensure storage is uniqued for clear.
         let c = MessageTestType.with {
@@ -1722,6 +1749,16 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         }
         assertDecodeFails([128, 3])
         assertDecodesAsUnknownFields([128, 3, 0])  // Wrong wire type (varint), valid as an unknown field
+
+        // Ensure message field over 2GB fail to decode according to spec.
+        XCTAssertThrowsError(try MessageTestType(serializedBytes: [
+          130, 3, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F,
+          // Don't need all the bytes, want some to let the length issue trigger.
+          0x01, 0x02, 0x03,
+        ])) {
+          XCTAssertEqual($0 as! BinaryDecodingError, BinaryDecodingError.tooLarge)
+        }
+
         assertDebugDescription("SwiftProtobufTests.ProtobufUnittest_TestAllTypes:\nrepeated_nested_message {\n  bb: 1\n}\nrepeated_nested_message {\n  bb: 2\n}\n") {(o: inout MessageTestType) in
             var m1 = MessageTestType.NestedMessage()
             m1.bb = 1


### PR DESCRIPTION
This probably takes care of the uses listed in #1377, but it might not hurt to consider updating that to full deal with the mixed use of `Int` for things.
