### PR TITLE
Fix the output from protoc for options errors.

### DIFF
--- a/Sources/protoc-gen-swift/GenerationError.swift
+++ b/Sources/protoc-gen-swift/GenerationError.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 
-enum GenerationError: Error {
+enum GenerationError: Error, CustomStringConvertible {
   /// Raised when parsing the parameter string and found an unknown key.
   case unknownParameter(name: String)
   /// Raised when a parameter was given an invalid value.


### PR DESCRIPTION
Without the conformance we were getting the type description instead.