### PR TITLE
Add explicit Dynamic and Static product libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,16 @@ let package = Package(
         targets: ["SwiftProtobuf"]
     ),
     .library(
+        name: "SwiftProtobufDynamic",
+        type: .dynamic,
+        targets: ["SwiftProtobuf"]
+    ),
+    .library(
+        name: "SwiftProtobufStatic",
+        type: .static,
+        targets: ["SwiftProtobuf"]
+    ),
+    .library(
         name: "SwiftProtobufPluginLibrary",
         targets: ["SwiftProtobufPluginLibrary"]
     ),


### PR DESCRIPTION
SwiftPM promises it can always correctly detect what library type (dynamic or static) should be use in the project. It is the case when all dependencies are given as a source code.
This is not always possible if some of the dependencies are binary targets. In that case SPM is not able to figure out what libraries are compiled (or linked) inside the binary. In that case SPM cannot properly resolve dependencies and set proper linking type for used libraries.
Currently there is also no easy way to list those dependencies for binary targets.

In this PR we propose to add explicit targets that provide required linking:
- SwiftProtobufDynamic for dynamic linking
- SwiftProtobufStatic for static linking

Those new targets will not break current setups and allow to manually manage dependencies if SPM cannot handle them properly by itself. 