### PR TITLE
Update supported Swift/Xcode Versions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,25 +29,11 @@ jobs:
         - 5.8.1-jammy
         - 5.7.3-jammy
         - 5.6.3-focal
-        - 5.5.3-focal
-        - 5.4.3-focal
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"
         # branch: "ref/heads/main"
         protobuf_git: ["ref/heads/main"]
-        # We are not testing the SPM plugins on Swift version that don't support SPM plugins
-        include:
-          - swift: 5.8.1-jammy
-            test_spm_plugin: true
-          - swift: 5.7.3-jammy
-            test_spm_plugin: true
-          - swift: 5.6.3-focal
-            test_spm_plugin: true
-          - swift: 5.5.3-focal
-            test_spm_plugin: false
-          - swift: 5.4.3-focal
-            test_spm_plugin: false
     container:
       image: swift:${{ matrix.swift }}
     steps:
@@ -114,7 +100,6 @@ jobs:
       working-directory: main
       run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner
     - name: Test SPM plugin
-      if: ${{ matrix.test_spm_plugin }}
       working-directory: main
       run: make test-spm-plugin PROTOC=../protobuf/cmake_build/protoc
 

--- a/Documentation/INTERNALS.md
+++ b/Documentation/INTERNALS.md
@@ -17,27 +17,13 @@ behavior are always appreciated.
 
 ## Swift Language Support
 
-We guarantee support for Swift versions that are up to one year old.
-For example, in March 2022 (when Swift 5.6 was released), we still
-guaranteed support for Swift 5.3.3 (released in January 2021, and still
-current in March 2021).
-Support for Swift versions older than one year is at the discretion
-of the SwiftProtobuf developers and will depend on the amount of
-effort required to maintain such support.
-We do not as a rule expect to support Swift versions more than two years
-old in any case.
+SwiftProtobuf tries to support back to the oldest of:
 
-(Originally, we tried to gaurantee "one full major version", which
-was essentially the same as "one year" until Swift 5, at which point
-we discovered that managing CI for 4-year-old releases was rather
-problematic.)
-
-Having said that, the issue is complicated by the fact that there are _toolchain
-versions_ and _language versions_.  As of Swift toolchain 5.x, the 4.2 _language
-version_ is still supported. In that case of SwiftProtobuf, there's the question
-of what _language version_ the core library supports, but also what _language
-versions_ the generated code need to compile (since that code ends up in
-whatever target developers pick).
+*  The
+   [Swift NIO guidelines support version](https://github.com/apple/swift-nio#supported-versions).
+*  Apple’s App Store submission requirements. This is announced on the
+   [Apple Developer News](https://developer.apple.com/news/) page; an
+   [example from March 2023](https://developer.apple.com/news/?id=jd9wcyov).
 
 When the minimum Swift version gets updated, update:
 - The `README.md` in the root of the project
@@ -47,6 +33,16 @@ When the minimum Swift version gets updated, update:
 - Update `Package.swift` and `SwiftProtobuf.podspec` files to list the
   versions supported. Eventually the version specific `Package@*.swift`
   files will go away.
+
+  NOTE: As the minimum Xcode version updates, that also implicitly updates
+  the minimum supports Apple OS versions. Those updates also go into the
+  podspec file. If the an older Xcode might support the NIO Swift version,
+  we still listed the lower Swift version but higher Xcode version in the
+  `README.md` and we adopt the deployment minimums from the Xcode in
+  `SwiftProtobuf.podspec`.
+
+  The deployment minimums for Xcode versions can be found on the [Developer
+  Support: Xcode](https://developer.apple.com/support/xcode/) page.
 
 ## Field Storage
 

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -19,9 +19,8 @@ Swift runtime library to your project.
 
 To use Swift with Protocol buffers, you'll need:
 
-* A recent Swift 4.0 compiler that includes the Swift Package Manager.
-  We recommend using the latest release build from
-  [Swift.org](https://swift.org) or the command-line tools included
+* A recent Swift compiler. We recommend using the latest release build
+  from [Swift.org](https://swift.org) or the command-line tools included
   with the latest version of Xcode.
 
 * Google's protoc compiler.  You can get recent versions from
@@ -40,10 +39,6 @@ swift build -c release
 This will create a binary called `protoc-gen-swift` in the
 `.build/release` directory.  To install, just copy this one executable
 anywhere in your PATH.
-
-NOTE: The Swift runtime support is now included with macOS. If you are
-using old Xcode versions or are on older system versions, you might need
-to use also use `--static-swift-stdlib` with `swift build`.
 
 ### Converting .proto files into Swift
 
@@ -165,8 +160,8 @@ The `proto_file_path` values here should match the paths used in the proto file
 ##### Generation Option: `ImplementationOnlyImports` - `@_implementationOnly`-annotated imports
 
 By default, SwiftProtobuf does not annotate any imports with `@_implementationOnly`.
-However, in some scenarios, such as when distributing an `XCFramework`, imports 
-for types used only internally should be annotated as `@_implementationOnly` to 
+However, in some scenarios, such as when distributing an `XCFramework`, imports
+for types used only internally should be annotated as `@_implementationOnly` to
 avoid exposing internal symbols to clients.
 You can change this with the `ImplementationOnlyImports` option:
 
@@ -178,11 +173,11 @@ The possible values for `ImplementationOnlyImports` are:
 
 * `false` (default): The `@_implementationOnly` annotation will never be used.
 * `true`: Imports of internal dependencies and any modules defined in the module
-mappings will be annotated as `@_implementationOnly`. 
+mappings will be annotated as `@_implementationOnly`.
 
-**Important:** Modules cannot be imported as implementation-only if they're 
+**Important:** Modules cannot be imported as implementation-only if they're
 exposed via public API, so even if `ImplementationOnlyImports` is set to `true`,
-this will only work if the `Visibility` is set to `internal`.  
+this will only work if the `Visibility` is set to `internal`.
 
 
 ### Building your project

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ your project as explained below.
 
 To use Swift with Protocol buffers, you'll need:
 
-* A Swift 5.0 or later compiler (Xcode 10.2 or later).  Support is included for
-  the Swift Package Manager. The Swift protobuf project is being developed and
-  tested against the latest release version of Swift available from
+* A Swift 5.6 or later compiler (or, if building with Xcode, Xcode 14.1 or later
+  as required by the App Store). The Swift protobuf project is being developed
+  and tested against the latest release version of Swift available from
   [Swift.org](https://swift.org)
 
 * Google's protoc compiler.  The Swift protoc plugin is being actively developed

--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -8,10 +8,10 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/apple/swift-protobuf.git', :tag => s.version }
 
   s.requires_arc = true
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
-  s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '11.0'
+  s.watchos.deployment_target = '4.0'
 
   s.cocoapods_version = '>= 1.7.0'
 


### PR DESCRIPTION
Update the documentation to reflect that we will try to support the older of the Swift NIO supported version and the minimum Xcode version supported for the Apple AppStore.

As of today, that means:

- Swift NIO: Swift 5.6 - https://github.com/apple/swift-nio#swiftnio-2
- AppStore: Xcode 14.1 - https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,or%20later.

Xcode 14.1 included Swift 5.7. So we'll support Swift 5.6+, but the Apple deployment minimums are moved up to the values from Xcode 14.1.

In addition to the documentation updates, this commit also:

- Updates the main Package.swift and SwiftProtobuf.podspec for the new deployment minimums.
- Updates the CI setup to the minimum Swift version.

NOTE: There are no code changes in this commit, once this CL is landed, the code changes will be done in follow ups since there are generation changes.