### PR TITLE
Add `useDeterministicOrdering` opt-in option to JSON + Binary encoding

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -1,0 +1,32 @@
+// Sources/SwiftProtobuf/BinaryEncodingOptions.swift - Binary encoding options
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Binary encoding options
+///
+// -----------------------------------------------------------------------------
+
+/// Options for binary encoding.
+public struct BinaryEncodingOptions: Sendable {
+    /// Whether to use deterministic ordering when serializing.
+    ///
+    /// Note that the deterministic serialization is NOT canonical across languages.
+    /// It is NOT guaranteed to remain stable over time. It is unstable across
+    /// different builds with schema changes due to unknown fields. Users who need
+    /// canonical serialization (e.g., persistent storage in a canonical form,
+    /// fingerprinting, etc.) should define their own canonicalization specification
+    /// and implement their own serializer rather than relying on this API.
+    ///
+    /// If deterministic serialization is requested, map entries will be sorted
+    /// by keys in lexographical order. This is an implementation detail
+    /// and subject to change.
+    public var useDeterministicOrdering: Bool = false
+
+    public init() {}
+}

--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -13,7 +13,7 @@
 // -----------------------------------------------------------------------------
 
 /// Options for binary encoding.
-public struct BinaryEncodingOptions: Sendable {
+public struct BinaryEncodingOptions {
     /// Whether to use deterministic ordering when serializing.
     ///
     /// Note that the deterministic serialization is NOT canonical across languages.

--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -22,5 +22,19 @@ public struct JSONEncodingOptions {
   /// By default they are converted to JSON(lowerCamelCase) names.
   public var preserveProtoFieldNames: Bool = false
 
+  /// Whether to use deterministic ordering when serializing.
+  ///
+  /// Note that the deterministic serialization is NOT canonical across languages. 
+  /// It is NOT guaranteed to remain stable over time. It is unstable across 
+  /// different builds with schema changes due to unknown fields. Users who need
+  /// canonical serialization (e.g., persistent storage in a canonical form,
+  /// fingerprinting, etc.) should define their own canonicalization specification
+  /// and implement their own serializer rather than relying on this API.
+  ///
+  /// If deterministic serialization is requested, map entries will be sorted
+  /// by keys in lexographical order. This is an implementation detail
+  /// and subject to change.
+  public var useDeterministicOrdering: Bool = false
+
   public init() {}
 }

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -374,7 +374,7 @@ internal struct JSONEncodingVisitor: Visitor {
   ) throws {
     try startField(for: fieldNumber)
     encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: JSONEncoder(), options: options)
+    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
     if options.useDeterministicOrdering {
       for (k,v) in map.sorted(by: { isOrderedBefore( $0.0, $1.0) }) {
         try encode(&mapVisitor, k, v)

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -340,39 +340,49 @@ internal struct JSONEncodingVisitor: Visitor {
   // Packed fields are handled the same as non-packed fields, so JSON just
   // relies on the default implementations in Visitor.swift
 
-
-
   mutating func visitMapField<KeyType, ValueType: MapValueType>(fieldType: _ProtobufMap<KeyType, ValueType>.Type, value: _ProtobufMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws {
-    try startField(for: fieldNumber)
-    encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
-    for (k,v) in value {
-        try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
-        try ValueType.visitSingular(value: v, fieldNumber: 2, with: &mapVisitor)
+    try iterateAndEncode(map: value, fieldNumber: fieldNumber, isOrderedBefore: KeyType._lessThan) {
+      (visitor: inout JSONMapEncodingVisitor, key, value) throws -> () in
+      try KeyType.visitSingular(value: key, fieldNumber: 1, with: &visitor)
+      try ValueType.visitSingular(value: value, fieldNumber: 2, with: &visitor)
     }
-    encoder = mapVisitor.encoder
-    encoder.append(text: "}")
   }
 
   mutating func visitMapField<KeyType, ValueType>(fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type, value: _ProtobufEnumMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws  where ValueType.RawValue == Int {
-    try startField(for: fieldNumber)
-    encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
-    for (k, v) in value {
-      try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
-      try mapVisitor.visitSingularEnumField(value: v, fieldNumber: 2)
+    try iterateAndEncode(map: value, fieldNumber: fieldNumber, isOrderedBefore: KeyType._lessThan) {
+      (visitor: inout JSONMapEncodingVisitor, key, value) throws -> () in
+      try KeyType.visitSingular(value: key, fieldNumber: 1, with: &visitor)
+      try visitor.visitSingularEnumField(value: value, fieldNumber: 2)
     }
-    encoder = mapVisitor.encoder
-    encoder.append(text: "}")
   }
 
   mutating func visitMapField<KeyType, ValueType>(fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type, value: _ProtobufMessageMap<KeyType, ValueType>.BaseType, fieldNumber: Int) throws {
+    try iterateAndEncode(map: value, fieldNumber: fieldNumber, isOrderedBefore: KeyType._lessThan) {
+      (visitor: inout JSONMapEncodingVisitor, key, value) throws -> () in
+      try KeyType.visitSingular(value: key, fieldNumber: 1, with: &visitor)
+      try visitor.visitSingularMessageField(value: value, fieldNumber: 2)
+    }
+  }
+
+  /// Helper to encapsulate the common structure of iterating over a map
+  /// and encoding the keys and values.
+  private mutating func iterateAndEncode<K, V>(
+    map: Dictionary<K, V>,
+    fieldNumber: Int,
+    isOrderedBefore: (K, K) -> Bool,
+    encode: (inout JSONMapEncodingVisitor, K, V) throws -> ()
+  ) throws {
     try startField(for: fieldNumber)
     encoder.append(text: "{")
-    var mapVisitor = JSONMapEncodingVisitor(encoder: encoder, options: options)
-    for (k,v) in value {
-        try KeyType.visitSingular(value: k, fieldNumber: 1, with: &mapVisitor)
-        try mapVisitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    var mapVisitor = JSONMapEncodingVisitor(encoder: JSONEncoder(), options: options)
+    if options.useDeterministicOrdering {
+      for (k,v) in map.sorted(by: { isOrderedBefore( $0.0, $1.0) }) {
+        try encode(&mapVisitor, k, v)
+      }
+    } else {
+      for (k,v) in map {
+        try encode(&mapVisitor, k, v)
+      }
     }
     encoder = mapVisitor.encoder
     encoder.append(text: "}")

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -28,7 +28,7 @@ extension Message {
   ///   message.
   /// - Throws: `BinaryEncodingError` if encoding fails.
   public func serializedData(partial: Bool = false) throws -> Data {
-    try serializedData(partial: partial, options: BinaryEncodingOptions())
+    return try serializedData(partial: partial, options: BinaryEncodingOptions())
   }
 
   /// Returns a `Data` value containing the Protocol Buffer binary format

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -22,15 +22,37 @@ extension Message {
   /// - Parameters:
   ///   - partial: If `false` (the default), this method will check
   ///     `Message.isInitialized` before encoding to verify that all required
-  ///     fields are present. If any are missing, this method throws
+  ///     fields are present. If any are missing, this method throws.
   ///     `BinaryEncodingError.missingRequiredFields`.
   /// - Returns: A `Data` value containing the binary serialization of the
   ///   message.
   /// - Throws: `BinaryEncodingError` if encoding fails.
   public func serializedData(partial: Bool = false) throws -> Data {
+    try serializedData(partial: partial, options: BinaryEncodingOptions())
+  }
+
+  /// Returns a `Data` value containing the Protocol Buffer binary format
+  /// serialization of the message.
+  ///
+  /// - Parameters:
+  ///   - partial: If `false` (the default), this method will check
+  ///     `Message.isInitialized` before encoding to verify that all required
+  ///     fields are present. If any are missing, this method throws.
+  ///     `BinaryEncodingError.missingRequiredFields`.
+  ///   - options: The `BinaryEncodingOptions` to use.
+  /// - Returns: A `SwiftProtobufContiguousBytes` instance containing the binary serialization
+  /// of the message.
+  ///
+  /// - Throws: `BinaryEncodingError` if encoding fails.
+  public func serializedData(
+    partial: Bool = false,
+    options: BinaryEncodingOptions
+  ) throws -> Data {
     if !partial && !isInitialized {
       throw BinaryEncodingError.missingRequiredFields
     }
+
+    // Note that this assumes `options` will not change the required size.
     let requiredSize = try serializedDataSize()
 
     // Messages have a 2GB limit in encoded size, the upstread C++ code
@@ -48,7 +70,7 @@ extension Message {
     var data = Data(count: requiredSize)
     try data.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
       if let baseAddress = body.baseAddress, body.count > 0 {
-        var visitor = BinaryEncodingVisitor(forWritingInto: baseAddress)
+        var visitor = BinaryEncodingVisitor(forWritingInto: baseAddress, options: options)
         try traverse(visitor: &visitor)
         // Currently not exposing this from the api because it really would be
         // an internal error in the library and should never happen.

--- a/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
@@ -1,0 +1,74 @@
+// Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift - Tests for binary encoding options
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Test for the use of BinaryEncodingOptions
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+import XCTest
+import SwiftProtobuf
+
+final class Test_BinaryEncodingOptions: XCTestCase {
+
+  func testUseDeterministicOrdering() throws {
+    var options = BinaryEncodingOptions()
+    options.useDeterministicOrdering = true
+
+    let message1 = SwiftProtoTesting_Message3.with {
+      $0.mapStringString = [
+        "b": "B",
+        "a": "A",
+        "0": "0",
+        "UPPER": "v",
+        "x": "X",
+      ]
+      $0.mapInt32Message = [
+        5: .with { $0.optionalSint32 = 5 },
+        1: .with { $0.optionalSint32 = 1 },
+        3: .with { $0.optionalSint32 = 3 },
+      ]
+      $0.mapInt32Enum = [
+        5: .foo,
+        3: .bar,
+        0: .baz,
+        1: .extra3,
+      ]
+    }
+
+    let message2 = SwiftProtoTesting_Message3.with {
+      $0.mapStringString = [
+        "UPPER": "v",
+        "a": "A",
+        "b": "B",
+        "x": "X",
+        "0": "0",
+      ]
+      $0.mapInt32Message = [
+        1: .with { $0.optionalSint32 = 1 },
+        3: .with { $0.optionalSint32 = 3 },
+        5: .with { $0.optionalSint32 = 5 },
+      ]
+      $0.mapInt32Enum = [
+        3: .bar,
+        5: .foo,
+        1: .extra3,
+        0: .baz,
+      ]
+    }
+
+    // Approximation that serializing models with the same data (but initialized with keys in
+    // different orders) consistently produces the same outputs.
+    let expectedOutput = try message1.serializedData(options: options)
+    for _ in 0..<10 {
+      XCTAssertEqual(try message2.serializedData(options: options), expectedOutput)
+    }
+  }
+}

--- a/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
@@ -22,7 +22,7 @@ final class Test_BinaryEncodingOptions: XCTestCase {
     var options = BinaryEncodingOptions()
     options.useDeterministicOrdering = true
 
-    let message1 = SwiftProtoTesting_Message3.with {
+    let message1 = ProtobufUnittest_Message3.with {
       $0.mapStringString = [
         "b": "B",
         "a": "A",
@@ -43,7 +43,7 @@ final class Test_BinaryEncodingOptions: XCTestCase {
       ]
     }
 
-    let message2 = SwiftProtoTesting_Message3.with {
+    let message2 = ProtobufUnittest_Message3.with {
       $0.mapStringString = [
         "UPPER": "v",
         "a": "A",

--- a/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryEncodingOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 import XCTest
 import SwiftProtobuf
 
-final class Test_BinaryEncodingOptions: XCTestCase {
+class Test_BinaryEncodingOptions: XCTestCase {
 
   func testUseDeterministicOrdering() throws {
     var options = BinaryEncodingOptions()

--- a/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
@@ -186,7 +186,7 @@ class Test_JSONEncodingOptions: XCTestCase {
     var options = JSONEncodingOptions()
     options.useDeterministicOrdering = true
 
-    let stringMap = SwiftProtoTesting_Message3.with {
+    let stringMap = ProtobufUnittest_Message3.with {
       $0.mapStringString = [
         "b": "B",
         "a": "A",
@@ -200,7 +200,7 @@ class Test_JSONEncodingOptions: XCTestCase {
       "{\"mapStringString\":{\"0\":\"0\",\"UPPER\":\"v\",\"a\":\"A\",\"b\":\"B\",\"x\":\"X\"}}"
     )
 
-    let messageMap = SwiftProtoTesting_Message3.with {
+    let messageMap = ProtobufUnittest_Message3.with {
       $0.mapInt32Message = [
         5: .with { $0.optionalSint32 = 5 },
         1: .with { $0.optionalSint32 = 1 },
@@ -212,7 +212,7 @@ class Test_JSONEncodingOptions: XCTestCase {
       "{\"mapInt32Message\":{\"1\":{\"optionalSint32\":1},\"3\":{\"optionalSint32\":3},\"5\":{\"optionalSint32\":5}}}"
     )
 
-    let enumMap = SwiftProtoTesting_Message3.with {
+    let enumMap = ProtobufUnittest_Message3.with {
       $0.mapInt32Enum = [
         5: .foo,
         3: .bar,

--- a/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
@@ -181,4 +181,48 @@ class Test_JSONEncodingOptions: XCTestCase {
     XCTAssertEqual(try msg7.jsonString(options: protoNames),
                    "{\"@type\":\"type.googleapis.com/protobuf_unittest.TestAllTypes\",\"optional_nested_enum\":\"NEG\"}")
   }
+
+  func testUseDeterministicOrdering() {
+    var options = JSONEncodingOptions()
+    options.useDeterministicOrdering = true
+
+    let stringMap = SwiftProtoTesting_Message3.with {
+      $0.mapStringString = [
+        "b": "B",
+        "a": "A",
+        "0": "0",
+        "UPPER": "v",
+        "x": "X",
+      ]
+    }
+    XCTAssertEqual(
+      try stringMap.jsonString(options: options),
+      "{\"mapStringString\":{\"0\":\"0\",\"UPPER\":\"v\",\"a\":\"A\",\"b\":\"B\",\"x\":\"X\"}}"
+    )
+
+    let messageMap = SwiftProtoTesting_Message3.with {
+      $0.mapInt32Message = [
+        5: .with { $0.optionalSint32 = 5 },
+        1: .with { $0.optionalSint32 = 1 },
+        3: .with { $0.optionalSint32 = 3 },
+      ]
+    }
+    XCTAssertEqual(
+      try messageMap.jsonString(options: options),
+      "{\"mapInt32Message\":{\"1\":{\"optionalSint32\":1},\"3\":{\"optionalSint32\":3},\"5\":{\"optionalSint32\":5}}}"
+    )
+
+    let enumMap = SwiftProtoTesting_Message3.with {
+      $0.mapInt32Enum = [
+        5: .foo,
+        3: .bar,
+        0: .baz,
+        1: .extra3,
+      ]
+    }
+    XCTAssertEqual(
+      try enumMap.jsonString(options: options),
+      "{\"mapInt32Enum\":{\"0\":\"BAZ\",\"1\":\"EXTRA_3\",\"3\":\"BAR\",\"5\":\"FOO\"}}"
+    )
+  }
 }


### PR DESCRIPTION
Cherry-picks #1478 and #1480 from `main` onto the 1.x branch. Includes various fixes because these were not clean cherry picks.