### PR TITLE
Add `Sendable` to more places that folks might want it.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for binary decoding.
-public struct BinaryDecodingOptions {
+public struct BinaryDecodingOptions: Sendable {
   /// The maximum nesting of message with messages.  The default is 100.
   ///
   /// To prevent corrupt or malicious messages from causing stack overflows,

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -22,7 +22,7 @@
 /// This is a protocol so that developers can build their own
 /// extension handling if they need something more complex than the
 /// standard `SimpleExtensionMap` implementation.
-public protocol ExtensionMap {
+public protocol ExtensionMap: Sendable {
     /// Returns the extension object describing an extension or nil
     subscript(messageType: Message.Type, fieldNumber: Int) -> AnyMessageExtension? { get }
 

--- a/Sources/SwiftProtobuf/JSONDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONDecodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for JSONDecoding.
-public struct JSONDecodingOptions {
+public struct JSONDecodingOptions: Sendable {
   /// The maximum nesting of message with messages.  The default is 100.
   ///
   /// To prevent corrupt or malicious messages from causing stack overflows,

--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for JSONEncoding.
-public struct JSONEncodingOptions {
+public struct JSONEncodingOptions: Sendable {
 
   /// Always prints int64s values as numbers.
   /// By default, they are printed as strings as per proto3 JSON mapping rules.

--- a/Sources/SwiftProtobuf/MessageExtension.swift
+++ b/Sources/SwiftProtobuf/MessageExtension.swift
@@ -15,10 +15,8 @@
 ///
 // -----------------------------------------------------------------------------
 
-// TODO: `AnyMessageExtension` should require `Sendable` but we cannot do so yet without possibly breaking compatibility.
-
 /// Type-erased MessageExtension field implementation.
-public protocol AnyMessageExtension {
+public protocol AnyMessageExtension: Sendable {
     var fieldNumber: Int { get }
     var fieldName: String { get }
     var messageType: Message.Type { get }
@@ -28,7 +26,7 @@ public protocol AnyMessageExtension {
 /// A "Message Extension" relates a particular extension field to
 /// a particular message.  The generic constraints allow
 /// compile-time compatibility checks.
-public class MessageExtension<FieldType: ExtensionField, MessageType: Message>: AnyMessageExtension {
+public final class MessageExtension<FieldType: ExtensionField, MessageType: Message>: AnyMessageExtension {
     public let fieldNumber: Int
     public let fieldName: String
     public let messageType: Message.Type

--- a/Sources/SwiftProtobuf/TextFormatDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for TextFormatDecoding.
-public struct TextFormatDecodingOptions {
+public struct TextFormatDecodingOptions: Sendable {
   /// The maximum nesting of message with messages.  The default is 100.
   ///
   /// To prevent corrupt or malicious messages from causing stack overflows,

--- a/Sources/SwiftProtobuf/TextFormatEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for TextFormatEncoding.
-public struct TextFormatEncodingOptions {
+public struct TextFormatEncodingOptions: Sendable {
 
   /// Default: Do print unknown fields using numeric notation
   public var printUnknownFields: Bool = true


### PR DESCRIPTION
The covers all places with the TODO comments from the first Sendable work.

Also ensure all the Decoding/Encoding Options types are marked Sendable.