### PR TITLE
Try pinning some testing to Swift 5.9.2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,9 @@ jobs:
         swiftpm_config: ["debug", "release"]
     container:
       # Test on the latest Swift release.
-      image: swift:latest
+      # image: swift:latest
+      # As of 5.10.0, the "thread" testing fails. Back to what last worked:
+      image: swift:5.9.2-jammy
     steps:
     - uses: actions/checkout@v4
     - name: Test
@@ -170,7 +172,9 @@ jobs:
         swiftpm_config: ["debug", "release"]
     container:
       # Test on the latest Swift release.
-      image: swift:latest
+      # image: swift:latest
+      # As of 5.10.0, the "thread" testing fails. Back to what last worked:
+      image: swift:5.9.2-jammy
     steps:
     - uses: actions/checkout@v4
     - name: Build


### PR DESCRIPTION
With the 5.10 release, we're seeing some test fail (#1573 and #1571), try pinning to 5.9.2 since CI from last week where `swift:latest` was that still worked.