### PR TITLE
Some new conformance tests that 1.x fails.

### DIFF
--- a/Sources/Conformance/text_format_failure_list_swift.txt
+++ b/Sources/Conformance/text_format_failure_list_swift.txt
@@ -1,1 +1,4 @@
-# No known failures
+Required.Proto2.TextFormatInput.GroupFieldLowercased.ProtobufOutput
+Required.Proto2.TextFormatInput.GroupFieldLowercased.TextFormatOutput
+Required.Proto2.TextFormatInput.GroupFieldLowercasedMultiWord.ProtobufOutput
+Required.Proto2.TextFormatInput.GroupFieldLowercasedMultiWord.TextFormatOutput


### PR DESCRIPTION
These will take some changes to the runtime to pass, so landing the known failures to ensure other things could be landed in the mean time.