### PR TITLE
Block more things

### DIFF
--- a/Reference/SwiftProtobufTests/generated_swift_names_enums.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_enums.pb.swift
@@ -8401,7 +8401,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Equatable: SwiftProtobuf.Enum {
+  enum EquatableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneEquatable // = 0
     case UNRECOGNIZED(Int)
@@ -8425,7 +8425,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Equatable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EquatableEnum] = [
       .noneEquatable,
     ]
 
@@ -12991,7 +12991,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Hashable: SwiftProtobuf.Enum {
+  enum HashableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneHashable // = 0
     case UNRECOGNIZED(Int)
@@ -13015,7 +13015,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Hashable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.HashableEnum] = [
       .noneHashable,
     ]
 
@@ -23221,7 +23221,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Sendable: SwiftProtobuf.Enum {
+  enum SendableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneSendable // = 0
     case UNRECOGNIZED(Int)
@@ -23245,7 +23245,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Sendable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SendableEnum] = [
       .noneSendable,
     ]
 
@@ -24571,7 +24571,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum {
+  enum SwiftEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneSwift // = 0
     case UNRECOGNIZED(Int)
@@ -24595,7 +24595,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Swift] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SwiftEnum] = [
       .noneSwift,
     ]
 
@@ -30775,7 +30775,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EnumValueOptio
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Equatable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EquatableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Equatable"),
   ]
@@ -31693,7 +31693,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.hash: SwiftPro
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Hashable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.HashableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Hashable"),
   ]
@@ -33739,7 +33739,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.semantic: Swif
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Sendable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SendableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Sendable"),
   ]
@@ -34009,7 +34009,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.subVisitor: Sw
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Swift: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SwiftEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Swift"),
   ]

