### PR TITLE
Add ExtraModuleImports option

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -161,6 +161,16 @@ mapping {
 The `proto_file_path` values here should match the paths used in the proto file
 `import` statements.
 
+##### Generation Option: `ExtraModuleImports` - Swift import names
+
+Allows specifying extra modules to declare as imports in the generated code.
+
+```
+$ protoc --swift_opt=ExtraModuleImports=ExampleModuleOne --swift_opt=ExtraModuleImports=ExampleModuleTwo --swift_out=. foo/bar/*.proto
+```
+
+Note: most users will not need to use this option.
+
 ### Building your project
 
 After copying the `.pb.swift` files into your project, you will need

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -100,6 +100,12 @@ class FileGenerator {
                 p.print("import \(i)")
             }
         }
+        if let neededCustomImports = generatorOptions.extraModuleImports {
+            p.print()
+            for i in neededCustomImports {
+                p.print("import \(i)\n")
+            }
+        }
 
         p.print()
         generateVersionCheck(printer: &p)

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -100,7 +100,8 @@ class FileGenerator {
                 p.print("import \(i)")
             }
         }
-        if let neededCustomImports = generatorOptions.extraModuleImports {
+        let neededCustomImports = generatorOptions.extraModuleImports
+        if !neededCustomImports.isEmpty{
             p.print()
             for i in neededCustomImports {
                 p.print("import \(i)\n")

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -49,7 +49,7 @@ class GeneratorOptions {
   let outputNaming: OutputNaming
   let protoToModuleMappings: ProtoFileToModuleMappings
   let visibility: Visibility
-  let extraModuleImports: [String]?
+  let extraModuleImports: [String]
 
   /// A string snippet to insert for the visibility
   let visibilitySourceSnippet: String
@@ -91,14 +91,14 @@ class GeneratorOptions {
                                                       value: pair.value)
         }
       case "ExtraModuleImports":
-      if !pair.value.isEmpty {
-          externalModuleImports.append(pair.value)
-      } else {
-        throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
-      }
-      default:
-        throw GenerationError.unknownParameter(name: pair.key)
-      }
+        if !pair.value.isEmpty {
+            externalModuleImports.append(pair.value)
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+        }
+        default:
+          throw GenerationError.unknownParameter(name: pair.key)
+        }
     }
 
     if let moduleMapPath = moduleMapPath {

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -49,6 +49,7 @@ class GeneratorOptions {
   let outputNaming: OutputNaming
   let protoToModuleMappings: ProtoFileToModuleMappings
   let visibility: Visibility
+  let extraModuleImports: [String]?
 
   /// A string snippet to insert for the visibility
   let visibilitySourceSnippet: String
@@ -58,6 +59,7 @@ class GeneratorOptions {
     var moduleMapPath: String?
     var visibility: Visibility = .internal
     var swiftProtobufModuleName: String? = nil
+    var externalModuleImports: [String] = []
 
     for pair in parseParameter(string:parameter) {
       switch pair.key {
@@ -88,6 +90,12 @@ class GeneratorOptions {
           throw GenerationError.invalidParameterValue(name: pair.key,
                                                       value: pair.value)
         }
+      case "ExtraModuleImports":
+      if !pair.value.isEmpty {
+          externalModuleImports.append(pair.value)
+      } else {
+        throw GenerationError.invalidParameterValue(name: pair.key, value: pair.value)
+      }
       default:
         throw GenerationError.unknownParameter(name: pair.key)
       }
@@ -107,6 +115,7 @@ class GeneratorOptions {
 
     self.outputNaming = outputNaming
     self.visibility = visibility
+    self.extraModuleImports = externalModuleImports
 
     switch visibility {
     case .internal:


### PR DESCRIPTION
Adds `ExtraModuleImports` generator option, just [like that present in the gRPC plugin](https://github.com/grpc/grpc-swift/blob/75b390e901c7d70af9b4c5ca2677e035f00cd1ab/Sources/protoc-gen-grpc-swift/options.swift#L64)
 & [connect-swift plugin](https://github.com/bufbuild/connect-swift/blob/ed165049ecd6e111e8bb2834a14292719556d0f8/Plugins/ConnectPluginUtilities/GeneratorOptions.swift#L109)