### PR TITLE
Use `loadUnaligned` when reading the conformance test request size.

### DIFF
--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -47,7 +47,7 @@ func readRequest() -> Data? {
         return nil
     }
     let countLE: UInt32 = countLEData.withUnsafeBytes { rawBuffer in
-        rawBuffer.load(as: UInt32.self)
+        rawBuffer.loadUnaligned(as: UInt32.self)
     }
     let count = UInt32(littleEndian: countLE)
     guard count < Int.max,


### PR DESCRIPTION
We recently updated our internal version of the Swift toolchain (2024-03-12 nightly) and the conformance test runner started crashing at runtime on Linux. I tracked the issue down to this `load` operation; apparently, the pointers we started getting back from `FileHandle.read` weren't always 4-byte-aligned anymore (the ones I was getting back were all `0x...2`). This was the case whether we were linking in our custom allocator ([tcmalloc](https://github.com/google/tcmalloc)) or using system `malloc`.

It's really puzzling that a Swift toolchain update would cause this change in behavior. I couldn't identify any specific code that had changed in swift-corelibs-foundation's Foundation or CoreFoundation that would alter the alignment; it looks like they both use standard `malloc` and `realloc` calls under the hood, and I would expect them to always return something that's _at least_ 4-byte-aligned.

But perhaps it's a latent bug that we've been assuming that alignment to always be true; the `read` function doesn't make any guarantees about the alignment of the data it returns, so this is strictly safer.

It's worth pointing out that our `BinaryDecoder` [avoids this problem](https://github.com/apple/swift-protobuf/blob/b505f6c11f2fea9840b9f0166b471a4381a04ed5/Sources/SwiftProtobuf/BinaryDecoder.swift#L1425-L1443) by using `copyMemory` to read 4- and 8-byte values. That code was written before `loadUnaligned` was available (Swift 5.7), so we could update that code to use more modern APIs as well.

@Lukasa @tbkka @FranzBusch Do any of you have any insight here?