--- a/Reference/SwiftProtobufTests/generated_swift_names_messages.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_messages.pb.swift
@@ -3379,7 +3379,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Equatable {
+  struct EquatableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -5215,7 +5215,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Hashable {
+  struct HashableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -9307,7 +9307,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Sendable {
+  struct SendableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -9847,7 +9847,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Swift {
+  struct SwiftMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -11931,7 +11931,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.enumType: @
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.enumvalue: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueDescriptorProto: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueOptions: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Error: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ExpressibleByArrayLiteral: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ExpressibleByDictionaryLiteral: @unchecked Sendable {}
@@ -12084,7 +12084,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasFieldPre
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasFullName: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasGoPackage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hash: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasher: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashVisitor: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasIdempotencyLevel: @unchecked Sendable {}
@@ -12425,7 +12425,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.scanner: @u
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.seconds: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.selfMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.semantic: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.separator: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.serialize: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.serializedBytes: @unchecked Sendable {}
@@ -12470,7 +12470,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.structValue
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subDecoder: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subscriptMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subVisitor: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.swiftPrefix: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftProtobufContiguousBytes: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.syntax: @unchecked Sendable {}
@@ -21573,7 +21573,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueOp
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Equatable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Equatable"),
@@ -21598,7 +21598,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: 
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage) -> Bool {
     if lhs.equatable != rhs.equatable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -26469,7 +26469,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hash: Swift
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Hashable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Hashable"),
@@ -26494,7 +26494,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: S
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage) -> Bool {
     if lhs.hashable != rhs.hashable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -37381,7 +37381,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.semantic: S
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Sendable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Sendable"),
@@ -37406,7 +37406,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: S
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage) -> Bool {
     if lhs.sendable != rhs.sendable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -38821,7 +38821,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subVisitor:
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Swift"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Swift"),
@@ -38846,7 +38846,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: Swif
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage) -> Bool {
     if lhs.swift != rhs.swift {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -2936,7 +2936,7 @@ struct SwiftProtoTesting_Names_MessageNames {
     fileprivate var _debugDescription_p: Int32? = nil
   }
 
-  struct Swift {
+  struct SwiftMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -7458,7 +7458,7 @@ struct SwiftProtoTesting_Names_EnumNames {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum {
+  enum SwiftEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSwift // = 0
 
@@ -12951,7 +12951,7 @@ extension SwiftProtoTesting_Names_MessageNames.UIntMessage: @unchecked Sendable 
 extension SwiftProtoTesting_Names_MessageNames.hashValueMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.descriptionMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.debugDescriptionMessage: @unchecked Sendable {}
-extension SwiftProtoTesting_Names_MessageNames.Swift: @unchecked Sendable {}
+extension SwiftProtoTesting_Names_MessageNames.SwiftMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.UNRECOGNIZED: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.classMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.deinitMessage: @unchecked Sendable {}
@@ -17814,7 +17814,7 @@ extension SwiftProtoTesting_Names_MessageNames.debugDescriptionMessage: SwiftPro
   }
 }
 
-extension SwiftProtoTesting_Names_MessageNames.Swift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Names_MessageNames.SwiftMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Names_MessageNames.protoMessageName + ".Swift"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Swift"),
@@ -17843,7 +17843,7 @@ extension SwiftProtoTesting_Names_MessageNames.Swift: SwiftProtobuf.Message, Swi
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Names_MessageNames.Swift, rhs: SwiftProtoTesting_Names_MessageNames.Swift) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Names_MessageNames.SwiftMessage, rhs: SwiftProtoTesting_Names_MessageNames.SwiftMessage) -> Bool {
     if lhs._swift != rhs._swift {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -25267,7 +25267,7 @@ extension SwiftProtoTesting_Names_EnumNames.debugDescriptionEnum: SwiftProtobuf.
   ]
 }
 
-extension SwiftProtoTesting_Names_EnumNames.Swift: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Names_EnumNames.SwiftEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "aSwift"),
   ]

--- a/Sources/SwiftProtobufPluginLibrary/NamingUtils.swift
+++ b/Sources/SwiftProtobufPluginLibrary/NamingUtils.swift
@@ -62,6 +62,16 @@ fileprivate let reservedTypeNames: Set<String> = {
   names.insert("Type")
   names.insert("Protocol")
 
+  // Getting something called "Swift" would be bad as it blocks access
+  // to built in things.
+  names.insert("Swift")
+
+  // And getting things on some of the common protocols could create
+  // some odd confusion.
+  names.insert("Equatable")
+  names.insert("Hashable")
+  names.insert("Sendable")
+
   names = names.union(swiftKeywordsUsedInDeclarations)
   names = names.union(swiftKeywordsUsedInStatements)
   names = names.union(swiftKeywordsUsedInExpressionsAndTypes)

--- a/Tests/SwiftProtobufTests/generated_swift_names_enums.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_enums.pb.swift
@@ -8401,7 +8401,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Equatable: SwiftProtobuf.Enum {
+  enum EquatableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneEquatable // = 0
     case UNRECOGNIZED(Int)
@@ -8425,7 +8425,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Equatable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EquatableEnum] = [
       .noneEquatable,
     ]
 
@@ -12991,7 +12991,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Hashable: SwiftProtobuf.Enum {
+  enum HashableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneHashable // = 0
     case UNRECOGNIZED(Int)
@@ -13015,7 +13015,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Hashable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.HashableEnum] = [
       .noneHashable,
     ]
 
@@ -23221,7 +23221,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Sendable: SwiftProtobuf.Enum {
+  enum SendableEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneSendable // = 0
     case UNRECOGNIZED(Int)
@@ -23245,7 +23245,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Sendable] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SendableEnum] = [
       .noneSendable,
     ]
 
@@ -24571,7 +24571,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum {
+  enum SwiftEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case noneSwift // = 0
     case UNRECOGNIZED(Int)
@@ -24595,7 +24595,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums {
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Swift] = [
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SwiftEnum] = [
       .noneSwift,
     ]
 
@@ -30775,7 +30775,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EnumValueOptio
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Equatable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.EquatableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Equatable"),
   ]
@@ -31693,7 +31693,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.hash: SwiftPro
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Hashable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.HashableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Hashable"),
   ]
@@ -33739,7 +33739,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.semantic: Swif
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Sendable: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SendableEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Sendable"),
   ]
@@ -34009,7 +34009,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.subVisitor: Sw
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.Swift: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.SwiftEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "NONE_Swift"),
   ]

