### PR TITLE
Support field separators on the last field of a message field.

### DIFF
--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -1298,6 +1298,12 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeSucceeds("optional_int32:1;\n") {(o: MessageTestType) in
             return o.optionalInt32 == 1
         }
+        assertTextFormatDecodeSucceeds("optional_nested_message {bb:3,},") {(o: MessageTestType) in
+            return o.optionalNestedMessage.bb == 3
+        }
+        assertTextFormatDecodeSucceeds("optional_nested_message {bb:7;};") {(o: MessageTestType) in
+            return o.optionalNestedMessage.bb == 7
+        }
     }
 
     //


### PR DESCRIPTION
https://protobuf.dev/reference/protobuf/textformat-spec/#fields calls out that `MessageField` and `ScalarField` both can be followed by a separator (`,` or `;`).

https://protobuf.dev/reference/protobuf/textformat-spec/#message then replies on this to handle the separators within a message field.

The existing parsing was accepting separators after all fields for top level fields, but when the decoder was for a message field (i.e. - there is a terminator stop at), it wouldn't properly the final separator followed by terminator correctly.