### PR TITLE
Update how copyrights are extraction for Editions.

### DIFF
--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -74,13 +74,20 @@ class FileGenerator {
         // The C++ FileDescriptor::GetSourceLocation(), says the location for
         // the file is an empty path. That never seems to have comments on it.
         // https://github.com/protocolbuffers/protobuf/issues/2249 opened to
-        // figure out the right way to do this since the syntax entry is
-        // optional.
-        var comments = String()
+        // figure out the right way to do this but going forward best bet seems
+        // to be to look for the "edition" or the "syntax" decl.
+        let editionPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.edition)
         let syntaxPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax)
-        if let syntaxLocation = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
-          comments = syntaxLocation.asSourceComment(commentPrefix: "///",
-                                                    leadingDetachedPrefix: "//")
+        var commentLocation: Google_Protobuf_SourceCodeInfo.Location? = nil
+        if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {
+            commentLocation = location
+        } else if let location = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
+            commentLocation = location
+        }
+        var comments = String()
+        if let commentLocation = commentLocation {
+          comments = commentLocation.asSourceComment(commentPrefix: "///",
+                                                     leadingDetachedPrefix: "//")
           // If the was a leading or tailing comment it won't have a blank
           // line, after it, so ensure there is one.
           if !comments.isEmpty && !comments.hasSuffix("\n\n") {

--- a/Sources/protoc-gen-swift/Google_Protobuf_FileDescriptorProto+Extensions.swift
+++ b/Sources/protoc-gen-swift/Google_Protobuf_FileDescriptorProto+Extensions.swift
@@ -20,5 +20,6 @@ extension Google_Protobuf_FileDescriptorProto {
   // Field numbers used to collect .proto file comments.
   struct FieldNumbers {
     static let syntax: Int = 12
+    static let edition: Int = 14
   }
 }


### PR DESCRIPTION
Since there won't be a `syntax` decl any more, look for `editions` first and then fall back to `syntax` of nothing was found.