### PR TITLE
Make it easier to copy/paste shell examples

### DIFF
--- a/Documentation/CONFORMANCE_TESTS.md
+++ b/Documentation/CONFORMANCE_TESTS.md
@@ -30,14 +30,14 @@ environment variable to the full path of the protobuf checkout.
 If the Makefile can find the protobuf project sources, then
 the following should suffice:
 ```console
-$ make test
+make test
 ```
 This will build and run the SwiftProtobuf test suite,
 verify the code generator, and finally run the conformance tests.
 
 You can also run the conformance tests by themselves:
 ```console
-$ make test-conformance
+make test-conformance
 ```
 
 ## Test Environment
@@ -54,7 +54,7 @@ GOOGLE_PROTOBUF_CHECKOUT?=../protobuf
 If these do not match your system, you can specify one or both
 on the command line
 ```
-$ make PROTOC=[path] GOOGLE_PROTOBUF_CHECKOUT=[path] test
+make PROTOC=[path] GOOGLE_PROTOBUF_CHECKOUT=[path] test
 ```
 
 ## If you have problems
@@ -64,16 +64,16 @@ program.  You may find it easier to switch to the directory where you
 have checked out Google's protobuf sources and build the host program
 manually:
 ```console
-$ cd protobuf
-$ ./configure
-$ make -C src
-$ make -C conformance
+cd protobuf
+./configure
+make -C src
+make -C conformance
 ```
 
 You can then manually run the conformance test using the following commands:
 ```console
-$ cd swift-protobuf
-$ ../protobuf/conformance/conformance-test-runner --failure_list failure_list_swift.txt .build/debug/Conformance
+cd swift-protobuf
+../protobuf/conformance/conformance-test-runner --failure_list failure_list_swift.txt .build/debug/Conformance
 ```
 
 ## Known Issues

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -32,9 +32,9 @@ To use Swift with Protocol buffers, you'll need:
 Building the plugin should be simple on any supported Swift platform:
 
 ```
-$ git clone https://github.com/apple/swift-protobuf
-$ cd swift-protobuf
-$ swift build -c release
+git clone https://github.com/apple/swift-protobuf
+cd swift-protobuf
+swift build -c release
 ```
 
 This will create a binary called `protoc-gen-swift` in the
@@ -51,7 +51,7 @@ To generate Swift output for your .proto files, you run the `protoc`
 command as usual, using the `--swift_out=<directory>` option:
 
 ```
-$ protoc --swift_out=. my.proto
+protoc --swift_out=. my.proto
 ```
 
 The `protoc` program will automatically look for `protoc-gen-swift` in your
@@ -69,13 +69,13 @@ specific needs.
 You can use the `--swift_opt` argument to `protoc` to pass options to the
 Swift code generator as follows:
 ```
-$ protoc --swift_opt=[NAME]=[VALUE] --swift_out:. foo/bar/*.proto mumble/*.proto
+protoc --swift_opt=[NAME]=[VALUE] --swift_out:. foo/bar/*.proto mumble/*.proto
 ```
 
 If you need to specify multiple options, you can use more than one
 `--swift_opt` argument:
 ```
-$ protoc \
+protoc \
     --swift_opt=[NAME1]=[VALUE1] \
     --swift_opt=[NAME2]=[VALUE2] \
     --swift_out=. foo/bar/*.proto mumble/*.proto
@@ -96,7 +96,7 @@ supports an option to control the generated file names, the option is
 given as part of the `--swift_opt` argument like this:
 
 ```
-$ protoc --swift_opt=FileNaming=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
+protoc --swift_opt=FileNaming=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 The possible values for `FileNaming` are:
@@ -117,7 +117,7 @@ up with the default (`internal`) access.  You can change this with the
 `Visibility` option:
 
 ```
-$ protoc --swift_opt=Visibility=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
+protoc --swift_opt=Visibility=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 The possible values for `Visibility` are:
@@ -139,7 +139,7 @@ generation to then `import` the module and scope the types. This option
 takes the path of a file providing the mapping:
 
 ```
-$ protoc --swift_opt=ProtoPathModuleMappings=[path.asciipb] --swift_out=. foo/bar/*.proto
+protoc --swift_opt=ProtoPathModuleMappings=[path.asciipb] --swift_out=. foo/bar/*.proto
 ```
 
 The format of that mapping file is defined in
@@ -171,7 +171,7 @@ avoid exposing internal symbols to clients.
 You can change this with the `ImplementationOnlyImports` option:
 
 ```
-$ protoc --swift_opt=ImplementationOnlyImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
+protoc --swift_opt=ImplementationOnlyImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 The possible values for `ImplementationOnlyImports` are:

--- a/Documentation/RELEASING.md
+++ b/Documentation/RELEASING.md
@@ -31,7 +31,7 @@ When doing a release:
    1. Run our tool to ensure the versions are all in sync:
 
       ```
-      $ DevTools/LibraryVersions.py --validate
+      DevTools/LibraryVersions.py --validate
       ```
 
       This will run silently if everything was ok; if something was wrong, you'll need to figure
@@ -51,7 +51,7 @@ When doing a release:
 1. Publish the `SwiftProtobuf.podspec`
 
       ```
-      $ pod trunk push SwiftProtobuf.podspec
+      pod trunk push SwiftProtobuf.podspec
       ```
 
       _Note:_ This uses that local copy of `SwiftProtobuf.podspec`, but checks
@@ -63,7 +63,7 @@ When doing a release:
    bump it to a new revision:
 
    ```
-   $ DevTools/LibraryVersions.py [a.b.c]
+   DevTools/LibraryVersions.py [a.b.c]
    ```
 
    Where _c_ is one higher than the release that was just done.

--- a/README.md
+++ b/README.md
@@ -110,23 +110,23 @@ protoc compiler and the SwiftProtobuf code generator plugin.
 Building the plugin should be simple on any supported Swift platform:
 
 ```
-$ git clone https://github.com/apple/swift-protobuf.git
-$ cd swift-protobuf
+git clone https://github.com/apple/swift-protobuf.git
+cd swift-protobuf
 ```
 
 Pick what released version of SwiftProtobuf you are going to use.  You can get
 a list of tags with:
 
 ```
-$ git tag -l
+git tag -l
 ```
 
 Once you pick the version you will use, set your local state to match, and
 build the protoc plugin:
 
 ```
-$ git checkout tags/[tag_name]
-$ swift build -c release
+git checkout tags/[tag_name]
+swift build -c release
 ```
 
 This will create a binary called `protoc-gen-swift` in the `.build/release`
@@ -144,7 +144,7 @@ to use also use `--static-swift-stdlib` with `swift build`.
 If you prefer using [Homebrew](https://brew.sh):
 
 ```
-$ brew install swift-protobuf
+brew install swift-protobuf
 ```
 
 This will install `protoc` compiler and Swift code generator plugin.
@@ -155,7 +155,7 @@ To generate Swift output for your .proto files, you run the `protoc` command as
 usual, using the `--swift_out=<directory>` option:
 
 ```
-$ protoc --swift_out=. my.proto
+protoc --swift_out=. my.proto
 ```
 
 The `protoc` program will automatically look for `protoc-gen-swift` in your
@@ -241,7 +241,7 @@ message BookInfo {
 
 Then generate Swift code using:
 ```
-$ protoc --swift_out=. DataModel.proto
+protoc --swift_out=. DataModel.proto
 ```
 
 The generated code will expose a Swift property for


### PR DESCRIPTION
It's easier for folks to copy/paste full lines, so we should prefer to omit the `$` shell prompt on shell examples.

Resolves #1435