### PR TITLE
Remove the bridging method without `BinaryEncodingOptions`.

### DIFF
--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -24,22 +24,6 @@ extension Message {
   ///     `Message.isInitialized` before encoding to verify that all required
   ///     fields are present. If any are missing, this method throws.
   ///     `BinaryEncodingError.missingRequiredFields`.
-  /// - Returns: A `SwiftProtobufContiguousBytes` instance containing the binary serialization
-  /// of the message.
-  ///
-  /// - Throws: `BinaryEncodingError` if encoding fails.
-  public func serializedBytes<Bytes: SwiftProtobufContiguousBytes>(partial: Bool = false) throws -> Bytes {
-    try serializedBytes(partial: partial, options: BinaryEncodingOptions())
-  }
-
-  /// Returns a `SwiftProtobufContiguousBytes` instance containing the Protocol Buffer binary
-  /// format serialization of the message.
-  ///
-  /// - Parameters:
-  ///   - partial: If `false` (the default), this method will check
-  ///     `Message.isInitialized` before encoding to verify that all required
-  ///     fields are present. If any are missing, this method throws.
-  ///     `BinaryEncodingError.missingRequiredFields`.
   ///   - options: The `BinaryEncodingOptions` to use.
   /// - Returns: A `SwiftProtobufContiguousBytes` instance containing the binary serialization
   /// of the message.
@@ -47,7 +31,7 @@ extension Message {
   /// - Throws: `BinaryEncodingError` if encoding fails.
   public func serializedBytes<Bytes: SwiftProtobufContiguousBytes>(
     partial: Bool = false,
-    options: BinaryEncodingOptions
+    options: BinaryEncodingOptions = BinaryEncodingOptions()
   ) throws -> Bytes {
     if !partial && !isInitialized {
       throw BinaryEncodingError.missingRequiredFields

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
@@ -78,26 +78,12 @@ extension Message {
   ///     `Message.isInitialized` before encoding to verify that all required
   ///     fields are present. If any are missing, this method throws
   ///     `BinaryEncodingError.missingRequiredFields`.
-  /// - Returns: A `Data` instance containing the binary serialization of the message.
-  /// - Throws: `BinaryEncodingError` if encoding fails.
-  public func serializedData(partial: Bool = false) throws -> Data {
-    try serializedBytes(partial: partial, options: BinaryEncodingOptions())
-  }
-
-  /// Returns a `Data` instance containing the Protocol Buffer binary
-  /// format serialization of the message.
-  ///
-  /// - Parameters:
-  ///   - partial: If `false` (the default), this method will check
-  ///     `Message.isInitialized` before encoding to verify that all required
-  ///     fields are present. If any are missing, this method throws
-  ///     `BinaryEncodingError.missingRequiredFields`.
   ///   - options: The `BinaryEncodingOptions` to use.
   /// - Returns: A `Data` instance containing the binary serialization of the message.
   /// - Throws: `BinaryEncodingError` if encoding fails.
   public func serializedData(
     partial: Bool = false, 
-    options: BinaryEncodingOptions
+    options: BinaryEncodingOptions = BinaryEncodingOptions()
   ) throws -> Data {
     try serializedBytes(partial: partial, options: options)
   }


### PR DESCRIPTION
Since `main` is going to be 2.0, it is accepting breaking changes, so we don't need to keep the shim without the argument, we can just have the newer signature with the default provided there.