### PR TITLE
Add missing `@preconcurrency` annotations to `Sendable`-conforming protocols

### DIFF
--- a/Sources/SwiftProtobuf/Enum.swift
+++ b/Sources/SwiftProtobuf/Enum.swift
@@ -16,6 +16,7 @@
 // -----------------------------------------------------------------------------
 
 /// Generated enum types conform to this protocol.
+@preconcurrency
 public protocol Enum: RawRepresentable, Hashable, CaseIterable, Sendable {
   /// Creates a new instance of the enum initialized to its default value.
   init()

--- a/Sources/SwiftProtobuf/ExtensibleMessage.swift
+++ b/Sources/SwiftProtobuf/ExtensibleMessage.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 // Messages that support extensions implement this protocol
+@preconcurrency
 public protocol ExtensibleMessage: Message {
     var _protobuf_extensionFieldValues: ExtensionFieldValueSet { get set }
 }

--- a/Sources/SwiftProtobuf/ExtensionFields.swift
+++ b/Sources/SwiftProtobuf/ExtensionFields.swift
@@ -22,6 +22,7 @@
 // equality with some other extension field; but it's type-sealed
 // so you can't actually access the contained value itself.
 //
+@preconcurrency
 public protocol AnyExtensionField: Sendable {
   func hash(into hasher: inout Hasher)
   var protobufExtension: any AnyMessageExtension { get }
@@ -46,7 +47,8 @@ extension AnyExtensionField {
 ///
 /// The regular ExtensionField type exposes the value directly.
 ///
-public protocol ExtensionField: AnyExtensionField, Hashable, Sendable {
+@preconcurrency
+public protocol ExtensionField: AnyExtensionField, Hashable {
   associatedtype ValueType
   var value: ValueType { get set }
   init(protobufExtension: any AnyMessageExtension, value: ValueType)

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -22,6 +22,7 @@
 /// This is a protocol so that developers can build their own
 /// extension handling if they need something more complex than the
 /// standard `SimpleExtensionMap` implementation.
+@preconcurrency
 public protocol ExtensionMap: Sendable {
     /// Returns the extension object describing an extension or nil
     subscript(messageType: any Message.Type, fieldNumber: Int) -> (any AnyMessageExtension)? { get }

--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -26,6 +26,7 @@ import Foundation
 
 // Note: The protobuf- and JSON-specific methods here are defined
 // in ProtobufTypeAdditions.swift and JSONTypeAdditions.swift
+@preconcurrency
 public protocol FieldType: Sendable {
     // The Swift type used to store data for this field.  For example,
     // proto "sint32" fields use Swift "Int32" type.
@@ -49,6 +50,7 @@ public protocol FieldType: Sendable {
 ///
 /// Marker protocol for types that can be used as map keys
 ///
+@preconcurrency
 public protocol MapKeyType: FieldType {
     /// A comparison function for where order is needed.  Can't use `Comparable`
     /// because `Bool` doesn't conform, and since it is `public` there is no way
@@ -66,6 +68,7 @@ extension MapKeyType where BaseType: Comparable {
 ///
 /// Marker Protocol for types that can be used as map values.
 ///
+@preconcurrency
 public protocol MapValueType: FieldType {
 }
 

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -31,6 +31,7 @@
 ///
 /// The actual functionality is implemented either in the generated code or in
 /// default implementations of the below methods and properties.
+@preconcurrency
 public protocol Message: _CommonMessageConformances {
   /// Creates a new message with all of its fields initialized to their default
   /// values.
@@ -182,6 +183,7 @@ extension Message {
 /// generic constraints if you need to write generic code that can be applied to
 /// multiple message types that uses equality tests, puts messages in a `Set`,
 /// or uses them as `Dictionary` keys.
+@preconcurrency
 public protocol _MessageImplementationBase: Message, Hashable {
 
   // Legacy function; no longer used, but left to maintain source compatibility.

--- a/Sources/SwiftProtobuf/MessageExtension.swift
+++ b/Sources/SwiftProtobuf/MessageExtension.swift
@@ -16,6 +16,7 @@
 // -----------------------------------------------------------------------------
 
 /// Type-erased MessageExtension field implementation.
+@preconcurrency
 public protocol AnyMessageExtension: Sendable {
     var fieldNumber: Int { get }
     var fieldName: String { get }


### PR DESCRIPTION
This is part of a wider effort to make breaking changes introduced in `main` non-breaking.

Adding `Sendable` conformance is a breaking change unless the protocols are annotated with `@preconcurrency`. This PR adds the missing annotations.