### PR TITLE
Add a --breakage-allowlist-path list for the diff against release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,8 @@ jobs:
       run: |
         LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
         echo "Checking for breaks against the tag: ${LAST_TAG}"
-        swift package diagnose-api-breaking-changes "${LAST_TAG}" --products SwiftProtobuf
+        swift package diagnose-api-breaking-changes "${LAST_TAG}" --products SwiftProtobuf \
+          --breakage-allowlist-path known_api_breaks.txt
 
   sanitizer_testing:
     # Using older ubuntu image due to issue with newer linux kernel images. When

--- a/known_api_breaks.txt
+++ b/known_api_breaks.txt
@@ -1,0 +1,11 @@
+API breakage: protocol Enum is now with @preconcurrency
+API breakage: protocol ExtensibleMessage is now with @preconcurrency
+API breakage: protocol AnyExtensionField is now with @preconcurrency
+API breakage: protocol ExtensionField is now with @preconcurrency
+API breakage: protocol ExtensionMap is now with @preconcurrency
+API breakage: protocol FieldType is now with @preconcurrency
+API breakage: protocol MapKeyType is now with @preconcurrency
+API breakage: protocol MapValueType is now with @preconcurrency
+API breakage: protocol Message is now with @preconcurrency
+API breakage: protocol _MessageImplementationBase is now with @preconcurrency
+API breakage: protocol AnyMessageExtension is now with @preconcurrency


### PR DESCRIPTION
This is needed incase there are more changes to descriptor, but also include the list from
https://github.com/apple/swift-protobuf/pull/1609#issuecomment-2034982265 which aren't actually breaks.