### PR TITLE
Support 'F' as a suffix for floating point in TextFormat.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -839,10 +839,9 @@ internal struct TextFormatScanner {
                  asciiLowerE,
                  asciiUpperE: // 0...9, ., +, -, e, E
                 p += 1
-            case asciiLowerF: // f
-                // proto1 allowed floats to be suffixed with 'f'
+            case asciiLowerF, asciiUpperF: // f or F
                 let d = doubleParser.utf8ToDouble(bytes: UnsafeRawBufferPointer(start: start, count: p - start))
-                // Just skip the 'f'
+                // Just skip the 'f'/'F'
                 p += 1
                 skipWhitespace()
                 return d

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -315,6 +315,10 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == 1.0
         }
+        assertTextFormatDecodeSucceeds("optional_float: 1.0F\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 1.0
+        }
         assertTextFormatDecodeSucceeds("optional_float: 11\n") {
             (o: MessageTestType) in
             return o.optionalFloat == 11.0
@@ -323,11 +327,19 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == 11.0
         }
+        assertTextFormatDecodeSucceeds("optional_float: 11F\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 11.0
+        }
         assertTextFormatDecodeSucceeds("optional_float: 0\n") {
             (o: MessageTestType) in
             return o.optionalFloat == 0.0
         }
         assertTextFormatDecodeSucceeds("optional_float: 0f\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 0.0
+        }
+        assertTextFormatDecodeSucceeds("optional_float: 0F\n") {
             (o: MessageTestType) in
             return o.optionalFloat == 0.0
         }
@@ -454,10 +466,28 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeSucceeds("optional_double: 1.0\n") {(o: MessageTestType) in
             return o.optionalDouble == 1.0
         }
+        assertTextFormatDecodeSucceeds("optional_double: 1.0f\n") {(o: MessageTestType) in
+            return o.optionalDouble == 1.0
+        }
+        assertTextFormatDecodeSucceeds("optional_double: 1.0F\n") {(o: MessageTestType) in
+            return o.optionalDouble == 1.0
+        }
         assertTextFormatDecodeSucceeds("optional_double: 1\n") {(o: MessageTestType) in
             return o.optionalDouble == 1.0
         }
+        assertTextFormatDecodeSucceeds("optional_double: 1f\n") {(o: MessageTestType) in
+            return o.optionalDouble == 1.0
+        }
+        assertTextFormatDecodeSucceeds("optional_double: 1F\n") {(o: MessageTestType) in
+            return o.optionalDouble == 1.0
+        }
         assertTextFormatDecodeSucceeds("optional_double: 0\n") {(o: MessageTestType) in
+            return o.optionalDouble == 0.0
+        }
+        assertTextFormatDecodeSucceeds("optional_double: 0f\n") {(o: MessageTestType) in
+            return o.optionalDouble == 0.0
+        }
+        assertTextFormatDecodeSucceeds("optional_double: 0F\n") {(o: MessageTestType) in
             return o.optionalDouble == 0.0
         }
         assertTextFormatDecodeSucceeds("12: 1.0\n") {(o: MessageTestType) in


### PR DESCRIPTION
Per https://protobuf.dev/reference/protobuf/textformat-spec/#numeric, a `FLOAT` value can be appended with 'f' or 'F'. So the support for the uppercase one was missing.