### PR TITLE
make fuzz and sanitizer tests not break CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,10 @@ jobs:
           --breakage-allowlist-path known_api_breaks.txt
 
   sanitizer_testing:
+    # Something likely changed in the base ubuntu image causing failures,
+    # don't fail the build based on these changes.
+    # https://github.com/apple/swift-protobuf/issues/1571
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -202,6 +206,10 @@ jobs:
         swift test -c ${{ matrix.swiftpm_config }} --sanitize=${{ matrix.sanitizer }} ${EXTRAS:-}
 
   fuzzing_regressions:
+    # Something likely changed in the base ubuntu image causing failures,
+    # don't fail the build based on these changes.
+    # https://github.com/apple/swift-protobuf/issues/1573
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Mark the build steps as allowed to fail while we work out what's happening since it doesn't seem related to Swift.

This is pulling #1576 to the 1.x branch.
