### PR TITLE
Use actions/cache v4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       run: make test-runtime ${{ matrix.swift.hook }}
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: protobuf
         # NOTE: for refs that can float like 'main' the cache might be out of date!

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -67,7 +67,7 @@ jobs:
         esac
     - name: Cache protobuf
       id: cache-protobuf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: protobuf
         # NOTE: for refs that can float like 'main' the cache might be out of date!


### PR DESCRIPTION
Resolves warnings around pending deprecation of older node as seen:
  https://github.com/apple/swift-protobuf/actions/runs/8586337325