### PR TITLE
Add a second api check against the last release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,12 +109,32 @@ jobs:
       working-directory: main
       run: make compile-tests PROTOC=../protobuf/cmake_build/protoc
 
-  api-breakage:
+  api-breakage-vs-main:
+    name: Api Breakage Compared to main Branch
     # Only on pull requests
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Since `main` is currently accepting breaking changes, don't fail the whole
-    # PR if this one check fails.
+    # Don't fail since we're actively revisit breaking changes on `main`
+    continue-on-error: true
+    container:
+      image: swift:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Mark the workspace as safe
+      # https://github.com/actions/checkout/issues/766
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+    - name: Check for API breaking changes
+      run: swift package diagnose-api-breaking-changes origin/main --products SwiftProtobuf
+
+  api-breakage-since-last-release:
+    name: Api Breakage Compared to Last Release
+    # Only on pull requests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Don't fail since we're actively revisit breaking changes on `main`
     continue-on-error: true
     container:
       # Test on the latest Swift release. This could run on all the support
@@ -130,10 +150,13 @@ jobs:
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Check for API breaking changes
-      # This will catch changes compared to main, so it doesn't build up a list.
-      # Once main is used for releases, we might want to change this to diff
-      # against the last release.
-      run: swift package diagnose-api-breaking-changes origin/main --products SwiftProtobuf
+      # This will catch changes compared to the latest release. Once we go back
+      # to releasing off `main`, the go back to:
+      #   LAST_TAG=$(git describe --abbrev=0 --tags)
+      run: |
+        LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        echo "Checking for breaks against the tag: ${LAST_TAG}"
+        swift package diagnose-api-breaking-changes "${LAST_TAG}" --products SwiftProtobuf
 
   sanitizer_testing:
     # Using older ubuntu image due to issue with newer linux kernel images. When


### PR DESCRIPTION
This way here is a report for what the tool thinks are api breaks between `main` (changes in the given PR), and and updated status of how things compare to the last release that was made.