### PR TITLE
Include "empty" privacy manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,12 +38,14 @@ let package = Package(
     .target(
         name: "SwiftProtobuf",
         exclude: ["CMakeLists.txt"],
+	resources: [.copy("PrivacyInfo.xcprivacy")],
         swiftSettings: .packageSettings
     ),
     .target(
         name: "SwiftProtobufPluginLibrary",
         dependencies: ["SwiftProtobuf"],
         exclude: ["CMakeLists.txt"],
+	resources: [.copy("PrivacyInfo.xcprivacy")],
         swiftSettings: .packageSettings
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -38,14 +38,14 @@ let package = Package(
     .target(
         name: "SwiftProtobuf",
         exclude: ["CMakeLists.txt"],
-	resources: [.copy("PrivacyInfo.xcprivacy")],
+        resources: [.copy("PrivacyInfo.xcprivacy")],
         swiftSettings: .packageSettings
     ),
     .target(
         name: "SwiftProtobufPluginLibrary",
         dependencies: ["SwiftProtobuf"],
         exclude: ["CMakeLists.txt"],
-	resources: [.copy("PrivacyInfo.xcprivacy")],
+        resources: [.copy("PrivacyInfo.xcprivacy")],
         swiftSettings: .packageSettings
     ),
     .target(

--- a/Sources/SwiftProtobuf/PrivacyInfo.xcprivacy
+++ b/Sources/SwiftProtobuf/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/SwiftProtobufPluginLibrary/PrivacyInfo.xcprivacy
+++ b/Sources/SwiftProtobufPluginLibrary/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0'
 
   s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
+  s.resource_bundle = {'SwiftProtobuf' => ['Sources/SwiftProtobuf/PrivacyInfo.xcprivacy']}
 
   s.swift_versions = ['5.0']
 end


### PR DESCRIPTION
Include it as a resource in both SwiftProtobuf library and SwiftProtobufPluginLibrary when built via podspec or swiftpm

Resolves #1529 