### PR TITLE
Use BufferPointer in the BinaryEncoding API

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -874,13 +874,11 @@ internal struct BinaryDecoder: Decoder {
                 let fieldSize = Varint.encodedSize(of: fieldTag.rawValue) + Varint.encodedSize(of: Int64(bodySize)) + bodySize
                 var field = Data(count: fieldSize)
                 field.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
-                  if let baseAddress = body.baseAddress, body.count > 0 {
-                    var encoder = BinaryEncoder(forWritingInto: baseAddress)
-                    encoder.startField(tag: fieldTag)
-                    encoder.putVarInt(value: Int64(bodySize))
-                    for v in extras {
-                        encoder.putVarInt(value: Int64(v))
-                    }
+                  var encoder = BinaryEncoder(forWritingInto: body)
+                  encoder.startField(tag: fieldTag)
+                  encoder.putVarInt(value: Int64(bodySize))
+                  for v in extras {
+                      encoder.putVarInt(value: Int64(v))
                   }
                 }
                 unknownOverride = field
@@ -1247,10 +1245,8 @@ internal struct BinaryDecoder: Decoder {
                         let payloadSize = Varint.encodedSize(of: Int64(data.count)) + data.count
                         var payload = Data(count: payloadSize)
                         payload.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
-                          if let baseAddress = body.baseAddress, body.count > 0 {
-                            var encoder = BinaryEncoder(forWritingInto: baseAddress)
-                            encoder.putBytesValue(value: data)
-                          }
+                          var encoder = BinaryEncoder(forWritingInto: body)
+                          encoder.putBytesValue(value: data)
                         }
                         fieldData = payload
                     } else {

--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -74,10 +74,8 @@ public enum BinaryDelimited {
     let totalSize = Varint.encodedSize(of: UInt64(serialized.count)) + serialized.count
     var bytes: [UInt8] = Array(repeating: 0, count: totalSize)
     bytes.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
-      if let baseAddress = body.baseAddress, body.count > 0 {
-        var encoder = BinaryEncoder(forWritingInto: baseAddress)
-        encoder.putBytesValue(value: serialized)
-      }
+      var encoder = BinaryEncoder(forWritingInto: body)
+      encoder.putBytesValue(value: serialized)
     }
 
     var written: Int = 0

--- a/Sources/SwiftProtobuf/BinaryEncoder.swift
+++ b/Sources/SwiftProtobuf/BinaryEncoder.swift
@@ -17,10 +17,12 @@ import Foundation
 
 /// Encoder for Binary Protocol Buffer format
 internal struct BinaryEncoder {
-    internal var pointer: UnsafeMutableRawPointer
+    private var pointer: UnsafeMutableRawPointer
+    private var buffer: UnsafeMutableRawBufferPointer
 
-    init(forWritingInto pointer: UnsafeMutableRawPointer) {
-        self.pointer = pointer
+    init(forWritingInto buffer: UnsafeMutableRawBufferPointer) {
+        self.buffer = buffer
+        self.pointer = buffer.baseAddress!
     }
 
     private mutating func append(_ byte: UInt8) {
@@ -32,9 +34,22 @@ internal struct BinaryEncoder {
         bytes.withUnsafeBytes { dataPointer in
             if let baseAddress = dataPointer.baseAddress, dataPointer.count > 0 {
                 pointer.copyMemory(from: baseAddress, byteCount: dataPointer.count)
-                pointer = pointer.advanced(by: dataPointer.count)
+                advance(dataPointer.count)
             }
         }
+    }
+
+    internal var used: Int {
+        return buffer.baseAddress!.distance(to: pointer)
+    }
+
+    internal var remainder: UnsafeMutableRawBufferPointer {
+        return UnsafeMutableRawBufferPointer(start: pointer,
+	    count: buffer.count - used)
+    }
+
+    internal mutating func advance(_ bytes: Int) {
+        pointer = pointer.advanced(by: bytes)
     }
 
     @discardableResult
@@ -45,10 +60,6 @@ internal struct BinaryEncoder {
         }
         pointer = pointer.advanced(by: count)
         return count
-    }
-
-    func distance(pointer: UnsafeMutableRawPointer) -> Int {
-        return pointer.distance(to: self.pointer)
     }
 
     mutating func appendUnknown(data: Data) {

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -27,8 +27,8 @@ internal struct BinaryEncodingVisitor: Visitor {
   /// - Precondition: `pointer` must point to an allocated block of memory that
   ///   is large enough to hold the entire encoded message. For performance
   ///   reasons, the encoder does not make any attempts to verify this.
-  init(forWritingInto pointer: UnsafeMutableRawPointer, options: BinaryEncodingOptions) {
-    self.encoder = BinaryEncoder(forWritingInto: pointer)
+  init(forWritingInto buffer: UnsafeMutableRawBufferPointer, options: BinaryEncodingOptions) {
+    self.encoder = BinaryEncoder(forWritingInto: buffer)
     self.options = options
   }
 
@@ -374,10 +374,10 @@ extension BinaryEncodingVisitor {
       encoder.putVarInt(value: length)
       // Create the sub encoder after writing the length.
       var subVisitor = BinaryEncodingVisitor(
-        forWritingInto: encoder.pointer, options: options
+        forWritingInto: encoder.remainder, options: options
       )
       try value.traverse(visitor: &subVisitor)
-      encoder.pointer = subVisitor.encoder.pointer
+      encoder.advance(subVisitor.encoder.used)
 
       encoder.putVarInt(value: Int64(WireFormat.MessageSet.Tags.itemEnd.rawValue))
     }

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -53,13 +53,11 @@ extension Message {
 
     var data = Bytes(repeating: 0, count: requiredSize)
     try data.withUnsafeMutableBytes { (body: UnsafeMutableRawBufferPointer) in
-      if let baseAddress = body.baseAddress, body.count > 0 {
-        var visitor = BinaryEncodingVisitor(forWritingInto: baseAddress, options: options)
-        try traverse(visitor: &visitor)
-        // Currently not exposing this from the api because it really would be
-        // an internal error in the library and should never happen.
-        assert(requiredSize == visitor.encoder.distance(pointer: baseAddress))
-      }
+      var visitor = BinaryEncodingVisitor(forWritingInto: body, options: options)
+      try traverse(visitor: &visitor)
+      // Currently not exposing this from the api because it really would be
+      // an internal error in the library and should never happen.
+      assert(visitor.encoder.remainder.count == 0)
     }
     return data
   }


### PR DESCRIPTION
Binary encoders are currently instantiated with a pointer to the beginning of the buffer into which they should encode the data.  In every case, we actually have a Swift "buffer pointer" which includes the size of the buffer.

As a general cleanup, pass the full buffer pointer into the encoder initializer and adjust the rest of the API a bit to fit better with this approach.

This also makes clients agnostic to whether the encoder is working front-to-back or back-to-front.