### PR TITLE
Remove unnecessary try/throw in SPM Plugin

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -116,8 +116,8 @@ struct SwiftProtobufPlugin {
         }
         let protocGenSwiftPath = try tool("protoc-gen-swift").path
         
-        return try configuration.invocations.map { invocation in
-            try self.invokeProtoc(
+        return configuration.invocations.map { invocation in
+            self.invokeProtoc(
                 directory: configurationFilePath.removingLastComponent(),
                 invocation: invocation,
                 protocPath: protocPath,
@@ -142,7 +142,7 @@ struct SwiftProtobufPlugin {
         protocPath: Path,
         protocGenSwiftPath: Path,
         outputDirectory: Path
-    ) throws -> Command {
+    ) -> Command {
         // Construct the `protoc` arguments.
         var protocArgs = [
             "--plugin=protoc-gen-swift=\(protocGenSwiftPath)",


### PR DESCRIPTION
While reviewing the patched code for the release branch, noticed some unnecessary try/throws in the `invoke` method. Removing those in this PR. This has already been applied in the release branch PR.