### PR TITLE
Fix assertTextFormatDecodeSucceeds to use the re-encode correctly.

### DIFF
--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -268,9 +268,9 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         }
     }
 
-    func assertTextFormatDecodeSucceeds(_ text: String, file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) throws -> Bool) {
+    func assertTextFormatDecodeSucceeds(_ text: String, options: TextFormatDecodingOptions = TextFormatDecodingOptions(), file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) throws -> Bool) {
         do {
-            let decoded: MessageTestType = try MessageTestType(textFormatString: text)
+            let decoded: MessageTestType = try MessageTestType(textFormatString: text, options: options)
             do {
                 let r = try check(decoded)
                 XCTAssert(r, "Condition failed for \(decoded)", file: file, line: line)
@@ -279,7 +279,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
             }
             let encoded = decoded.textFormatString()
             do {
-                let redecoded = try MessageTestType(textFormatString: text)
+                let redecoded = try MessageTestType(textFormatString: encoded)
                 do {
                     let r = try check(redecoded)
                     XCTAssert(r, "Condition failed for redecoded \(redecoded)", file: file, line: line)

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -348,9 +348,13 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == 0.0 && o.optionalFloat.sign == .plus
         }
-        assertTextFormatDecodeSucceeds("optional_float: -1e-50\n") {
-            (o: MessageTestType) in
-            return o.optionalFloat == 0.0 && o.optionalFloat.sign == .minus
+        // The negative version won't really round trip, because -0.0 for proto3 counts as not set.
+        do {
+            let msg = try MessageTestType(textFormatString: "optional_float: -1e-50\n")
+            XCTAssertEqual(msg.optionalFloat, 0.0)
+            XCTAssertEqual(msg.optionalFloat.sign, .minus)
+        } catch {
+            XCTFail("Shouldn't have throws on decode: \(error)")
         }
         // protobuf conformance requires subnormals to be handled
         assertTextFormatDecodeSucceeds("optional_float: 1.17549e-39\n") {


### PR DESCRIPTION
While at it, support optional decoding options.