### PR TITLE
Consistently use the last word before colon as the class name

### DIFF
--- a/DevTools/CollectTests.awk
+++ b/DevTools/CollectTests.awk
@@ -49,8 +49,8 @@ BEGIN {
 	printf("}\n")
     }
     split($0, a, ":")
-    split(a[1], words, " ")
-    CLASS=words[2]
+    n=split(a[1], words, " ")
+    CLASS=words[n]
     TESTCASES = TESTCASES TESTCASE_separator "\n" "        testCase(" CLASS ".allTests)"
     TESTCASE_separator = ","
     printf("\n")


### PR DESCRIPTION
This allows the test collection script to work correctly for test classes defined in either of the following ways:
```
class Test_Foo: XCTestCase
final class Test_Foo: XCTestCase
```

Note:  The CollectTests.awk is only still needed for compatibility with old Swift systems that did not automatically discover tests on Linux.