### PR TITLE
Support JSON encoding/decoding on group fields.

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -1,2 +1,1 @@
-Required.Editions.ProtobufInput.ValidDelimitedField.GroupLike.JsonOutput
-Required.Editions.ProtobufInput.ValidDelimitedField.NotGroupLike.JsonOutput
+# No known failures.

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -605,11 +605,11 @@ internal struct JSONDecoder: Decoder {
   }
 
   mutating func decodeSingularGroupField<G: Message>(value: inout G?) throws {
-    throw JSONDecodingError.schemaMismatch
+    try decodeSingularMessageField(value: &value)
   }
 
   mutating func decodeRepeatedGroupField<G: Message>(value: inout [G]) throws {
-    throw JSONDecodingError.schemaMismatch
+    try decodeRepeatedMessageField(value: &value)
   }
 
   mutating func decodeMapField<KeyType, ValueType: MapValueType>(

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -191,7 +191,7 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitSingularGroupField<G: Message>(value: G, fieldNumber: Int) throws {
-    // Google does not serialize groups into JSON
+    try visitSingularMessageField(value: value, fieldNumber: fieldNumber)
   }
 
   mutating func visitRepeatedFloatField(value: [Float], fieldNumber: Int) throws {
@@ -351,8 +351,7 @@ internal struct JSONEncodingVisitor: Visitor {
   }
 
   mutating func visitRepeatedGroupField<G: Message>(value: [G], fieldNumber: Int) throws {
-    assert(!value.isEmpty)
-    // Google does not serialize groups into JSON
+    try visitRepeatedMessageField(value: value, fieldNumber: fieldNumber)
   }
 
   // Packed fields are handled the same as non-packed fields, so JSON just

--- a/Tests/SwiftProtobufTests/Test_JSON_Group.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Group.swift
@@ -21,10 +21,20 @@ final class Test_JSON_Group: XCTestCase, PBTestHelpers {
     typealias MessageTestType = SwiftProtoTesting_TestAllTypes
 
     func testOptionalGroup() {
-        assertJSONDecodeFails("{\"optionalgroup\":{\"a\":3}}")
+        assertJSONEncode("{\"optionalgroup\":{\"a\":3}}") {(o: inout MessageTestType) in
+          o.optionalGroup.a = 3
+        }
     }
 
     func testRepeatedGroup() {
-        assertJSONDecodeFails("{\"repeatedgroup\":[{\"a\":1},{\"a\":2}]}")
+        assertJSONEncode("{\"repeatedgroup\":[{\"a\":1},{\"a\":2}]}") {(o: inout MessageTestType) in
+          let one = SwiftProtoTesting_TestAllTypes.RepeatedGroup.with {
+            $0.a = 1
+          }
+          let two = SwiftProtoTesting_TestAllTypes.RepeatedGroup.with {
+            $0.a = 2
+          }
+          o.repeatedGroup = [one, two]
+        }
     }
 }


### PR DESCRIPTION
The `message_encoding = DELIMITED` feature in Editions maps the field to be a "group" field instead of a "message" field to generally reuse all the plumbing in languages for "group" encoding of the binary format.

As a result, the previous assertion on the code that Groups wouldn't be needed in JSON support is correct and an Editions based file still needs to support JSON.

- Write up encode/decode of groups fields by mapping them to the message versions.
- Update the tests to cover the support.
- Remove the conformance test failures that cover this support.