### PR TITLE
Add support for decoding options during fuzz testing.

### DIFF
--- a/FuzzTesting/Sources/FuzzAsyncMessageSequence/main.swift
+++ b/FuzzTesting/Sources/FuzzAsyncMessageSequence/main.swift
@@ -15,6 +15,9 @@ fileprivate func asyncByteStream(bytes: UnsafeRawBufferPointer) -> AsyncStream<U
 
 @_cdecl("LLVMFuzzerTestOneInput")
 public func FuzzAsyncMessageSequence(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
+  // No decoding options here, a leading zero is actually valid (zero length message),
+  // so we rely on the other Binary fuzz tester to test options, and just let this
+  // one focus on issue around framing of the messages on the stream.
   let bytes = UnsafeRawBufferPointer(start: start, count: count)
   let asyncBytes = asyncByteStream(bytes: bytes)
   let decoding = asyncBytes.binaryProtobufDelimitedMessages(

--- a/FuzzTesting/Sources/FuzzBinary/main.swift
+++ b/FuzzTesting/Sources/FuzzBinary/main.swift
@@ -4,12 +4,15 @@ import SwiftProtobuf
 
 @_cdecl("LLVMFuzzerTestOneInput")
 public func FuzzBinary(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
-  let bytes = UnsafeRawBufferPointer(start: start, count: count)
+  guard let (options, bytes) = BinaryDecodingOptions.extractOptions(start, count) else {
+    return 1
+  }
   var msg: SwiftProtoTesting_Fuzz_Message?
   do {
     msg = try SwiftProtoTesting_Fuzz_Message(
       serializedBytes: Array(bytes),
-      extensions: SwiftProtoTesting_Fuzz_FuzzTesting_Extensions)
+      extensions: SwiftProtoTesting_Fuzz_FuzzTesting_Extensions,
+      options: options)
   } catch {
     // Error parsing are to be expected since not all input will be well formed.
   }

--- a/FuzzTesting/Sources/FuzzBinaryDelimited/main.swift
+++ b/FuzzTesting/Sources/FuzzBinaryDelimited/main.swift
@@ -6,6 +6,9 @@ import SwiftProtobuf
 
 @_cdecl("LLVMFuzzerTestOneInput")
 public func FuzzDelimited(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
+  // No decoding options here, a leading zero is actually valid (zero length message),
+  // so we rely on the other Binary fuzz tester to test options, and just let this
+  // one focus on issue around framing of the messages on the stream.
   let bytes = UnsafeRawBufferPointer(start: start, count: count)
   let istream = InputStream(data: Data(bytes))
   istream.open()

--- a/FuzzTesting/Sources/FuzzCommon/Options.swift
+++ b/FuzzTesting/Sources/FuzzCommon/Options.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+import SwiftProtobuf
+
+public enum FuzzOption<T: SupportsFuzzOptions> {
+    case boolean(WritableKeyPath<T, Bool>)
+    case byte(WritableKeyPath<T, Int>, mod: UInt8 = .max)
+}
+
+public protocol SupportsFuzzOptions {
+    static var fuzzOptionsList: [FuzzOption<Self>] { get }
+    init()
+}
+
+extension SupportsFuzzOptions {
+    public static func extractOptions(
+        _ start: UnsafeRawPointer,
+        _ count: Int
+    ) -> (Self, UnsafeRawBufferPointer)? {
+        var start = start
+        var count = count
+        var options = Self()
+
+        // No format can start with zero (invalid tag, not really UTF-8), so use that to
+        // indicate there are decoding options. The one case that can start with a zero
+        // would be length delimited binary, but since that's a zero length message, we
+        // can go ahead and use that one also.
+        guard count >= 2, start.loadUnaligned(as: UInt8.self) == 0 else {
+            return (options, UnsafeRawBufferPointer(start: start, count: count))
+        }
+
+        // Set over the zero
+        start += 1
+        count -= 1
+
+        var optionsBits: UInt8? = nil
+        var bit = 0
+        for opt in fuzzOptionsList {
+            if optionsBits == nil {
+                guard count >= 1 else {
+                    return nil  // No data left to read bits
+                }
+                optionsBits = start.loadUnaligned(as: UInt8.self)
+                start += 1
+                count -= 1
+            }
+
+            let isSet = optionsBits! & (1 << bit) != 0
+            switch opt {
+            case .boolean(let keypath):
+                options[keyPath: keypath] = isSet
+            case .byte(let keypath, let mod):
+                assert(mod >= 1 && mod <= UInt8.max)
+                if isSet {
+                    guard count >= 1 else {
+                        return nil  // No more bytes to get a value, fail
+                    }
+                    let value = start.loadUnaligned(as: UInt8.self)
+                    start += 1
+                    count -= 1
+                    options[keyPath: keypath] = Int(value % mod)
+                }
+            }
+
+            bit += 1
+            if bit == 8 {  // Rolled over, cause a new load next time through
+                bit = 0
+                optionsBits = nil
+            }
+        }
+        // Ensure the any remaining bits are zero so they can be used in the future
+        while optionsBits != nil && bit < 8 {
+            if optionsBits! & (1 << bit) != 0 {
+                return nil
+            }
+            bit += 1
+        }
+
+        return (options, UnsafeRawBufferPointer(start: start, count: count))
+    }
+
+}
+
+extension BinaryDecodingOptions: SupportsFuzzOptions {
+    public static var fuzzOptionsList: [FuzzOption<Self>] {
+        return [
+            // NOTE: Do not reorder these in the future as it invalidates all
+            // existing cases.
+
+            // The default depth is 100, so limit outselves to modding by 8 to
+            // avoid allowing larger depths that could timeout.
+            .byte(\.messageDepthLimit, mod: 8),
+            .boolean(\.discardUnknownFields),
+        ]
+    }
+}
+
+extension JSONDecodingOptions: SupportsFuzzOptions {
+    public static var fuzzOptionsList: [FuzzOption<Self>] {
+        return [
+            // NOTE: Do not reorder these in the future as it invalidates all
+            // existing cases.
+
+            // The default depth is 100, so limit outselves to modding by 8 to
+            // avoid allowing larger depths that could timeout.
+            .byte(\.messageDepthLimit, mod: 8),
+            .boolean(\.ignoreUnknownFields),
+        ]
+    }
+}
+
+extension TextFormatDecodingOptions: SupportsFuzzOptions {
+    public static var fuzzOptionsList: [FuzzOption<Self>] {
+        return [
+            // NOTE: Do not reorder these in the future as it invalidates all
+            // existing cases.
+
+            // The default depth is 100, so limit outselves to modding by 8 to
+            // avoid allowing larger depths that could timeout.
+            .byte(\.messageDepthLimit, mod: 8),
+            .boolean(\.ignoreUnknownFields),
+            .boolean(\.ignoreUnknownExtensionFields),
+        ]
+    }
+}

--- a/FuzzTesting/Sources/FuzzJSON/main.swift
+++ b/FuzzTesting/Sources/FuzzJSON/main.swift
@@ -6,12 +6,15 @@ import SwiftProtobuf
 
 @_cdecl("LLVMFuzzerTestOneInput")
 public func FuzzJSON(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
-  let bytes = UnsafeRawBufferPointer(start: start, count: count)
+  guard let (options, bytes) = JSONDecodingOptions.extractOptions(start, count) else {
+    return 1
+  }
   var msg: SwiftProtoTesting_Fuzz_Message?
   do {
     msg = try SwiftProtoTesting_Fuzz_Message(
       jsonUTF8Data: Data(bytes),
-      extensions: SwiftProtoTesting_Fuzz_FuzzTesting_Extensions)
+      extensions: SwiftProtoTesting_Fuzz_FuzzTesting_Extensions,
+      options: options)
   } catch {
     // Error parsing are to be expected since not all input will be well formed.
   }

--- a/FuzzTesting/Sources/FuzzTextFormat/main.swift
+++ b/FuzzTesting/Sources/FuzzTextFormat/main.swift
@@ -2,14 +2,19 @@ import Foundation
 
 import FuzzCommon
 
+import SwiftProtobuf
+
 @_cdecl("LLVMFuzzerTestOneInput")
 public func FuzzTextFormat(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
-  let bytes = UnsafeRawBufferPointer(start: start, count: count)
+  guard let (options, bytes) = TextFormatDecodingOptions.extractOptions(start, count) else {
+    return 1
+  }
   guard let str = String(data: Data(bytes), encoding: .utf8) else { return 0 }
   var msg: SwiftProtoTesting_Fuzz_Message?
   do {
     msg = try SwiftProtoTesting_Fuzz_Message(
       textFormatString: str,
+      options: options,
       extensions: SwiftProtoTesting_Fuzz_FuzzTesting_Extensions)
   } catch {
     // Error parsing are to be expected since not all input will be well formed.


### PR DESCRIPTION
In Binary, TextFormat, and JSON, a leading byte is not value, so leverage that to indicate that the next byte should be used as bits for decoding options.