### PR TITLE
Annotate marker protocols with @_marker

### DIFF
--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -115,7 +115,7 @@ public protocol Message: _MessageBase {
 #if DEBUG
 public protocol _MessageBase: Sendable, CustomDebugStringConvertible {}
 #else
-public protocol _MessageBase: Sendable {}
+@_marker public protocol _MessageBase: Sendable {}
 #endif
 
 extension Message {

--- a/Sources/SwiftProtobuf/ProtobufAPIVersionCheck.swift
+++ b/Sources/SwiftProtobuf/ProtobufAPIVersionCheck.swift
@@ -31,7 +31,7 @@
 /// `Version.compatibilityVersion` in `protoc-gen-swift`. That version and this
 /// version must match for the generated protos to be compatible, so if you
 /// update one, make sure to update it here and in the associated type below.
-public protocol ProtobufAPIVersion_3 {}
+@_marker public protocol ProtobufAPIVersion_3 {}
 
 /// This protocol is expected to be implemented by a `fileprivate` type in each
 /// source file emitted by `protoc-gen-swift`. It effectively creates a binding


### PR DESCRIPTION
Apple introduced the `@_marker` attribute to enforce a property at compile time without adding any runtime information. 
Swift-protobuf contains two protocols, `_MessageBase` and `ProtobufAPIVersion_3` , that fulfill the required restrictions and can be annotated with the attribute.
The main motivation for this change is the reduction in code size. In our case this result in a 80 kB decrease.

`@_marker` is prefixed with an underscore, so usage is discouraged in general. I still see a benefit adding the attribute to the two protocols. In the worst case, it needs to be removed when a future Swift version is released and the code size regresses. 

More information about the semantics can be found [here](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_marker) and [here](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md#marker-protocols). The attribute was introduced as part of Swift 5.7.