### PR TITLE
Add SwiftPM diagnose-api-breaking-changes check to 1_x branch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,32 @@ jobs:
       working-directory: main
       run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner
 
+  api-breakage:
+    # Only on pull requests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container:
+      # Test on the latest Swift release. This could run on all the support
+      # Swift versions, but the SwiftPM support isn't in all the version supported.
+      image: swift:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Mark the workspace as safe
+      # https://github.com/actions/checkout/issues/766
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+    - name: Check for API breaking changes
+      # Since descriptor.proto is generated and exposed, any changes upstream
+      # can result in things that would count as breaking changes, the allowlist
+      # is used to those won't count in this test.
+      run: |
+        LAST_TAG=$(git describe --abbrev=0 --tags)
+        echo "Comparing to tag: ${LAST_TAG}"
+        swift package diagnose-api-breaking-changes "${LAST_TAG}" --products SwiftProtobuf \
+          --breakage-allowlist-path known_api_breaks.txt
+
   sanitizer_testing:
     runs-on: ubuntu-latest
     strategy:

--- a/known_api_breaks.txt
+++ b/known_api_breaks.txt
@@ -1,0 +1,36 @@
+API breakage: enumelement Google_Protobuf_Edition.proto2 has been added as a new enum case
+API breakage: enumelement Google_Protobuf_Edition.proto3 has been added as a new enum case
+API breakage: enumelement Google_Protobuf_Edition.max has been added as a new enum case
+API breakage: var Google_Protobuf_FileDescriptorProto.edition has declared type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FileDescriptorProto.edition.Get() has return type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FileDescriptorProto.edition.Set() has parameter 0 type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: var Google_Protobuf_FieldOptions.EditionDefault.edition has declared type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FieldOptions.EditionDefault.edition.Get() has return type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FieldOptions.EditionDefault.edition.Set() has parameter 0 type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: var Google_Protobuf_FeatureSetDefaults.minimumEdition has declared type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.minimumEdition.Get() has return type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.minimumEdition.Set() has parameter 0 type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: var Google_Protobuf_FeatureSetDefaults.maximumEdition has declared type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.maximumEdition.Get() has return type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.maximumEdition.Set() has parameter 0 type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: var Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.edition has declared type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.edition.Get() has return type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: accessor Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.edition.Set() has parameter 0 type change from Swift.String to SwiftProtobuf.Google_Protobuf_Edition
+API breakage: var Google_Protobuf_FileDescriptorProto.editionEnum has been removed
+API breakage: var Google_Protobuf_FileDescriptorProto.hasEditionEnum has been removed
+API breakage: func Google_Protobuf_FileDescriptorProto.clearEditionEnum() has been removed
+API breakage: var Google_Protobuf_FileOptions.phpGenericServices has been removed
+API breakage: var Google_Protobuf_FileOptions.hasPhpGenericServices has been removed
+API breakage: func Google_Protobuf_FileOptions.clearPhpGenericServices() has been removed
+API breakage: var Google_Protobuf_FieldOptions.EditionDefault.editionEnum has been removed
+API breakage: var Google_Protobuf_FieldOptions.EditionDefault.hasEditionEnum has been removed
+API breakage: func Google_Protobuf_FieldOptions.EditionDefault.clearEditionEnum() has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.minimumEditionEnum has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.hasMinimumEditionEnum has been removed
+API breakage: func Google_Protobuf_FeatureSetDefaults.clearMinimumEditionEnum() has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.maximumEditionEnum has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.hasMaximumEditionEnum has been removed
+API breakage: func Google_Protobuf_FeatureSetDefaults.clearMaximumEditionEnum() has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.editionEnum has been removed
+API breakage: var Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.hasEditionEnum has been removed
+API breakage: func Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault.clearEditionEnum() has been removed


### PR DESCRIPTION
Just run this on each PR to flag any changes. This will check against the last tag on this branch so it should collect changes across commits until a new tag is made. If we did accept breaking changes, we'd have to add the exceptions list and/or prevent this step from breaking.

We also have to accept changes as a side effect of generating from descriptor.proto as we don't control that and don't really expect folks to need to directly interact with the file, it is just provide to make dealing with .proto file that make use of proto options easier.

Used some of the https://github.com/vapor projects for reference and the git magic needed to for the action to run.