### PR TITLE
Honor features and expose potential support to `CodeGenerator`

### DIFF
--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -124,7 +124,6 @@ class OneofGenerator {
     private let storedProperty: String
 
     init(descriptor: OneofDescriptor, generatorOptions: GeneratorOptions, namer: SwiftProtobufNamer, usesHeapStorage: Bool) {
-        precondition(!descriptor.isSynthetic)
         self.oneofDescriptor = descriptor
         self.generatorOptions = generatorOptions
         self.namer = namer

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import SwiftProtobuf
-import SwiftProtobufPluginLibrary
+@testable import SwiftProtobufPluginLibrary
 
 final class Test_Descriptor: XCTestCase {
 


### PR DESCRIPTION
This does not enable editions for Swift Protobuf, this is just more internals to build things out.
