### PR TITLE
Make `anyTranscodeFailure` more descriptive

### DIFF
--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -210,7 +210,7 @@ internal class AnyMessageStorage {
     case .contentJSON(let contentJSON, let options):
       // contentJSON requires we have the type available for decoding
       guard let messageType = Google_Protobuf_Any.messageType(forTypeURL: _typeURL) else {
-          throw BinaryEncodingError.anyTranscodeFailure
+          throw BinaryEncodingError.anyTypeURLNotRegistered(typeURL: _typeURL)
       }
       do {
         // Decodes the full JSON and then discard the result.
@@ -414,7 +414,7 @@ extension AnyMessageStorage {
         // binary value, so we're stuck.  (The Google spec does not
         // provide a way to just package the binary value for someone
         // else to decode later.)
-        throw JSONEncodingError.anyTranscodeFailure
+        throw JSONEncodingError.anyTypeURLNotRegistered(typeURL: _typeURL)
       }
       let m = try messageType.init(serializedBytes: valueData, partial: true)
       return try serializeAnyJSON(for: m, typeURL: _typeURL, options: options)

--- a/Sources/SwiftProtobuf/BinaryEncodingError.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingError.swift
@@ -13,18 +13,18 @@
 // -----------------------------------------------------------------------------
 
 /// Describes errors that can occur when decoding a message from binary format.
-public enum BinaryEncodingError: Error {
+public enum BinaryEncodingError: Error, Equatable {
   /// `Any` fields that were decoded from JSON cannot be re-encoded to binary
   /// unless the object they hold is a well-known type or a type registered via
   /// `Google_Protobuf_Any.register()`.
+  case anyTypeURLNotRegistered(typeURL: String)
+  /// An unexpected failure when deserializing a `Google_Protobuf_Any`.
   case anyTranscodeFailure
-
   /// The definition of the message or one of its nested messages has required
   /// fields but the message being encoded did not include values for them. You
   /// must pass `partial: true` during encoding if you wish to explicitly ignore
   /// missing required fields.
   case missingRequiredFields
-
   /// Messages are limited to a maximum of 2GB in encoded size.
   case tooLarge
 }

--- a/Sources/SwiftProtobuf/JSONEncodingError.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingError.swift
@@ -12,12 +12,12 @@
 ///
 // -----------------------------------------------------------------------------
 
-public enum JSONEncodingError: Error {
+public enum JSONEncodingError: Error, Equatable {
     /// Any fields that were decoded from binary format cannot be
     /// re-encoded into JSON unless the object they hold is a
     /// well-known type or a type registered with via
     /// Google_Protobuf_Any.register()
-    case anyTranscodeFailure
+    case anyTypeURLNotRegistered(typeURL: String)
     /// Timestamp values can only be JSON encoded if they hold a value
     /// between 0001-01-01Z00:00:00 and 9999-12-31Z23:59:59.
     case timestampRange


### PR DESCRIPTION
Right now it's quite difficult to identify _which type_ is missing from the `Google_Protobuf_Any` registry when the `anyTranscodeFailure` is thrown without having Xcode and breakpoints to debug the program. This change makes the error more descriptive and actionable by including the type URL that needs to be registered.

Errors now look like this:

> Swift/ErrorType.swift:200: Fatal error: Error raised at top level: SwiftProtobuf.BinaryEncodingError.anyTypeURLNotRegistered(typeURL: "type.googleapis.com/connectrpc.conformance.v1.IdempotentUnaryRequest")