### PR TITLE
Move to actions/checkout@v4 (on 1.x branch).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,8 @@ jobs:
       image: swift:${{ matrix.swift }}${{ matrix.ubuntu }}
     steps:
     - name: Checkout
+      # 5.1.5 and lower Swift versions end up on images where actions/checkout@v4
+      # fails because the image is too old.
       uses: actions/checkout@v3
       with:
         path: main
@@ -115,7 +117,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
     - name: Checkout protobuf repo
       if: ${{ matrix.build_protobuf && steps.cache-protobuf.outputs.cache-hit != 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: protocolbuffers/protobuf
         ref: ${{ steps.get-sha.outputs.sha }}
@@ -154,7 +156,7 @@ jobs:
     container:
       image: swift:latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test
       run: |
         set -eu
@@ -182,6 +184,6 @@ jobs:
     container:
       image: swift:latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: FuzzTesting/do_build.sh --${{ matrix.swiftpm_config }}-only --run-regressions

--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: main
     - name: Checkout protobufbuffers/protobuf
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: protocolbuffers/protobuf
         path: protobuf

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -36,7 +36,7 @@ jobs:
       image: swift:${{ matrix.swift }}-${{ matrix.ubuntu }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: main
     - name: Update and install dependencies
@@ -65,7 +65,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
     - name: Checkout protobuf repo
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: protocolbuffers/protobuf
         ref: ${{ steps.get-sha.outputs.sha }}


### PR DESCRIPTION
Resolves the warnings seen on the actions output:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.