### PR TITLE
Try to get the performance harness running again...

### DIFF
--- a/Performance/Harness.h
+++ b/Performance/Harness.h
@@ -94,7 +94,7 @@ private:
    * from the main results.
    */
   template <typename Function>
-  typename std::result_of<Function()>::type measure_subtask(
+  typename std::invoke_result<Function>::type measure_subtask(
       const std::string& name, Function&& func);
 
   /**
@@ -171,7 +171,7 @@ void Harness::measure(const Function& func) {
 }
 
 template <typename Function>
-typename std::result_of<Function()>::type Harness::measure_subtask(
+typename std::invoke_result<Function>::type Harness::measure_subtask(
   const std::string& name, Function&& func) {
   subtask_names.push_back(name);
   using std::chrono::steady_clock;

--- a/Performance/Harness.swift
+++ b/Performance/Harness.swift
@@ -106,7 +106,7 @@ class Harness: GeneratedHarnessMembers {
 
         for name in taskNames {
           let time = currentSubtasks[name] ?? 0
-          print(String(format: "%9.3f", name, time), terminator: "")
+          print(String(format: "%9.3f", time), terminator: "")
           subtaskTimings[name] = (subtaskTimings[name] ?? []) + [time]
         }
         print()

--- a/Performance/generators/cpp.sh
+++ b/Performance/generators/cpp.sh
@@ -98,7 +98,6 @@ using google::protobuf::util::BinaryToJsonString;
 using google::protobuf::util::JsonToBinaryString;
 using google::protobuf::util::MessageDifferencer;
 using google::protobuf::util::NewTypeResolverForDescriptorPool;
-using google::protobuf::util::Status;
 using google::protobuf::util::TypeResolver;
 using std::cerr;
 using std::endl;
@@ -148,12 +147,14 @@ void Harness::run() {
       // Exercise JSON serialization.
       auto json = measure_subtask("Encode JSON", [&]() {
         string out_json;
-        BinaryToJsonString(type_resolver, *type_url, data, &out_json);
+        auto r = BinaryToJsonString(type_resolver, *type_url, data, &out_json);
+        (void)r; // UNUSED
         return out_json;
       });
       auto decoded_binary = measure_subtask("Decode JSON", [&]() {
         string out_binary;
-        JsonToBinaryString(type_resolver, *type_url, json, &out_binary);
+        auto r = JsonToBinaryString(type_resolver, *type_url, json, &out_binary);
+        (void)r; // UNUSED
         return out_binary;
       });
 

--- a/Performance/generators/swift.sh
+++ b/Performance/generators/swift.sh
@@ -106,20 +106,20 @@ extension Harness {
         populateFields(of: &message)
       }
 
-      message = measureSubtask("Populate fields with with") {
+      message = measureSubtask("Populate (with)") {
         return populateFieldsWithWith()
       }
 
       // Exercise binary serialization.
-      let data = try measureSubtask("Encode binary") {
-        return try message.serializedBytes()
+      let data = try measureSubtask("Encode binary") { () -> Data in
+        try message.serializedBytes()
       }
       let message2 = try measureSubtask("Decode binary") {
         return try PerfMessage(serializedData: data)
       }
 
       // Exercise JSON serialization.
-      let json = try measureSubtask("Encode JSON") {
+      let json = try measureSubtask("Encode JSON") { () -> Data in
         return try message.jsonUTF8Bytes()
       }
       _ = try measureSubtask("Decode JSON") {

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -46,7 +46,7 @@ readonly script_dir=`pwd`
 # Change this if your checkout of github.com/protocolbuffers/protobuf is in a
 # different location.
 readonly GOOGLE_PROTOBUF_CHECKOUT=${GOOGLE_PROTOBUF_CHECKOUT:-"$script_dir/../../protobuf"}
-readonly PROTOC=${PROTOC:-"${GOOGLE_PROTOBUF_CHECKOUT}/src/protoc"}
+readonly PROTOC=${PROTOC:-"${GOOGLE_PROTOBUF_CHECKOUT}/protoc"}
 
 function usage() {
   cat >&2 <<EOF

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -351,6 +351,11 @@ echo
 
 build_swift_packages "$script_dir/.." "ForWorkTree"
 
+${PROTOC} --plugin="$script_dir/../.build/release/protoc-gen-swift" \
+          --swift_out=FileNaming=DropPath:"$GIT_WORKTREE/Performance/_generated" \
+          --proto_path=`dirname $gen_message_path` \
+          "$gen_message_path"
+
 harness_swift="$script_dir/_generated/harness_swift"
 results_trace="$script_dir/_results/$report_type (swift)"
 display_results_trace="$results_trace"

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -123,7 +123,7 @@ EOF
 
   echo "Running $language test harness alone..."
   sleep 3
-  DYLD_LIBRARY_PATH="$script_dir/_generated" "$harness" "$partial_results"
+  DYLD_LIBRARY_PATH=`dirname $harness` "$harness" "$partial_results"
   sleep 3
 
   cp "$harness" "${harness}_stripped"

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -352,7 +352,7 @@ echo
 build_swift_packages "$script_dir/.." "ForWorkTree"
 
 ${PROTOC} --plugin="$script_dir/../.build/release/protoc-gen-swift" \
-          --swift_out=FileNaming=DropPath:"$GIT_WORKTREE/Performance/_generated" \
+          --swift_out=FileNaming=DropPath:`dirname $gen_message_path` \
           --proto_path=`dirname $gen_message_path` \
           "$gen_message_path"
 

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -151,8 +151,10 @@ function profile_harness() {
   perf_dir="$3"
 
   echo "Running $description test harness in Instruments..."
-  instruments -t "$script_dir/Protobuf" -D "$results_trace" \
-      "$harness" -e DYLD_LIBRARY_PATH "$perf_dir/_generated"
+  mkdir -p "$results_trace"
+  xctrace record --template 'Time Profiler' --output "$results_trace" \
+	  --env DYLD_LIBRARY_PATH="$perf_dir/_generated" \
+	  --launch -- "$harness"
 }
 
 # Inserts the partial visualization results from all the languages tested into
@@ -359,6 +361,5 @@ EOF
 
 insert_visualization_results "$partial_results" "$results_js"
 
-# Open the Instruments trace and HTML report at the end.
-open -g "$display_results_trace.trace"
+# Open the HTML report at the end.
 open -g "$script_dir/harness-visualization.html"

--- a/Performance/runners/CMakeLists.txt
+++ b/Performance/runners/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# cmake configuration file for building the C++ test harness
+#
+# This assumes you have a protobuf source checkout handy,
+# and have used `git submodule update` to obtain all the
+# related source repos.
+#
+# This script uses the protobuf sources to build libprotobuf and
+# statically links it into the test harness executable.
+# (This is probably not necessary; updates to this file to
+# use a better strategy would be appreciated.)
+#
+# Also assumes that you have abseil_cpp and googletest installed
+# locally via e.g.,
+#   brew install googletest
+#   brew install abseil
+#
+
+cmake_minimum_required(VERSION 3.10...3.26)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+project(swiftprotobuf-perf C CXX)
+
+# Update this with the appropriate path to the protobuf source
+# checkout, starting from the directory holding this file.
+# Default here assumes that `protobuf` is checked out beside
+# `swift-protobuf`
+set(protobuf_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../../protobuf)
+set(protobuf_VERSION "999.999")
+
+# Use protobuf cmake scripts to locate suitable abseil package:
+set(protobuf_ABSL_PROVIDER "package")
+include(${protobuf_SOURCE_DIR}/cmake/abseil-cpp.cmake)
+
+# Use protobuf cmake scripts for building libprotobuf
+include(${protobuf_SOURCE_DIR}/cmake/libprotobuf.cmake)
+
+# Use utf8_range from protobuf checkout
+set(utf8_range_SOURCE_DIR ${protobuf_SOURCE_DIR}/third_party/utf8_range)
+add_subdirectory(${utf8_range_SOURCE_DIR} third_party/utf8_range)
+
+include_directories(
+  ${protobuf_SOURCE_DIR}/src
+  ${utf8_range_SOURCE_DIR}
+)
+
+add_executable(harness_cpp
+  ../main.cc
+  ../Harness.cc
+  ../_generated/Harness+Generated.cc
+  ../_generated/message.pb.cc
+)
+
+target_include_directories(harness_cpp PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/..
+  ${ABSL_ROOT_DIR}
+  ${utf8_range_SOURCE_DIR}
+)
+
+target_link_libraries(harness_cpp PRIVATE libprotobuf)

--- a/Performance/runners/cpp.sh
+++ b/Performance/runners/cpp.sh
@@ -34,7 +34,7 @@ function run_cpp_harness() {
     cmake -B ../_generated -S .
     cmake --build ../_generated
     popd
-    
+
     run_harness_and_concatenate_results "C++" "$harness" "$partial_results"
     echo
   )

--- a/Performance/runners/cpp.sh
+++ b/Performance/runners/cpp.sh
@@ -27,24 +27,12 @@ function run_cpp_harness() {
     generate_cpp_harness
 
     echo "Building C++ test harness..."
-    time ( g++ --std=c++11 -O \
-        -o "$harness" \
-        -I "$script_dir" \
-        -I "$GOOGLE_PROTOBUF_CHECKOUT/src" \
-        -L "$GOOGLE_PROTOBUF_CHECKOUT/src/.libs" \
-        -lprotobuf \
-        "$gen_harness_path" \
-        "$script_dir/Harness.cc" \
-        "$script_dir/_generated/message.pb.cc" \
-        "$script_dir/main.cc" \
-    )
-    echo
 
-    # Make sure the dylib is loadable from the harness if the user hasn't
-    # actually installed them.
-    cp "$GOOGLE_PROTOBUF_CHECKOUT"/src/.libs/libprotobuf.*.dylib \
-        "$script_dir/_generated"
-
+    pushd $script_dir/runners
+    cmake -B ../_generated -S .
+    cmake --build ../_generated
+    popd
+    
     run_harness_and_concatenate_results "C++" "$harness" "$partial_results"
   )
 }

--- a/Performance/runners/cpp.sh
+++ b/Performance/runners/cpp.sh
@@ -26,7 +26,9 @@ function run_cpp_harness() {
     gen_harness_path="$script_dir/_generated/Harness+Generated.cc"
     generate_cpp_harness
 
-    echo "Building C++ test harness..."
+    echo
+    echo "Building C++ libprotobuf and performance test harness..."
+    echo
 
     pushd $script_dir/runners
     cmake -B ../_generated -S .
@@ -34,5 +36,6 @@ function run_cpp_harness() {
     popd
     
     run_harness_and_concatenate_results "C++" "$harness" "$partial_results"
+    echo
   )
 }


### PR DESCRIPTION
Ongoing changes to the protobuf build system broke the previous performance harness scripts.

I've rebuilt the C++ perf harness by using a CMake build script to build libprotobuf and the C++ harness together.  This uses more of the protobuf build machinery than I'd like -- it could probably be simplified and made more robust.

This has some requirements:
 * A protobuf source checkout that has all the submodules
 * abseil and googletest libraries installed on the local system and findable by CMake (On Mac, `brew install abseil googletest` seems to suffice)