### PR TITLE
Remove 'u' suffix support from TextFormat.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -609,10 +609,6 @@ internal struct TextFormatScanner {
                         val = UInt64(digit - asciiLowerA + 10)
                     case asciiUpperA...asciiUpperF:
                         val = UInt64(digit - asciiUpperA + 10)
-                    case asciiLowerU: // trailing 'u'
-                        p += 1
-                        skipWhitespace()
-                        return n
                     default:
                         skipWhitespace()
                         return n
@@ -629,11 +625,6 @@ internal struct TextFormatScanner {
                 var n: UInt64 = 0
                 while p != end {
                     let digit = p[0]
-                    if digit == asciiLowerU { // trailing 'u'
-                        p += 1
-                        skipWhitespace()
-                        return n
-                    }
                     if digit < asciiZero || digit > asciiSeven {
                         skipWhitespace()
                         return n // not octal digit
@@ -652,11 +643,6 @@ internal struct TextFormatScanner {
             var n = UInt64(c - asciiZero)
             while p != end {
                 let digit = p[0]
-                if digit == asciiLowerU { // trailing 'u'
-                    p += 1
-                    skipWhitespace()
-                    return n
-                }
                 if digit < asciiZero || digit > asciiNine {
                     skipWhitespace()
                     return n // not a digit

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -149,11 +149,11 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatEncode("optional_uint32: 3\n") {(o: inout MessageTestType) in
             o.optionalUint32 = 3
         }
-        assertTextFormatDecodeSucceeds("optional_uint32: 3u") {
+        assertTextFormatDecodeSucceeds("optional_uint32: 0x3") {
             (o: MessageTestType) in
             return o.optionalUint32 == 3
         }
-        assertTextFormatDecodeSucceeds("optional_uint32: 3u optional_int32: 1") {
+        assertTextFormatDecodeSucceeds("optional_uint32: 03 optional_int32: 1") {
             (o: MessageTestType) in
             return o.optionalUint32 == 3 && o.optionalInt32 == 1
         }


### PR DESCRIPTION
https://protobuf.dev/reference/protobuf/textformat-spec/#numeric and https://protobuf.dev/reference/protobuf/textformat-spec/#literals don't seem to show any signs that a 'u' suffix was ever valid. I also don't see any references in the C++ code. It also seems like we would parse `-12u` as valid which seems a little odd since it clearly isn't an unsigned value.

So dropping the 'u' support as it seems out of spec.