--- a/Tests/SwiftProtobufTests/generated_swift_names_messages.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_messages.pb.swift
@@ -3379,7 +3379,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Equatable {
+  struct EquatableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -5215,7 +5215,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Hashable {
+  struct HashableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -9307,7 +9307,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Sendable {
+  struct SendableMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -9847,7 +9847,7 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages {
     init() {}
   }
 
-  struct Swift {
+  struct SwiftMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -11931,7 +11931,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.enumType: @
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.enumvalue: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueDescriptorProto: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueOptions: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Error: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ExpressibleByArrayLiteral: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ExpressibleByDictionaryLiteral: @unchecked Sendable {}
@@ -12084,7 +12084,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasFieldPre
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasFullName: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasGoPackage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hash: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasher: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashVisitor: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hasIdempotencyLevel: @unchecked Sendable {}
@@ -12425,7 +12425,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.scanner: @u
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.seconds: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.selfMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.semantic: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.separator: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.serialize: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.serializedBytes: @unchecked Sendable {}
@@ -12470,7 +12470,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.structValue
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subDecoder: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subscriptMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subVisitor: @unchecked Sendable {}
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: @unchecked Sendable {}
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.swiftPrefix: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftProtobufContiguousBytes: @unchecked Sendable {}
 extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.syntax: @unchecked Sendable {}
@@ -21573,7 +21573,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EnumValueOp
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Equatable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Equatable"),
@@ -21598,7 +21598,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable: 
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Equatable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.EquatableMessage) -> Bool {
     if lhs.equatable != rhs.equatable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -26469,7 +26469,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.hash: Swift
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Hashable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Hashable"),
@@ -26494,7 +26494,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable: S
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Hashable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.HashableMessage) -> Bool {
     if lhs.hashable != rhs.hashable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -37381,7 +37381,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.semantic: S
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Sendable"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Sendable"),
@@ -37406,7 +37406,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable: S
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Sendable) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SendableMessage) -> Bool {
     if lhs.sendable != rhs.sendable {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -38821,7 +38821,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.subVisitor:
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".Swift"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Swift"),
@@ -38846,7 +38846,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift: Swif
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.Swift) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.SwiftMessage) -> Bool {
     if lhs.swift != rhs.swift {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -2936,7 +2936,7 @@ struct SwiftProtoTesting_Names_MessageNames {
     fileprivate var _debugDescription_p: Int32? = nil
   }
 
-  struct Swift {
+  struct SwiftMessage {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -7458,7 +7458,7 @@ struct SwiftProtoTesting_Names_EnumNames {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum {
+  enum SwiftEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSwift // = 0
 
@@ -12951,7 +12951,7 @@ extension SwiftProtoTesting_Names_MessageNames.UIntMessage: @unchecked Sendable 
 extension SwiftProtoTesting_Names_MessageNames.hashValueMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.descriptionMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.debugDescriptionMessage: @unchecked Sendable {}
-extension SwiftProtoTesting_Names_MessageNames.Swift: @unchecked Sendable {}
+extension SwiftProtoTesting_Names_MessageNames.SwiftMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.UNRECOGNIZED: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.classMessage: @unchecked Sendable {}
 extension SwiftProtoTesting_Names_MessageNames.deinitMessage: @unchecked Sendable {}
@@ -17814,7 +17814,7 @@ extension SwiftProtoTesting_Names_MessageNames.debugDescriptionMessage: SwiftPro
   }
 }
 
-extension SwiftProtoTesting_Names_MessageNames.Swift: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Names_MessageNames.SwiftMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = SwiftProtoTesting_Names_MessageNames.protoMessageName + ".Swift"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "Swift"),
@@ -17843,7 +17843,7 @@ extension SwiftProtoTesting_Names_MessageNames.Swift: SwiftProtobuf.Message, Swi
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Names_MessageNames.Swift, rhs: SwiftProtoTesting_Names_MessageNames.Swift) -> Bool {
+  static func ==(lhs: SwiftProtoTesting_Names_MessageNames.SwiftMessage, rhs: SwiftProtoTesting_Names_MessageNames.SwiftMessage) -> Bool {
     if lhs._swift != rhs._swift {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -25267,7 +25267,7 @@ extension SwiftProtoTesting_Names_EnumNames.debugDescriptionEnum: SwiftProtobuf.
   ]
 }
 
-extension SwiftProtoTesting_Names_EnumNames.Swift: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Names_EnumNames.SwiftEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "aSwift"),
   ]


### PR DESCRIPTION
So if one tries to move say `Sendable` off the generated `extension [MessageName]` and declare it when the `struct` is declare, then things go comically wrong as the compiler decides we're trying to say all the other `struct`s try to use the local version of _Sendable_ which is another `struct`. And trying to scope it as `Swift.Sendable` also fails, because the locally defined `Swift` gets in the way.

I guess no one has ever really hit this in the field, but it seems better to play it safe and force any attempt to use these as type should get them remapped to avoid the potential confusion they will create.
