### PR TITLE
Mark `_NameMap` and supporting types as `Sendable`.

### DIFF
--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -279,3 +279,16 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
     return jsonToNumberMap[n]
   }
 }
+
+// The `_NameMap` (and supporting types) are only mutated during their initial
+// creation, then for the lifetime of the a process they are constant. Swift
+// 5.10 flags the generated `_protobuf_nameMap` usages as a problem
+// (https://github.com/apple/swift-protobuf/issues/1560) so this silences those
+// warnings since the usage has been deemed safe.
+//
+// https://github.com/apple/swift-protobuf/issues/1561 is also opened to revisit
+// the `_NameMap` generally as it dates back to the days before Swift perferred
+// the UTF-8 internal encoding.
+extension _NameMap : Sendable {}
+extension _NameMap.Name : @unchecked Sendable {}
+extension InternPool : @unchecked Sendable {}


### PR DESCRIPTION
I think this is the rest of the issues in #1560

This is the different approach discussed in #1564.