### PR TITLE
Add a 5.8 Package.swift file for the 1.x branch

### DIFF
--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.6
+
+// Package.swift
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftProtobuf",
+  products: [
+    .executable(name: "protoc-gen-swift", targets: ["protoc-gen-swift"]),
+    .library(name: "SwiftProtobuf", targets: ["SwiftProtobuf"]),
+    .library(name: "SwiftProtobufPluginLibrary", targets: ["SwiftProtobufPluginLibrary"]),
+    .plugin(
+        name: "SwiftProtobufPlugin",
+        targets: ["SwiftProtobufPlugin"]
+    ),
+  ],
+  targets: [
+    .target(name: "SwiftProtobuf"),
+    .target(name: "SwiftProtobufPluginLibrary",
+            dependencies: ["SwiftProtobuf"]),
+    .executableTarget(name: "protoc-gen-swift",
+            dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"]),
+    .executableTarget(name: "Conformance",
+            dependencies: ["SwiftProtobuf"]),
+    .plugin(
+        name: "SwiftProtobufPlugin",
+        capability: .buildTool(),
+        dependencies: [
+            "protoc-gen-swift"
+        ]
+    ),
+    .testTarget(name: "SwiftProtobufTests",
+                dependencies: ["SwiftProtobuf"]),
+    .testTarget(name: "SwiftProtobufPluginLibraryTests",
+                dependencies: ["SwiftProtobufPluginLibrary"]),
+  ],
+  swiftLanguageVersions: [.v4, .v4_2, .version("5")]
+)


### PR DESCRIPTION
The branch still goes back to some 4.x versions, so just copy the existing 5.x specific files to avoid warnings when building with current released toolchains.