### PR TITLE
Update 1.x podspec to work with Xcode 14.3

### DIFF
--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 


### PR DESCRIPTION
Fixes #1401.

As discussed in the issue, Xcode 14.3 no longer contains libarclite-*.a and podspecs targeting macOS 10.9 and 10.10 fail.  There's limited traction on Cocoapods to implement a fix and this impacts our podspec maintainers' ability to release their specs and users' ability to consume them.

There are currently 10 projects in the Cocoapods spec repo that target 10.10 or below and none are actively maintained.  Similarly, Xcode has dropped official support for 10.10 and below for several years.