### PR TITLE
Expose the error to the `os(WASI)` build.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -14,6 +14,7 @@
 
 #if !os(WASI)
 import Foundation
+#endif
 
 /// Helper methods for reading/writing messages with a length prefix.
 public enum BinaryDelimited {
@@ -47,6 +48,7 @@ public enum BinaryDelimited {
     case noBytesAvailable
   }
 
+#if !os(WASI)
   /// Serialize a single size-delimited message to the given stream. Delimited
   /// format allows a single file or stream to contain multiple messages,
   /// whereas normally writing multiple non-delimited messages to the same
@@ -222,8 +224,10 @@ public enum BinaryDelimited {
                       partial: partial,
                       options: options)
   }
+#endif  // !os(WASI)
 }
 
+#if !os(WASI)
 // TODO: This should go away when encoding/decoding are more stream based
 // as that should provide a more direct way to do this. This is basically
 // a rewrite of BinaryDecoder.decodeVarint().
@@ -268,4 +272,4 @@ internal func decodeVarint(_ stream: InputStream) throws -> UInt64 {
     }
   }
 }
-#endif
+#endif  // !os(WASI)


### PR DESCRIPTION
This should let `AsyncMessageSequency.swift` build.