### PR TITLE
Mark all test classes as `final`.

### DIFF
--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -12,7 +12,7 @@ import XCTest
 import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 
-class Test_Descriptor: XCTestCase {
+final class Test_Descriptor: XCTestCase {
 
   func testParsing() throws {
     let fileSet = try Google_Protobuf_FileDescriptorSet(serializedData: fileDescriptorSetData)

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
@@ -12,7 +12,7 @@ import XCTest
 import SwiftProtobuf
 @testable import SwiftProtobufPluginLibrary
 
-class Test_NamingUtils: XCTestCase {
+final class Test_NamingUtils: XCTestCase {
 
   func testTypePrefix() throws {
     // package, swiftPrefix, expected

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -30,7 +30,7 @@ extension ProtoFileToModuleMappings.LoadError: Equatable {
 
 fileprivate typealias FileDescriptorProto = Google_Protobuf_FileDescriptorProto
 
-class Test_ProtoFileToModuleMappings: XCTestCase {
+final class Test_ProtoFileToModuleMappings: XCTestCase {
 
   func test_Initialization() {
     // ProtoFileToModuleMappings always includes mappings for the protos that

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftLanguage.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftLanguage.swift
@@ -15,7 +15,7 @@
 import XCTest
 import SwiftProtobufPluginLibrary
 
-class Test_SwiftLanguage: XCTestCase {
+final class Test_SwiftLanguage: XCTestCase {
     func testIsValidSwiftIdentifier() {
         let cases = [
             "H9000",

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftProtobufNamer.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftProtobufNamer.swift
@@ -13,7 +13,7 @@ import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 import SwiftProtobufTestHelpers
 
-class Test_SwiftProtobufNamer: XCTestCase {
+final class Test_SwiftProtobufNamer: XCTestCase {
 
   func testEnumValueHandling_AliasNameMatches() throws {
     let txt = [

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -19,7 +19,7 @@ import Foundation
 import SwiftProtobuf
 import XCTest
 
-class Test_AllTypes: XCTestCase, PBTestHelpers {
+final class Test_AllTypes: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllTypes
 
     // Custom decodeSucceeds that also does a round-trip through the Empty

--- a/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
@@ -18,7 +18,7 @@
 import Foundation
 import XCTest
 
-class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
+final class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
     // Custom decodeSucceeds that also does a round-trip through the Empty

--- a/Tests/SwiftProtobufTests/Test_AllTypes_Proto3_Optional.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes_Proto3_Optional.swift
@@ -18,7 +18,7 @@
 import Foundation
 import XCTest
 
-class Test_AllTypes_Proto3_Optional: XCTestCase, PBTestHelpers {
+final class Test_AllTypes_Proto3_Optional: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestProto3Optional
 
     // Custom decodeSucceeds that also does a round-trip through the Empty

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -19,7 +19,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Any: XCTestCase {
+final class Test_Any: XCTestCase {
 
     func test_Any() throws {
         var content = SwiftProtoTesting_TestAllTypes()

--- a/Tests/SwiftProtobufTests/Test_Api.swift
+++ b/Tests/SwiftProtobufTests/Test_Api.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Api: XCTestCase, PBTestHelpers {
+final class Test_Api: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Api
 
     func testExists() {

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_BasicFields_Access_Proto2: XCTestCase {
+final class Test_BasicFields_Access_Proto2: XCTestCase {
 
   // Optional
 

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_BasicFields_Access_Proto3: XCTestCase {
+final class Test_BasicFields_Access_Proto3: XCTestCase {
 
   // Optional
 

--- a/Tests/SwiftProtobufTests/Test_BinaryDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDecodingOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_BinaryDecodingOptions: XCTestCase {
+final class Test_BinaryDecodingOptions: XCTestCase {
 
     func testMessageDepthLimit() throws {
 

--- a/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDelimited.swift
@@ -18,7 +18,7 @@ fileprivate func openInputStream(_ bytes: [UInt8]) -> InputStream {
   return istream
 }
 
-class Test_BinaryDelimited: XCTestCase {
+final class Test_BinaryDelimited: XCTestCase {
 
   /// Helper to assert the next message read matches and expected one.
   func assertParse<M: Message & Equatable>(expected: M, onStream istream: InputStream) {

--- a/Tests/SwiftProtobufTests/Test_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_Conformance.swift
@@ -17,7 +17,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Conformance: XCTestCase, PBTestHelpers {
+final class Test_Conformance: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Test3_TestAllTypesProto3
 
     func testFieldNaming() throws {

--- a/Tests/SwiftProtobufTests/Test_Duration.swift
+++ b/Tests/SwiftProtobufTests/Test_Duration.swift
@@ -17,7 +17,7 @@ import XCTest
 import SwiftProtobuf
 import Foundation
 
-class Test_Duration: XCTestCase, PBTestHelpers {
+final class Test_Duration: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Duration
 
     func testJSON_encode() throws {

--- a/Tests/SwiftProtobufTests/Test_Empty.swift
+++ b/Tests/SwiftProtobufTests/Test_Empty.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Empty: XCTestCase, PBTestHelpers {
+final class Test_Empty: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Empty
 
     func testExists() throws {

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Enum: XCTestCase, PBTestHelpers {
+final class Test_Enum: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
     func testEqual() {

--- a/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
+++ b/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-class Test_EnumWithAliases: XCTestCase, PBTestHelpers {
+final class Test_EnumWithAliases: XCTestCase, PBTestHelpers {
   typealias MessageTestType = SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest
 
   func testJSONEncodeUsesOriginalNames() {

--- a/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-class Test_Enum_Proto2: XCTestCase, PBTestHelpers {
+final class Test_Enum_Proto2: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllTypes
 
     func testEqual() {

--- a/Tests/SwiftProtobufTests/Test_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_Extensions.swift
@@ -18,7 +18,7 @@ import SwiftProtobuf
 
 // Exercise the support for Proto2 extensions.
 
-class Test_Extensions: XCTestCase, PBTestHelpers {
+final class Test_Extensions: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllExtensions
     var extensions = SwiftProtobuf.SimpleExtensionMap()
 

--- a/Tests/SwiftProtobufTests/Test_ExtremeDefaultValues.swift
+++ b/Tests/SwiftProtobufTests/Test_ExtremeDefaultValues.swift
@@ -21,7 +21,7 @@ import XCTest
 // Verify that the Swift backend correctly encodes various
 // extreme values when generating code that applies defaults.
 //
-class Test_ExtremeDefaultValues: XCTestCase {
+final class Test_ExtremeDefaultValues: XCTestCase {
 
     func test_escapedBytes() {
         let m = SwiftProtoTesting_TestExtremeDefaultValues()

--- a/Tests/SwiftProtobufTests/Test_FieldMask.swift
+++ b/Tests/SwiftProtobufTests/Test_FieldMask.swift
@@ -20,7 +20,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_FieldMask: XCTestCase, PBTestHelpers {
+final class Test_FieldMask: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_FieldMask
 
     func testJSON() {

--- a/Tests/SwiftProtobufTests/Test_FieldOrdering.swift
+++ b/Tests/SwiftProtobufTests/Test_FieldOrdering.swift
@@ -20,7 +20,7 @@
 import Foundation
 import XCTest
 
-class Test_FieldOrdering: XCTestCase {
+final class Test_FieldOrdering: XCTestCase {
     typealias MessageTestType = SwiftProtoTesting_Order_TestFieldOrderings
 
     func test_FieldOrdering() throws {

--- a/Tests/SwiftProtobufTests/Test_FuzzTests.swift
+++ b/Tests/SwiftProtobufTests/Test_FuzzTests.swift
@@ -23,7 +23,7 @@
 import Foundation
 import XCTest
 
-class Test_FuzzTests: XCTestCase {
+final class Test_FuzzTests: XCTestCase {
 
   func assertBinaryFails(_ bytes: [UInt8], file: XCTestFileArgType = #file, line: UInt = #line) {
     XCTAssertThrowsError(

--- a/Tests/SwiftProtobufTests/Test_GroupWithGroups.swift
+++ b/Tests/SwiftProtobufTests/Test_GroupWithGroups.swift
@@ -11,7 +11,7 @@
 import Foundation
 import XCTest
 
-class Test_GroupWithinGroup: XCTestCase, PBTestHelpers {
+final class Test_GroupWithinGroup: XCTestCase, PBTestHelpers {
   typealias MessageTestType = SwiftTestNestingGroupsMessage
 
   func testGroupWithGroup_Single() {

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSON: XCTestCase, PBTestHelpers {
+final class Test_JSON: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
     private func configureLargeObject(_ o: inout MessageTestType) {
@@ -973,7 +973,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
 }
 
 
-class Test_JSONPacked: XCTestCase, PBTestHelpers {
+final class Test_JSONPacked: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestPackedTypes
 
     func testPackedFloat() {
@@ -1185,7 +1185,7 @@ class Test_JSONPacked: XCTestCase, PBTestHelpers {
     }
 }
 
-class Test_JSONrepeated: XCTestCase, PBTestHelpers {
+final class Test_JSONrepeated: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestUnpackedTypes
 
     func testPackedInt32() {

--- a/Tests/SwiftProtobufTests/Test_JSONDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSONDecodingOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSONDecodingOptions: XCTestCase {
+final class Test_JSONDecodingOptions: XCTestCase {
 
     func testMessageDepthLimit() {
         let jsonInputs: [String] = [

--- a/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSONEncodingOptions: XCTestCase {
+final class Test_JSONEncodingOptions: XCTestCase {
   
   func testAlwaysPrintInt64sAsNumbers() {
     // Use explicit options (the default is false), no reason only others can be pedantic.

--- a/Tests/SwiftProtobufTests/Test_JSON_Array.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Array.swift
@@ -18,7 +18,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSON_Array: XCTestCase, PBTestHelpers {
+final class Test_JSON_Array: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
     private func configureTwoObjects(_ o: inout [MessageTestType]) {

--- a/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Conformance.swift
@@ -17,7 +17,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSON_Conformance: XCTestCase {
+final class Test_JSON_Conformance: XCTestCase {
     func assertEmptyDecode(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line) -> () {
         do {
             let decoded = try SwiftProtoTesting_Test3_TestAllTypesProto3(jsonString: json)

--- a/Tests/SwiftProtobufTests/Test_JSON_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Extensions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_JSON_Extensions: XCTestCase, PBTestHelpers {
+final class Test_JSON_Extensions: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllExtensions
     var extensions = SwiftProtobuf.SimpleExtensionMap()
 
@@ -131,7 +131,7 @@ class Test_JSON_Extensions: XCTestCase, PBTestHelpers {
     }
 }
 
-class Test_JSON_RecursiveNested_Extensions: XCTestCase, PBTestHelpers {
+final class Test_JSON_RecursiveNested_Extensions: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Extend_Msg1
     let extensions = SwiftProtoTesting_Extend_UnittestSwiftExtension_Extensions
 

--- a/Tests/SwiftProtobufTests/Test_JSON_Group.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Group.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-class Test_JSON_Group: XCTestCase, PBTestHelpers {
+final class Test_JSON_Group: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllTypes
 
     func testOptionalGroup() {

--- a/Tests/SwiftProtobufTests/Test_JSON_Performance.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Performance.swift
@@ -15,7 +15,7 @@
 import XCTest
 import SwiftProtobuf
 
-class Test_JSON_Performance: XCTestCase, PBTestHelpers {
+final class Test_JSON_Performance: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Fuzz_Message
 
     // Each of the following should be under 1s on a reasonably

--- a/Tests/SwiftProtobufTests/Test_Map.swift
+++ b/Tests/SwiftProtobufTests/Test_Map.swift
@@ -15,7 +15,7 @@
 import Foundation
 import XCTest
 
-class Test_Map: XCTestCase, PBTestHelpers {
+final class Test_Map: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestMap
 
     func assertMapEncode(_ expectedBlocks: [[UInt8]], file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_MapFields_Access_Proto2: XCTestCase {
+final class Test_MapFields_Access_Proto2: XCTestCase {
 
   func testMapInt32Int32() {
     var msg = SwiftProtoTesting_Message2()

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_MapFields_Access_Proto3: XCTestCase {
+final class Test_MapFields_Access_Proto3: XCTestCase {
 
   func testMapInt32Int32() {
     var msg = SwiftProtoTesting_Message3()

--- a/Tests/SwiftProtobufTests/Test_Map_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_Map_JSON.swift
@@ -21,7 +21,7 @@ import SwiftProtobuf
 // TODO: Testing encoding needs some help, since the order of
 // entries isn't well-defined.
 
-class Test_Map_JSON: XCTestCase, PBTestHelpers {
+final class Test_Map_JSON: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestMap
 
     func testMapInt32Int32() throws {

--- a/Tests/SwiftProtobufTests/Test_Merge.swift
+++ b/Tests/SwiftProtobufTests/Test_Merge.swift
@@ -12,7 +12,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Merge: XCTestCase, PBTestHelpers {
+final class Test_Merge: XCTestCase, PBTestHelpers {
   typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
   func testMergeSimple() throws {

--- a/Tests/SwiftProtobufTests/Test_MessageSet.swift
+++ b/Tests/SwiftProtobufTests/Test_MessageSet.swift
@@ -24,7 +24,7 @@ extension SwiftProtoTesting_RawMessageSet.Item {
   }
 }
 
-class Test_MessageSet: XCTestCase {
+final class Test_MessageSet: XCTestCase {
 
   // wireformat_unittest.cc: TEST(WireFormatTest, SerializeMessageSet)
   func testSerialize() throws {

--- a/Tests/SwiftProtobufTests/Test_Naming.swift
+++ b/Tests/SwiftProtobufTests/Test_Naming.swift
@@ -23,13 +23,13 @@ import SwiftProtobuf
 
 // NOTE: If this code fails to compile, make sure the name changes make sense.
 
-class Test_PackageMapping: XCTestCase {
+final class Test_PackageMapping: XCTestCase {
   func testPackageStartingWithNumber() {
     let _ = _4fun_SwiftProtoTesting_Mumble_MyMessage()
   }
 }
 
-class Test_FieldNamingInitials: XCTestCase {
+final class Test_FieldNamingInitials: XCTestCase {
   func testHidingFunctions() throws {
     // Check that we can access the standard `serializeData`, etc
     // methods even on messages that define fields or submessages with
@@ -257,7 +257,7 @@ class Test_FieldNamingInitials: XCTestCase {
   }
 }
 
-class Test_ExtensionNamingInitials_MessageScoped: XCTestCase {
+final class Test_ExtensionNamingInitials_MessageScoped: XCTestCase {
   func testLowers() {
     var msg = SwiftProtoTesting_Names_ExtensionNamingInitials()
 
@@ -467,7 +467,7 @@ class Test_ExtensionNamingInitials_MessageScoped: XCTestCase {
   }
 }
 
-class Test_ExtensionNamingInitials_GlobalScoped: XCTestCase {
+final class Test_ExtensionNamingInitials_GlobalScoped: XCTestCase {
   func testLowers() {
     var msg = SwiftProtoTesting_Names_ExtensionNamingInitialsLowers()
 
@@ -669,7 +669,7 @@ class Test_ExtensionNamingInitials_GlobalScoped: XCTestCase {
   }
 }
 
-class Test_ExtensionNamingInitials_GlobalScoped_NoPrefix: XCTestCase {
+final class Test_ExtensionNamingInitials_GlobalScoped_NoPrefix: XCTestCase {
   func testLowers() {
     var msg = SwiftProtoTesting_Names_ExtensionNamingInitialsLowers()
 
@@ -879,7 +879,7 @@ class Test_ExtensionNamingInitials_GlobalScoped_NoPrefix: XCTestCase {
   }
 }
 
-class Test_ValidIdentifiers: XCTestCase {
+final class Test_ValidIdentifiers: XCTestCase {
   func testFieldNames() {
     let msg = SwiftProtoTesting_Names_ValidIdentifiers()
     XCTAssertEqual(msg._1Field, 0)

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_OneofFields_Access_Proto2: XCTestCase {
+final class Test_OneofFields_Access_Proto2: XCTestCase {
 
   // Accessing one field.
   // - Returns default

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
@@ -20,7 +20,7 @@ import Foundation
 // these tests should be done once with a message that gets that storage
 // class and a second time with messages that avoid that.
 
-class Test_OneofFields_Access_Proto3: XCTestCase {
+final class Test_OneofFields_Access_Proto3: XCTestCase {
 
   // Accessing one field.
   // - Returns default

--- a/Tests/SwiftProtobufTests/Test_Packed.swift
+++ b/Tests/SwiftProtobufTests/Test_Packed.swift
@@ -16,7 +16,7 @@
 import Foundation
 import XCTest
 
-class Test_Packed: XCTestCase, PBTestHelpers {
+final class Test_Packed: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestPackedTypes
 
     func testEncoding_packedInt32() {

--- a/Tests/SwiftProtobufTests/Test_ParsingMerge.swift
+++ b/Tests/SwiftProtobufTests/Test_ParsingMerge.swift
@@ -18,7 +18,7 @@
 import Foundation
 import XCTest
 
-class Test_ParsingMerge: XCTestCase {
+final class Test_ParsingMerge: XCTestCase {
 
     func test_Merge() {
         // Repeated fields generator has field1

--- a/Tests/SwiftProtobufTests/Test_ReallyLargeTagNumber.swift
+++ b/Tests/SwiftProtobufTests/Test_ReallyLargeTagNumber.swift
@@ -15,7 +15,7 @@
 import Foundation
 import XCTest
 
-class Test_ReallyLargeTagNumber: XCTestCase {
+final class Test_ReallyLargeTagNumber: XCTestCase {
 
     func test_ReallyLargeTagNumber() {
         var m = SwiftProtoTesting_TestReallyLargeTagNumber()

--- a/Tests/SwiftProtobufTests/Test_RecursiveMap.swift
+++ b/Tests/SwiftProtobufTests/Test_RecursiveMap.swift
@@ -15,7 +15,7 @@
 import Foundation
 import XCTest
 
-class Test_RecursiveMap: XCTestCase {
+final class Test_RecursiveMap: XCTestCase {
     func test_RecursiveMap() throws {
         let inner = SwiftProtoTesting_TestRecursiveMapMessage()
         var mid = SwiftProtoTesting_TestRecursiveMapMessage()

--- a/Tests/SwiftProtobufTests/Test_Required.swift
+++ b/Tests/SwiftProtobufTests/Test_Required.swift
@@ -32,7 +32,7 @@ import XCTest
 
 import SwiftProtobuf
 
-class Test_Required: XCTestCase, PBTestHelpers {
+final class Test_Required: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllRequiredTypes
 
     func test_IsInitialized() {
@@ -348,7 +348,7 @@ class Test_Required: XCTestCase, PBTestHelpers {
     }
 }
 
-class Test_SmallRequired: XCTestCase, PBTestHelpers {
+final class Test_SmallRequired: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestSomeRequiredTypes
     // Check behavior of a small message (non-heap-stored) with required fields
 

--- a/Tests/SwiftProtobufTests/Test_Reserved.swift
+++ b/Tests/SwiftProtobufTests/Test_Reserved.swift
@@ -19,7 +19,7 @@ import Foundation
 import XCTest
 @testable import SwiftProtobuf
 
-class Test_Reserved: XCTestCase {
+final class Test_Reserved: XCTestCase {
     func testEnumNaming() {
         XCTAssertEqual(SwiftProtoTesting_SwiftReservedTest.Enum.double.rawValue, 1)
         XCTAssertEqual(String(describing: SwiftProtoTesting_SwiftReservedTest.Enum.double.name!), "DOUBLE")

--- a/Tests/SwiftProtobufTests/Test_SimpleExtensionMap.swift
+++ b/Tests/SwiftProtobufTests/Test_SimpleExtensionMap.swift
@@ -50,7 +50,7 @@ let ext4 = MessageExtension<OptionalExtensionField<ProtobufBool>, SwiftProtoTest
 )
 
 
-class Test_SimpleExtensionMap: XCTestCase {
+final class Test_SimpleExtensionMap: XCTestCase {
   func assert(map: SimpleExtensionMap, contains: [AnyMessageExtension], line: UInt = #line) {
     // Extact what it constaings.
     var includes = [AnyMessageExtension]()

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -17,7 +17,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Struct: XCTestCase, PBTestHelpers {
+final class Test_Struct: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Struct
 
     func testStruct_pbencode() {
@@ -103,7 +103,7 @@ class Test_Struct: XCTestCase, PBTestHelpers {
     }
 }
 
-class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
+final class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_ListValue
 
     // Since ProtobufJSONList is handbuilt rather than generated,
@@ -194,7 +194,7 @@ class Test_JSON_ListValue: XCTestCase, PBTestHelpers {
 }
 
 
-class Test_Value: XCTestCase, PBTestHelpers {
+final class Test_Value: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Value
 
     func testValue_empty() throws {
@@ -213,7 +213,7 @@ class Test_Value: XCTestCase, PBTestHelpers {
 
 
 // TODO: Should have convenience initializers on Google_Protobuf_Value
-class Test_JSON_Value: XCTestCase, PBTestHelpers {
+final class Test_JSON_Value: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Value
 
     func testValue_emptyShouldThrow() throws {

--- a/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormatDecodingOptions: XCTestCase {
+final class Test_TextFormatDecodingOptions: XCTestCase {
 
     func testMessageDepthLimit() {
         let textInput = "a: { a: { i: 1 } }"

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Map_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Map_proto3.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_Map_proto3: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_Map_proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestMap
 
     func test_Int32Int32() {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
@@ -15,7 +15,7 @@
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_Performance: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_Performance: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Fuzz_Message
 
     // Each of the following should be under 1s on a reasonably

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 @testable import SwiftProtobuf
 
-class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestEmptyMessage
 
     func test_unknown_varint() throws {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestWellKnownTypes
 
     func assertAnyTest<M: Message & Equatable>(_ message: M, expected: String, file: XCTestFileArgType = #file, line: UInt = #line) {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto2.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_proto2: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_proto2: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllTypes
 
     func test_group() {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto2_extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto2_extensions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_proto2_extensions: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_proto2_extensions: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllExtensions
 
     func test_file_level_extension() {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
+final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestAllTypes
 
     func testDecoding_comments() {

--- a/Tests/SwiftProtobufTests/Test_Timestamp.swift
+++ b/Tests/SwiftProtobufTests/Test_Timestamp.swift
@@ -24,7 +24,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Timestamp: XCTestCase, PBTestHelpers {
+final class Test_Timestamp: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Timestamp
 
     func testJSON() throws {

--- a/Tests/SwiftProtobufTests/Test_Type.swift
+++ b/Tests/SwiftProtobufTests/Test_Type.swift
@@ -20,7 +20,7 @@ import SwiftProtobuf
 // in it) this is a fairly thin test just to ensure that the proto
 // does get into the runtime:
 
-class Test_Type: XCTestCase, PBTestHelpers {
+final class Test_Type: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Google_Protobuf_Type
 
     func testExists() {

--- a/Tests/SwiftProtobufTests/Test_Unknown_proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_Unknown_proto2.swift
@@ -20,7 +20,7 @@ import SwiftProtobuf
 // Verify that unknown fields are correctly preserved by
 // proto2 messages.
 
-class Test_Unknown_proto2: XCTestCase, PBTestHelpers {
+final class Test_Unknown_proto2: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestEmptyMessage
 
     /// Verify that json decode ignores the provided fields but otherwise succeeds

--- a/Tests/SwiftProtobufTests/Test_Unknown_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_Unknown_proto3.swift
@@ -22,7 +22,7 @@ import SwiftProtobuf
 // happens to be defined in a .proto that is also used for testing
 // C++ arena support.
 
-class Test_Unknown_proto3: XCTestCase, PBTestHelpers {
+final class Test_Unknown_proto3: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_Proto3_TestEmptyMessage
 
     /// Verify that json decode ignores the provided fields but otherwise succeeds

--- a/Tests/SwiftProtobufTests/Test_Wrappers.swift
+++ b/Tests/SwiftProtobufTests/Test_Wrappers.swift
@@ -17,7 +17,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-class Test_Wrappers: XCTestCase {
+final class Test_Wrappers: XCTestCase {
 
     /// Asserts that decoding the JSON "null" literal for the given message type
     /// throws `illegalNull`.

--- a/Tests/protoc-gen-swiftTests/Test_DescriptorExtensions.swift
+++ b/Tests/protoc-gen-swiftTests/Test_DescriptorExtensions.swift
@@ -13,7 +13,7 @@ import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 @testable import protoc_gen_swift
 
-class Test_DescriptorExtensions: XCTestCase {
+final class Test_DescriptorExtensions: XCTestCase {
 
   func testExtensionRanges() throws {
     let fileSet = try Google_Protobuf_FileDescriptorSet(serializedData: fileDescriptorSetData)

--- a/Tests/protoc-gen-swiftTests/Test_SwiftProtobufNamerExtensions.swift
+++ b/Tests/protoc-gen-swiftTests/Test_SwiftProtobufNamerExtensions.swift
@@ -14,7 +14,7 @@ import SwiftProtobufPluginLibrary
 import SwiftProtobufTestHelpers
 @testable import protoc_gen_swift
 
-class Test_SwiftProtobufNamer: XCTestCase {
+final class Test_SwiftProtobufNamer: XCTestCase {
 
   func testEnumValueHandling_AliasNameMatches() throws {
     let txt = [


### PR DESCRIPTION
From the comment in the review on
https://github.com/apple/swift-protobuf/pull/1480, doing this for all tests.