### PR TITLE
Fix ordering bug in MessageSet parsing (1.x branch)

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -1213,7 +1213,7 @@ internal struct BinaryDecoder: Decoder {
                         extDecoder.fieldWireFormat = .lengthDelimited
                         try extDecoder.decodeExtensionField(values: &values,
                                                             messageType: messageType,
-                                                            fieldNumber: fieldNumber,
+                                                            fieldNumber: ext.fieldNumber,
                                                             messageExtension: ext)
                         wasDecoded = extDecoder.consumed
                       }

--- a/Tests/SwiftProtobufTests/Test_MessageSet.swift
+++ b/Tests/SwiftProtobufTests/Test_MessageSet.swift
@@ -144,6 +144,44 @@ class Test_MessageSet: XCTestCase {
     "}\n"
   )
 
+  func testParseOrder1() throws {
+    let serialized = Data([11,
+        16, 176, 166, 94, // Extension ID
+        26, 2, 120, 123, // Payload message
+        12])
+
+    let msg: Proto2WireformatUnittest_TestMessageSet
+    do {
+      msg = try Proto2WireformatUnittest_TestMessageSet(
+        serializedData: serialized,
+        extensions: ProtobufUnittest_UnittestMset_Extensions)
+    } catch let e {
+      XCTFail("Failed to parse: \(e)")
+      return
+    }
+    XCTAssertEqual(
+      msg.ProtobufUnittest_TestMessageSetExtension1_messageSetExtension.i, 123)
+  }
+
+  func testParseOrder2() throws {
+    let serialized = Data([11,
+        26, 2, 120, 123, // Payload message
+        16, 176, 166, 94, // Extension ID
+        12])
+
+    let msg: Proto2WireformatUnittest_TestMessageSet
+    do {
+      msg = try Proto2WireformatUnittest_TestMessageSet(
+        serializedData: serialized,
+        extensions: ProtobufUnittest_UnittestMset_Extensions)
+    } catch let e {
+      XCTFail("Failed to parse: \(e)")
+      return
+    }
+    XCTAssertEqual(
+      msg.ProtobufUnittest_TestMessageSetExtension1_messageSetExtension.i, 123)
+  }
+
   // text_format_unittest.cc: TEST_F(TextFormatMessageSetTest, Serialize)
   func testTextFormat_Serialize() {
     let msg = ProtobufUnittest_TestMessageSetContainer.with {


### PR DESCRIPTION
MessageSet encodes protobuf groups each containing an extension ID and a payload.  According to standard protobuf conventions, these two fields can occur in either order within the group.  Add two tests that check decoding of each possible order and fix the bug that this uncovers.

This is pulling #1512 to the 1.x branch.
