### PR TITLE
`CodeGenerator` support for response edition information.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift
@@ -20,11 +20,13 @@ extension Google_Protobuf_Compiler_CodeGeneratorResponse {
   }
 
   /// Helper to make a response with a set of files
+  @available(*, deprecated, message: "Please move your plugin to the CodeGenerator interface")
   public init(files: [Google_Protobuf_Compiler_CodeGeneratorResponse.File]) {
     self.init(files: files, supportedFeatures: [])
   }
 
   /// Helper to make a response with a set of files and supported features.
+  @available(*, deprecated, message: "Please move your plugin to the CodeGenerator interface")
   public init(
     files: [Google_Protobuf_Compiler_CodeGeneratorResponse.File],
     supportedFeatures: [Google_Protobuf_Compiler_CodeGeneratorResponse.Feature] = []

--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
@@ -1,0 +1,25 @@
+// Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift - Google_Protobuf_Edition extensions
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Extensions to `Google_Protobuf_Edition` provide some simple helpers.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+import SwiftProtobuf
+
+/// The spec for editions calls out them being ordered and comparable.
+/// https://github.com/protocolbuffers/protobuf/blob/main/docs/design/editions/edition-naming.md
+extension Google_Protobuf_Edition: Comparable {
+  public static func < (lhs: Google_Protobuf_Edition, rhs: Google_Protobuf_Edition) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+  }
+}


### PR DESCRIPTION
- Add api to get supported editions range.
- If the generator signals editions support, add the range into the generation response.
- Make the protos Editions enum Comparable since the docs document it and it then will allow other code paths to do version comparisons.