### PR TITLE
Provide better errors for the SPM plugin (1.x branch)

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -4,13 +4,27 @@ import PackagePlugin
 @main
 struct SwiftProtobufPlugin {
     /// Errors thrown by the `SwiftProtobufPlugin`
-    enum PluginError: Error {
+    enum PluginError: Error, CustomStringConvertible {
         /// Indicates that the target where the plugin was applied to was not `SourceModuleTarget`.
-        case invalidTarget
+        case invalidTarget(Target)
         /// Indicates that the file extension of an input file was not `.proto`.
-        case invalidInputFileExtension
+        case invalidInputFileExtension(String)
         /// Indicates that there was no configuration file at the required location.
-        case noConfigFound
+        case noConfigFound(String)
+
+        var description: String {
+            switch self {
+            case let .invalidTarget(target):
+                return "Expected a SwiftSourceModuleTarget but got '\(type(of: target))'."
+            case let .invalidInputFileExtension(path):
+                return "The input file '\(path)' does not have a '.proto' extension."
+            case let .noConfigFound(path):
+                return """
+                    No configuration file found named '\(path)'. The file must not be listed in the \
+                    'exclude:' argument for the target in Package.swift.
+                    """
+            }
+        }
     }
 
     /// The configuration of the plugin.
@@ -85,7 +99,7 @@ struct SwiftProtobufPlugin {
     }
 
     static let configurationFileName = "swift-protobuf-config.json"
-    
+
     /// Create build commands for the given arguments
     /// - Parameters:
     ///   - pluginWorkDirectory: The path of a writable directory into which the plugin or the build
@@ -103,7 +117,7 @@ struct SwiftProtobufPlugin {
                 $0.path.lastComponent == Self.configurationFileName
             }
         )?.path else {
-            throw PluginError.noConfigFound
+            throw PluginError.noConfigFound(Self.configurationFileName)
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: "\(configurationFilePath)"))
         let configuration = try JSONDecoder().decode(Configuration.self, from: data)
@@ -128,7 +142,7 @@ struct SwiftProtobufPlugin {
             protocPath = try tool("protoc").path
         }
         let protocGenSwiftPath = try tool("protoc-gen-swift").path
-        
+
         return configuration.invocations.map { invocation in
             self.invokeProtoc(
                 directory: targetDirectory,
@@ -184,7 +198,7 @@ struct SwiftProtobufPlugin {
         if let implementationOnlyImports = invocation.implementationOnlyImports {
             protocArgs.append("--swift_opt=ImplementationOnlyImports=\(implementationOnlyImports)")
         }
-        
+
         var inputFiles = [Path]()
         var outputFiles = [Path]()
 
@@ -221,7 +235,7 @@ struct SwiftProtobufPlugin {
         for invocation in configuration.invocations {
             for protoFile in invocation.protoFiles {
                 if !protoFile.hasSuffix(".proto") {
-                    throw PluginError.invalidInputFileExtension
+                    throw PluginError.invalidInputFileExtension(protoFile)
                 }
             }
         }
@@ -234,7 +248,7 @@ extension SwiftProtobufPlugin: BuildToolPlugin {
         target: Target
     ) async throws -> [Command] {
         guard let swiftTarget = target as? SwiftSourceModuleTarget else {
-            throw PluginError.invalidTarget
+            throw PluginError.invalidTarget(target)
         }
         return try createBuildCommands(
             pluginWorkDirectory: context.pluginWorkDirectory,

--- a/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
+++ b/Sources/protoc-gen-swift/Docs.docc/spm-plugin.md
@@ -51,7 +51,7 @@ let package = Package(
 
 ### Configuring the plugin
 
-Configuring the plugin is done by adding a `swift-protobuf-config.json` file anywhere in your target's sources. 
+Configuring the plugin is done by adding a `swift-protobuf-config.json` file anywhere in your target's sources.
 Before you start configuring the plugin, you need to add the `.proto` files to your sources. You should also commit these
 files to your git repository since the generated types are now generated on demand.
 It's also important to note that the proto files in your configuration should be in
@@ -92,8 +92,8 @@ So, the configuration file would look something like this:
 }
 
 ```
-As you can see in the above configuration, the paths are relative with respect to the `ProtoBuf` folder and not the root folder. 
-If you add a file in the `Sources` folder, the plugin would be unable to access it as the path is computed relative to 
+As you can see in the above configuration, the paths are relative with respect to the `ProtoBuf` folder and not the root folder.
+If you add a file in the `Sources` folder, the plugin would be unable to access it as the path is computed relative to
 the `swift-protobuf-config.json` file.
 
 > Note: paths to your `.proto` files will have to include the relative path from the config file directory to the `.proto` file location.
@@ -107,10 +107,10 @@ problems where a single target contains two or more proto files with the same na
 
 ### Defining the path to the protoc binary
 
-The plugin needs to be able to invoke the `protoc` binary to generate the Swift types. There are several ways to achieve this. 
+The plugin needs to be able to invoke the `protoc` binary to generate the Swift types. There are several ways to achieve this.
 
-First, by default, the package manager looks into the `$PATH` to find binaries named `protoc`. 
-This works immediately if you use `swift build` to build your package and `protoc` is installed 
+First, by default, the package manager looks into the `$PATH` to find binaries named `protoc`.
+This works immediately if you use `swift build` to build your package and `protoc` is installed
 in the `$PATH` (`brew` is adding it to your `$PATH` automatically).
 However, this doesn't work if you want to compile from Xcode since Xcode is not passed the `$PATH`.
 
@@ -140,7 +140,15 @@ env PROTOC_PATH=/opt/homebrew/bin/protoc xcodebuild <Here goes your command>
 }
 ```
 
-> Warning: The configuration file option only solves the problem for leaf packages that are using the Swift package manager
-plugin since there you can point the package manager to the right binary. The environment variable
-does solve the problem for transitive packages as well; however, it requires your users to set
-the variable now. In general we advise against adopting the plugin as a non-leaf package!
+### Known Issues
+
+- The configuration file _must not_ be excluded from the list of sources for the
+  target in the package manifest (that is, it should not be present in the
+  `exclude` argument for the target). The build system does not have access to
+  the file if it is excluded, however, `swift build` will result in a warning
+  that the file should be excluded.
+- The plugin should only be used for leaf packages. The configuration file option
+  only solves the problem for leaf packages that are using the Swift package
+  manager plugin since there you can point the package manager to the right
+  binary. The environment variable does solve the problem for transitive
+  packages as well; however, it requires your users to set the variable now.


### PR DESCRIPTION
Motivation:

The SPM plugin errors are not all that clear. We also discovered that including the SPM configuration file in the `exclude` list for a target results in the plugin failing with `notFound`. However, not including it in the `exclude` list yields a build warning.

Modifications:

- Not the known warning
- Improve errors

Result:

Clearer errors for the SPM plugin.