### PR TITLE
Allow target relative path to protoc in SPM Plugin

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -104,7 +104,13 @@ struct SwiftProtobufPlugin: BuildToolPlugin {
         let protocPath: Path
         if let configuredProtocPath = configuration.protocPath {
             // The user set the config path in the file. So let's take that
-            protocPath = Path(configuredProtocPath)
+            if configuredProtocPath.hasPrefix("/") {
+                // An absolute path has been provided
+                protocPath = Path(configuredProtocPath)
+            } else {
+                // Not an absolute path, assume it is relative to the target's directory
+                protocPath = target.directory.appending(subpath: configuredProtocPath)
+            }
         } else if let environmentPath = ProcessInfo.processInfo.environment["PROTOC_PATH"] {
             // The user set the env variable. So let's take that
             protocPath = Path(environmentPath)


### PR DESCRIPTION
### Problem
SPM currently requires an absolute path to be passed to the build command.  This is not ideal for situations where `protoc` is in a directory of the repository - e.g. `../tools/protoc`.

### Solution
This adds a check to the user provided `protocPath`.  When the provided path is not absolute, it assumes the provided path is relative to the target directory and adds the target directory as the path's prefix. 