### PR TITLE
Don't allow implementationOnly with package visibility.

### DIFF
--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -91,9 +91,9 @@ class FileGenerator {
         p.print("\(comments)import Foundation")
 
         if self.generatorOptions.implementationOnlyImports,
-           self.generatorOptions.visibility == .public {
+           self.generatorOptions.visibility != .internal {
             errorString = """
-                Cannot use @_implementationOnly imports when the proto visibility is public.
+                Cannot use @_implementationOnly imports when the proto visibility is public or package.
                 Either change the visibility to internal, or disable @_implementationOnly imports.
             """
             return


### PR DESCRIPTION
Follow up to #1472, looks like we didn't realize this gate should also be updated.