### PR TITLE
Add support for Musl.

### DIFF
--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -15,8 +15,10 @@
 ///
 // -----------------------------------------------------------------------------
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 import Darwin.C
 #endif


### PR DESCRIPTION
You can't import `Glibc` when using Musl.