### PR TITLE
Remove some '@unchecked' usages.

### DIFF
--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -21,9 +21,7 @@ import Foundation
 /// implementation or were valid field numbers but with mismatching wire
 /// formats (for example, a field encoded as a varint when a fixed32 integer
 /// was expected).
-public struct UnknownStorage: Equatable, @unchecked Sendable {
-  // Once swift(>=5.7) the '@unchecked' can be removed, it is needed for Data.
-
+public struct UnknownStorage: Equatable, Sendable {
   /// The raw protocol buffer binary-encoded bytes that represent the unknown
   /// fields of a decoded message.
   public private(set) var data = Data()

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -828,7 +828,7 @@ struct ConflictingImportMessage:
     SwiftProtobuf.Message,
     SwiftProtobuf._MessageImplementationBase,
     SwiftProtobuf._ProtoNameProviding,
-    @unchecked Sendable {  // Once swift(>=5.7) the '@unchecked' can be removed, it is needed for Data.
+    Sendable {
   static let protoMessageName: String = "swift_proto_testing.import.ImportMessage"
 
   var unknownFields = SwiftProtobuf.UnknownStorage()


### PR DESCRIPTION
There were needed because of `Data` and Swift 5.6, but with 5.7 as a minimum they can go away.