### PR TITLE
Backport fixes for WASI compilation to v1

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -14,6 +14,7 @@
 
 #if !os(WASI)
 import Foundation
+#endif
 
 /// Helper methods for reading/writing messages with a length prefix.
 public enum BinaryDelimited {
@@ -30,6 +31,7 @@ public enum BinaryDelimited {
     case truncated
   }
 
+#if !os(WASI)
   /// Serialize a single size-delimited message from the given stream. Delimited
   /// format allows a single file or stream to contain multiple messages,
   /// whereas normally writing multiple non-delimited messages to the same
@@ -204,8 +206,10 @@ public enum BinaryDelimited {
                       partial: partial,
                       options: options)
   }
+#endif  // !os(WASI)
 }
 
+#if !os(WASI)
 // TODO: This should go away when encoding/decoding are more stream based
 // as that should provide a more direct way to do this. This is basically
 // a rewrite of BinaryDecoder.decodeVarint().
@@ -247,4 +251,4 @@ internal func decodeVarint(_ stream: InputStream) throws -> UInt64 {
     }
   }
 }
-#endif
+#endif  // !os(WASI)

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -14,11 +14,13 @@
 // -----------------------------------------------------------------------------
 
 import Foundation
+#if !os(WASI)
 #if canImport(Dispatch)
 import Dispatch
 fileprivate let knownTypesQueue =
     DispatchQueue(label: "org.swift.protobuf.typeRegistry",
                   attributes: .concurrent)
+#endif
 #endif
 
 // TODO: Should these first four be exposed as methods to go with


### PR DESCRIPTION
I had the same reaction as in #1603 seeing changes not make it into the latest release and then learned of the v1 release branch. Wondering if it is appropriate to bring in these two small commits to allow compilation to WASI with v1.

I have verified this branch can be compiled to WASI here

https://github.com/wasilibs/go-protoc-gen-swift/pull/1

It cherrypicks two commits

https://github.com/apple/swift-protobuf/commit/ef8bca9 (automatic)
https://github.com/apple/swift-protobuf/commit/ea9ac1c4 (manual due to conflicts)

If this is not the type of fix you generally backport, feel free to close the PR and I'll target `main`, just sending it in case.