### PR TITLE
Explicitly annotate existential usage of `Message` with the existential `any` keyword.

### DIFF
--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -84,7 +84,7 @@ func buildResponse(serializedBytes: [UInt8]) -> Conformance_ConformanceResponse 
         return response
     }
 
-    let msgType: SwiftProtobuf.Message.Type
+    let msgType: any SwiftProtobuf.Message.Type
     let extensions: SwiftProtobuf.ExtensionMap
     switch request.messageType {
     case "":
@@ -102,7 +102,7 @@ func buildResponse(serializedBytes: [UInt8]) -> Conformance_ConformanceResponse 
         return response
     }
 
-    let testMessage: SwiftProtobuf.Message
+    let testMessage: any SwiftProtobuf.Message
     switch request.payload {
     case .protobufPayload(let data)?:
         do {

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 fileprivate func serializeAnyJSON(
-  for message: Message,
+  for message: any Message,
   typeURL: String,
   options: JSONEncodingOptions
 ) throws -> String {
@@ -33,7 +33,7 @@ fileprivate func serializeAnyJSON(
   return visitor.stringResult
 }
 
-fileprivate func emitVerboseTextForm(visitor: inout TextFormatEncodingVisitor, message: Message, typeURL: String) {
+fileprivate func emitVerboseTextForm(visitor: inout TextFormatEncodingVisitor, message: any Message, typeURL: String) {
   let url: String
   if typeURL.isEmpty {
     url = buildTypeURL(forMessage: message, typePrefix: defaultAnyTypeURLPrefix)
@@ -55,7 +55,7 @@ fileprivate func asJSONObject(body: [UInt8]) -> Data {
 fileprivate func unpack(contentJSON: [UInt8],
                         extensions: ExtensionMap,
                         options: JSONDecodingOptions,
-                        as messageType: Message.Type) throws -> Message {
+                        as messageType: any Message.Type) throws -> any Message {
   guard messageType is _CustomJSONCodable.Type else {
     let contentJSONAsObject = asJSONObject(body: contentJSON)
     return try messageType.init(jsonUTF8Bytes: contentJSONAsObject, extensions: extensions, options: options)
@@ -135,7 +135,7 @@ internal class AnyMessageStorage {
     // unpacking that takes new options when a developer decides to decode it.
     case binary(Data)
     // a message
-    case message(Message)
+    case message(any Message)
     // parsed JSON with the @type removed and the decoding options.
     case contentJSON([UInt8], JSONDecodingOptions)
   }

--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -1090,7 +1090,7 @@ internal struct BinaryDecoder: Decoder {
 
     internal mutating func decodeExtensionField(
       values: inout ExtensionFieldValueSet,
-      messageType: Message.Type,
+      messageType: any Message.Type,
       fieldNumber: Int
     ) throws {
         if let ext = extensions?[messageType, fieldNumber] {
@@ -1104,7 +1104,7 @@ internal struct BinaryDecoder: Decoder {
     /// Helper to reuse between Extension decoding and MessageSet Extension decoding.
     private mutating func decodeExtensionField(
       values: inout ExtensionFieldValueSet,
-      messageType: Message.Type,
+      messageType: any Message.Type,
       fieldNumber: Int,
       messageExtension ext: AnyMessageExtension
     ) throws {
@@ -1131,7 +1131,7 @@ internal struct BinaryDecoder: Decoder {
 
     internal mutating func decodeExtensionFieldsAsMessageSet(
       values: inout ExtensionFieldValueSet,
-      messageType: Message.Type
+      messageType: any Message.Type
     ) throws {
         // Spin looking for the Item group, everything else will end up in unknown fields.
         while let fieldNumber = try self.nextFieldNumber() {
@@ -1175,7 +1175,7 @@ internal struct BinaryDecoder: Decoder {
 
     private mutating func decodeMessageSetItem(
       values: inout ExtensionFieldValueSet,
-      messageType: Message.Type
+      messageType: any Message.Type
     ) throws -> DecodeMessageSetItemResult {
         // This is loosely based on the C++:
         //   ExtensionSet::ParseMessageSetItem()

--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -65,7 +65,7 @@ public enum BinaryDelimited {
   ///           `BinaryDelimited.Error` for some writing errors, or the
   ///           underlying `OutputStream.streamError` for a stream error.
   public static func serialize(
-    message: Message,
+    message: any Message,
     to stream: OutputStream,
     partial: Bool = false
   ) throws {

--- a/Sources/SwiftProtobuf/Decoder.swift
+++ b/Sources/SwiftProtobuf/Decoder.swift
@@ -204,11 +204,11 @@ public protocol Decoder {
   // Decode extension fields
 
   /// Decode an extension field
-  mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: Message.Type, fieldNumber: Int) throws
+  mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: any Message.Type, fieldNumber: Int) throws
 
   // Run a decode loop decoding the MessageSet format for Extensions.
   mutating func decodeExtensionFieldsAsMessageSet(values: inout ExtensionFieldValueSet,
-                                                  messageType: Message.Type) throws
+                                                  messageType: any Message.Type) throws
 }
 
 /// Most Decoders won't care about Extension handing as in MessageSet
@@ -217,7 +217,7 @@ public protocol Decoder {
 extension Decoder {
   public mutating func decodeExtensionFieldsAsMessageSet(
     values: inout ExtensionFieldValueSet,
-    messageType: Message.Type
+    messageType: any Message.Type
   ) throws {
     while let fieldNumber = try self.nextFieldNumber() {
       try self.decodeExtensionField(values: &values,

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -24,7 +24,7 @@
 /// standard `SimpleExtensionMap` implementation.
 public protocol ExtensionMap: Sendable {
     /// Returns the extension object describing an extension or nil
-    subscript(messageType: Message.Type, fieldNumber: Int) -> AnyMessageExtension? { get }
+    subscript(messageType: any Message.Type, fieldNumber: Int) -> AnyMessageExtension? { get }
 
     /// Returns the field number for a message with a specific field name
     ///
@@ -34,5 +34,5 @@ public protocol ExtensionMap: Sendable {
     /// for the proto file and `message` is the name of the message in
     /// which the extension was defined. (This is different from the
     /// message that is being extended!)
-    func fieldNumberForProto(messageType: Message.Type, protoFieldName: String) -> Int?
+    func fieldNumberForProto(messageType: any Message.Type, protoFieldName: String) -> Int?
 }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -38,7 +38,7 @@ extension Google_Protobuf_Any {
   /// - Throws: `BinaryEncodingError.missingRequiredFields` if `partial` is
   ///     false and `message` wasn't fully initialized.
   public init(
-    message: Message,
+    message: any Message,
     partial: Bool = false,
     typePrefix: String = defaultAnyTypeURLPrefix
   ) throws {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -26,7 +26,7 @@ fileprivate let knownTypesQueue =
 // TODO: Should these first four be exposed as methods to go with
 // the general registry support?
 
-internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
+internal func buildTypeURL(forMessage message: any Message, typePrefix: String) -> String {
   var url = typePrefix
   let needsSlash = typePrefix.isEmpty || typePrefix.last != "/"
   if needsSlash {
@@ -35,7 +35,7 @@ internal func buildTypeURL(forMessage message: Message, typePrefix: String) -> S
   return url + typeName(fromMessage: message)
 }
 
-internal func typeName(fromMessage message: Message) -> String {
+internal func typeName(fromMessage message: any Message) -> String {
   let messageType = type(of: message)
   return messageType.protoMessageName
 }
@@ -67,7 +67,7 @@ fileprivate final class UnsafeMutableTransferBox<Wrapped> {
 extension UnsafeMutableTransferBox: @unchecked Sendable {}
 
 // All access to this should be done on `knownTypesQueue`.
-fileprivate let knownTypes: UnsafeMutableTransferBox<[String:Message.Type]> = .init([
+fileprivate let knownTypes: UnsafeMutableTransferBox<[String: any Message.Type]> = .init([
   // Seeded with the Well Known Types.
   "google.protobuf.Any": Google_Protobuf_Any.self,
   "google.protobuf.BoolValue": Google_Protobuf_BoolValue.self,
@@ -117,7 +117,7 @@ extension Google_Protobuf_Any {
     ///
     /// Returns: true if the type was registered, false if something
     ///   else was already registered for the messageName.
-    @discardableResult public static func register(messageType: Message.Type) -> Bool {
+    @discardableResult public static func register(messageType: any Message.Type) -> Bool {
         let messageTypeName = messageType.protoMessageName
         var result: Bool = false
         execute(flags: .barrier) {
@@ -136,14 +136,14 @@ extension Google_Protobuf_Any {
     }
 
     /// Returns the Message.Type expected for the given type URL.
-    public static func messageType(forTypeURL url: String) -> Message.Type? {
+    public static func messageType(forTypeURL url: String) -> (any Message.Type)? {
       let messageTypeName = typeName(fromURL: url)
       return messageType(forMessageName: messageTypeName)
     }
 
     /// Returns the Message.Type expected for the given proto message name.
-    public static func messageType(forMessageName name: String) -> Message.Type? {
-        var result: Message.Type?
+    public static func messageType(forMessageName name: String) -> (any Message.Type)? {
+        var result: (any Message.Type)?
         execute(flags: .none) {
             result = knownTypes.wrappedValue[name]
         }

--- a/Sources/SwiftProtobuf/Internal.swift
+++ b/Sources/SwiftProtobuf/Internal.swift
@@ -29,7 +29,7 @@ public enum Internal {
 
   /// Helper to loop over a list of Messages to see if they are all
   /// initialized (see Message.isInitialized for what that means).
-  public static func areAllInitialized(_ listOfMessages: [Message]) -> Bool {
+  public static func areAllInitialized(_ listOfMessages: [any Message]) -> Bool {
     for msg in listOfMessages {
       if !msg.isInitialized {
         return false
@@ -40,7 +40,7 @@ public enum Internal {
 
   /// Helper to loop over dictionary with values that are Messages to see if
   /// they are all initialized (see Message.isInitialized for what that means).
-  public static func areAllInitialized<K>(_ mapToMessages: [K: Message]) -> Bool {
+  public static func areAllInitialized<K>(_ mapToMessages: [K: any Message]) -> Bool {
     for (_, msg) in mapToMessages {
       if !msg.isInitialized {
         return false

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -16,7 +16,7 @@ import Foundation
 
 internal struct JSONDecoder: Decoder {
   internal var scanner: JSONScanner
-  internal var messageType: Message.Type
+  internal var messageType: any Message.Type
   private var fieldCount = 0
   private var isMapKey = false
   private var fieldNameMap: _NameMap?
@@ -30,14 +30,14 @@ internal struct JSONDecoder: Decoder {
   }
 
   internal init(source: UnsafeRawBufferPointer, options: JSONDecodingOptions,
-                messageType: Message.Type, extensions: ExtensionMap?) {
+                messageType: any Message.Type, extensions: ExtensionMap?) {
     let scanner = JSONScanner(source: source,
                                options: options,
                                extensions: extensions)
     self.init(scanner: scanner, messageType: messageType)
   }
 
-  private init(scanner: JSONScanner, messageType: Message.Type) {
+  private init(scanner: JSONScanner, messageType: any Message.Type) {
     self.scanner = scanner
     self.messageType = messageType
   }
@@ -730,7 +730,7 @@ internal struct JSONDecoder: Decoder {
 
   mutating func decodeExtensionField(
     values: inout ExtensionFieldValueSet,
-    messageType: Message.Type,
+    messageType: any Message.Type,
     fieldNumber: Int
   ) throws {
     // Force-unwrap: we can only get here if the extension exists.

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -34,7 +34,7 @@ internal struct JSONEncodingVisitor: Visitor {
 
   /// Creates a new visitor for serializing a message of the given type to JSON
   /// format.
-  init(type: Message.Type, options: JSONEncodingOptions) throws {
+  init(type: any Message.Type, options: JSONEncodingOptions) throws {
     if let nameProviding = type as? _ProtoNameProviding.Type {
       self.nameMap = nameProviding._protobuf_nameMap
     } else {
@@ -51,13 +51,13 @@ internal struct JSONEncodingVisitor: Visitor {
     encoder.endArray()
   }
 
-  mutating func startObject(message: Message) {
-    self.extensions = (message as? ExtensibleMessage)?._protobuf_extensionFieldValues
+  mutating func startObject(message: any Message) {
+    self.extensions = (message as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
     encoder.startObject()
   }
 
-  mutating func startArrayObject(message: Message) {
-    self.extensions = (message as? ExtensibleMessage)?._protobuf_extensionFieldValues
+  mutating func startArrayObject(message: any Message) {
+    self.extensions = (message as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
     encoder.startArrayObject()
   }
 

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1252,7 +1252,7 @@ internal struct JSONScanner {
   /// it silently skips it.
   internal mutating func nextFieldNumber(
     names: _NameMap,
-    messageType: Message.Type
+    messageType: any Message.Type
   ) throws -> Int? {
     while true {
       var fieldName: String

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -109,7 +109,7 @@ public protocol Message: _CommonMessageConformances {
   /// Helper to compare `Message`s when not having a specific type to use
   /// normal `Equatable`. `Equatable` is provided with specific generated
   /// types.
-  func isEqualTo(message: Message) -> Bool
+  func isEqualTo(message: any Message) -> Bool
 }
 
 #if DEBUG
@@ -189,7 +189,7 @@ public protocol _MessageImplementationBase: Message, Hashable {
 }
 
 extension _MessageImplementationBase {
-  public func isEqualTo(message: Message) -> Bool {
+  public func isEqualTo(message: any Message) -> Bool {
     guard let other = message as? Self else {
       return false
     }

--- a/Sources/SwiftProtobuf/MessageExtension.swift
+++ b/Sources/SwiftProtobuf/MessageExtension.swift
@@ -19,7 +19,7 @@
 public protocol AnyMessageExtension: Sendable {
     var fieldNumber: Int { get }
     var fieldName: String { get }
-    var messageType: Message.Type { get }
+    var messageType: any Message.Type { get }
     func _protobuf_newField<D: Decoder>(decoder: inout D) throws -> AnyExtensionField?
 }
 
@@ -29,7 +29,7 @@ public protocol AnyMessageExtension: Sendable {
 public final class MessageExtension<FieldType: ExtensionField, MessageType: Message>: AnyMessageExtension {
     public let fieldNumber: Int
     public let fieldName: String
-    public let messageType: Message.Type
+    public let messageType: any Message.Type
     public init(_protobuf_fieldNumber: Int, fieldName: String) {
         self.fieldNumber = _protobuf_fieldNumber
         self.fieldName = fieldName

--- a/Sources/SwiftProtobuf/SimpleExtensionMap.swift
+++ b/Sources/SwiftProtobuf/SimpleExtensionMap.swift
@@ -32,7 +32,7 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral {
       }
     }
 
-    public subscript(messageType: Message.Type, fieldNumber: Int) -> AnyMessageExtension? {
+    public subscript(messageType: any Message.Type, fieldNumber: Int) -> AnyMessageExtension? {
         get {
             if let l = fields[fieldNumber] {
                 for e in l {
@@ -45,7 +45,7 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral {
         }
     }
 
-    public func fieldNumberForProto(messageType: Message.Type, protoFieldName: String) -> Int? {
+    public func fieldNumberForProto(messageType: any Message.Type, protoFieldName: String) -> Int? {
         // TODO: Make this faster...
         for (_, list) in fields {
             for e in list {

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -25,7 +25,7 @@ internal struct TextFormatDecoder: Decoder {
     private var fieldCount = 0
     private var terminator: UInt8?
     private var fieldNameMap: _NameMap?
-    private var messageType: Message.Type?
+    private var messageType: (any Message.Type)?
 
     internal var complete: Bool {
         mutating get {
@@ -34,7 +34,7 @@ internal struct TextFormatDecoder: Decoder {
     }
 
     internal init(
-      messageType: Message.Type,
+      messageType: any Message.Type,
       utf8Pointer: UnsafeRawPointer,
       count: Int,
       options: TextFormatDecodingOptions,
@@ -48,7 +48,7 @@ internal struct TextFormatDecoder: Decoder {
         self.messageType = messageType
     }
 
-    internal init(messageType: Message.Type, scanner: TextFormatScanner, terminator: UInt8?) throws {
+    internal init(messageType: any Message.Type, scanner: TextFormatScanner, terminator: UInt8?) throws {
         self.scanner = scanner
         self.terminator = terminator
         guard let nameProviding = (messageType as? _ProtoNameProviding.Type) else {
@@ -706,7 +706,7 @@ internal struct TextFormatDecoder: Decoder {
         }
     }
 
-    mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: Message.Type, fieldNumber: Int) throws {
+    mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: any Message.Type, fieldNumber: Int) throws {
         if let ext = scanner.extensions?[messageType, fieldNumber] {
             try values.modify(index: fieldNumber) { fieldValue in
                 if fieldValue != nil {

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -32,14 +32,14 @@ internal struct TextFormatEncodingVisitor: Visitor {
 
   /// Creates a new visitor that serializes the given message to protobuf text
   /// format.
-  init(message: Message, options: TextFormatEncodingOptions) {
+  init(message: any Message, options: TextFormatEncodingOptions) {
     let nameMap: _NameMap?
     if let nameProviding = message as? _ProtoNameProviding {
         nameMap = type(of: nameProviding)._protobuf_nameMap
     } else {
         nameMap = nil
     }
-    let extensions = (message as? ExtensibleMessage)?._protobuf_extensionFieldValues
+    let extensions = (message as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
 
     self.nameMap = nameMap
     self.nameResolver = [:]
@@ -272,7 +272,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
       // Update configuration for new message
       self.nameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap
       self.nameResolver = [:]
-      self.extensions = (value as? ExtensibleMessage)?._protobuf_extensionFieldValues
+      self.extensions = (value as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
       // Encode submessage
       encoder.startMessageField()
       if let any = value as? Google_Protobuf_Any {
@@ -290,7 +290,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
   // Emit the full "verbose" form of an Any.  This writes the typeURL
   // as a field name in `[...]` followed by the fields of the
   // contained message.
-  internal mutating func visitAnyVerbose(value: Message, typeURL: String) {
+  internal mutating func visitAnyVerbose(value: any Message, typeURL: String) {
       encoder.emitExtensionFieldName(name: typeURL)
       encoder.startMessageField()
 
@@ -301,7 +301,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
       // Update configuration for new message
       self.nameMap = (type(of: value) as? _ProtoNameProviding.Type)?._protobuf_nameMap
       self.nameResolver = [:]
-      self.extensions = (value as? ExtensibleMessage)?._protobuf_extensionFieldValues
+      self.extensions = (value as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
 
       if let any = value as? Google_Protobuf_Any {
           any.textTraverse(visitor: &self)
@@ -472,7 +472,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
       // Update encoding state for new message type
       self.nameMap = (M.self as? _ProtoNameProviding.Type)?._protobuf_nameMap
       self.nameResolver = [:]
-      self.extensions = (value as? ExtensibleMessage)?._protobuf_extensionFieldValues
+      self.extensions = (value as? (any ExtensibleMessage))?._protobuf_extensionFieldValues
       // Iterate and encode each message
       for v in value {
           encoder.emitFieldName(name: fieldName)

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -382,7 +382,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
 }
 
 extension XCTestCase {
-    func assertDebugDescription(_ expected: String, _ m: SwiftProtobuf.Message, fmt: String? = nil, file: XCTestFileArgType = #file, line: UInt = #line) {
+    func assertDebugDescription(_ expected: String, _ m: any SwiftProtobuf.Message, fmt: String? = nil, file: XCTestFileArgType = #file, line: UInt = #line) {
         // `assertDebugDescription` is a no-op in release as `debugDescription` is unavailable.
         #if DEBUG
         let actual = m.debugDescription
@@ -392,7 +392,7 @@ extension XCTestCase {
     /// Like ``assertDebugDescription``, but only checks the the ``debugDescription`` ends with
     /// ``expectedSuffix``, mainly useful where you want to be agnotics to some preable like
     /// the module name.
-    func assertDebugDescriptionSuffix(_ expectedSuffix: String, _ m: SwiftProtobuf.Message, fmt: String? = nil, file: XCTestFileArgType = #file, line: UInt = #line) {
+    func assertDebugDescriptionSuffix(_ expectedSuffix: String, _ m: any SwiftProtobuf.Message, fmt: String? = nil, file: XCTestFileArgType = #file, line: UInt = #line) {
         // `assertDebugDescriptionSuffix` is a no-op in release as `debugDescription` is unavailable.
 #if DEBUG
         let actual = m.debugDescription

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -795,7 +795,7 @@ final class Test_Any: XCTestCase {
       XCTAssertNil(Google_Protobuf_Any.messageType(forMessageName: SwiftProtoTesting_TestMap.protoMessageName))
 
       // All the WKTs should be registered.
-      let wkts: [Message.Type] = [
+      let wkts: [any Message.Type] = [
         Google_Protobuf_Any.self,
         Google_Protobuf_BoolValue.self,
         Google_Protobuf_BytesValue.self,

--- a/Tests/SwiftProtobufTests/Test_AsyncMessageSequence.swift
+++ b/Tests/SwiftProtobufTests/Test_AsyncMessageSequence.swift
@@ -229,7 +229,7 @@ final class Test_AsyncMessageSequence: XCTestCase {
       }
   }
 
-  fileprivate func serializedMessageData(messages: [Message]) throws -> [UInt8] {
+  fileprivate func serializedMessageData(messages: [any Message]) throws -> [UInt8] {
     let memoryOutputStream = OutputStream.toMemory()
     memoryOutputStream.open()
     for message in messages {

--- a/Tests/SwiftProtobufTests/Test_BinaryDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_BinaryDecodingOptions.swift
@@ -20,7 +20,7 @@ final class Test_BinaryDecodingOptions: XCTestCase {
 
     func testMessageDepthLimit() throws {
 
-        let tests: [([UInt8], Message.Type, ExtensionMap?, [(Int, Bool)])] = [
+        let tests: [([UInt8], any Message.Type, ExtensionMap?, [(Int, Bool)])] = [
             // Input, (Limit, success/failure)
 
             // Messages within messages:     // outer is msg 1

--- a/Tests/SwiftProtobufTests/Test_Unknown_proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_Unknown_proto2.swift
@@ -159,7 +159,7 @@ final class Test_Unknown_proto2: XCTestCase, PBTestHelpers {
     }
 
 
-    func assertUnknownFields(_ message: Message, _ bytes: [UInt8], line: UInt = #line) {
+    func assertUnknownFields(_ message: any Message, _ bytes: [UInt8], line: UInt = #line) {
         XCTAssertEqual(message.unknownFields.data, Data(bytes), line: line)
     }
 

--- a/Tests/SwiftProtobufTests/Test_Unknown_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_Unknown_proto3.swift
@@ -161,7 +161,7 @@ final class Test_Unknown_proto3: XCTestCase, PBTestHelpers {
     }
 
 
-    func assertUnknownFields(_ message: Message, _ bytes: [UInt8], line: UInt = #line) {
+    func assertUnknownFields(_ message: any Message, _ bytes: [UInt8], line: UInt = #line) {
         XCTAssertEqual(message.unknownFields.data, Data(bytes), line: line)
     }
 


### PR DESCRIPTION
This PR separates out the addition of the existential `any` from https://github.com/apple/swift-protobuf/pull/1504 into its own distinct PR for easier consumption. 

Context: https://github.com/apple/swift-protobuf/pull/1504 adds Self constraints to Message with the addition of `static var _fields: Field<Self>`. With this change the swift compiler will require uses of the existential `Message` type to be explicitly annotated with the `any` keyword. This keyword is currently optional for existential types without Self constraints however it will be required in swift 6.