### PR TITLE
Fix compilation for web assembly

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -14,11 +14,13 @@
 // -----------------------------------------------------------------------------
 
 import Foundation
+#if !os(WASI)
 #if canImport(Dispatch)
 import Dispatch
 fileprivate var knownTypesQueue =
     DispatchQueue(label: "org.swift.protobuf.typeRegistry",
                   attributes: .concurrent)
+#endif
 #endif
 
 // TODO: Should these first four be exposed as methods to go with


### PR DESCRIPTION
When compiling for web assembly on linux it currently gives this error. `swift-protobuf/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift:20:5: error: cannot find 'DispatchQueue' in scope`. Adding `#if !os(WASI)` should fix this issue. Note it is also being used this way in [foundation]( https://github.com/apple/swift-corelibs-foundation/blob/818de4858f3c3f72f75d25fbe94d2388ca653f18/Sources/Foundation/NSIndexSet.swift#L10)