### PR TITLE
Add a descriptor object for ExtensionRange.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
@@ -33,6 +33,14 @@ extension Descriptor: ProvidesLocationPath, ProvidesSourceCodeLocation, TypeOrFi
   public var isDeprecated: Bool { options.deprecated }
 }
 
+extension Descriptor.ExtensionRange: ProvidesLocationPath, ProvidesSourceCodeLocation {
+  public func getLocationPath(path: inout IndexPath) {
+    containingType.getLocationPath(path: &path)
+    path.append(Google_Protobuf_DescriptorProto.FieldNumbers.extensionRange)
+    path.append(index)
+  }
+}
+
 extension EnumDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation, TypeOrFileProvidesDeprecationComment {
   public func getLocationPath(path: inout IndexPath) {
     if let containingType = containingType {

--- a/Sources/SwiftProtobufPluginLibrary/FieldNumbers.swift
+++ b/Sources/SwiftProtobufPluginLibrary/FieldNumbers.swift
@@ -29,6 +29,7 @@ extension Google_Protobuf_DescriptorProto {
     static let field: Int = 2
     static let nestedType: Int = 3
     static let enumType: Int = 4
+    static let extensionRange: Int = 4
     static let `extension`: Int = 6
     static let oneofDecl: Int = 8
   }


### PR DESCRIPTION
Upstream protobuf has also done similiar, moving form a simple `struct` to a full `class`. Protobuf Editions supports Features on ExtensionRanges so this is needed to properly model the full Features support in the future.

In theory this would a a breaking api change to the Plugin library, however nothing outside of of the local generator uses this, so it should be safe safe as there really isn't a reason something else (grpc) would really need this information.