### PR TITLE
Start on the 5.9 Sendable issues

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -17,7 +17,7 @@ import Foundation
 #if !os(WASI)
 #if canImport(Dispatch)
 import Dispatch
-fileprivate var knownTypesQueue =
+fileprivate let knownTypesQueue =
     DispatchQueue(label: "org.swift.protobuf.typeRegistry",
                   attributes: .concurrent)
 #endif

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -2583,7 +2583,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
     }
 
     func testWithFactoryHelperRethrows() {
-        class TestWithFactoryHelperRethrows_Error : Error {}
+        struct TestWithFactoryHelperRethrows_Error : Error {}
 
         let pNoThrow: (inout SwiftProtoTesting_ForeignMessage) -> () = { $0.c = 1 }
         let m1 = SwiftProtoTesting_ForeignMessage.with(pNoThrow)


### PR DESCRIPTION
`knownTypes` is still a problem within the Any code, but this takes care of all the other issues flagged at the moment.
