### PR TITLE
Add a fail out if raw field numbers are too long.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -68,6 +68,11 @@ private let asciiLowerY = UInt8(ascii: "y")
 private let asciiLowerZ = UInt8(ascii: "z")
 private let asciiUpperZ = UInt8(ascii: "Z")
 
+// https://protobuf.dev/programming-guides/proto2/#assigning
+// Fields can be between 1 and 536,870,911. So we can stop parsing
+// a raw number if we go over this (it also avoid rollover).
+private let maxFieldNumLength: Int = 9
+
 private func fromHexDigit(_ c: UInt8) -> UInt8? {
   if c >= asciiZero && c <= asciiNine {
     return c - asciiZero
@@ -1090,9 +1095,26 @@ internal struct TextFormatScanner {
             }
             throw TextFormatDecodingError.unknownField
         case asciiLowerA...asciiLowerZ,
-             asciiUpperA...asciiUpperZ,
-             asciiOne...asciiNine: // a...z, A...Z, 1...9
+             asciiUpperA...asciiUpperZ: // a...z, A...Z
             return parseIdentifier()
+        case asciiOne...asciiNine:  // 1...9 (field numbers are 123, not 0123)
+            let start = p
+            p += 1
+            while p != end {
+                let c = p[0]
+                if c < asciiZero || c > asciiNine {
+                    break
+                }
+                p += 1
+                if p - start > maxFieldNumLength {
+                    throw TextFormatDecodingError.malformedText
+                }
+            }
+            let buff = UnsafeRawBufferPointer(start: start, count: p - start)
+            skipWhitespace()
+            let s = utf8ToString(bytes: buff.baseAddress!, count: buff.count)
+            // Safe, can't be invalid UTF-8 given the input.
+            return s!
         default:
             throw TextFormatDecodingError.malformedText
         }
@@ -1147,6 +1169,7 @@ internal struct TextFormatScanner {
                 // Unknown field name
                 break
             case asciiOne...asciiNine:  // 1-9 (field numbers are 123, not 0123)
+                let start = p
                 var fieldNum = Int(c) - Int(asciiZero)
                 p += 1
                 while p != end {
@@ -1157,6 +1180,9 @@ internal struct TextFormatScanner {
                         break
                     }
                     p += 1
+                    if p - start > maxFieldNumLength {
+                        throw TextFormatDecodingError.malformedText
+                    }
                 }
                 skipWhitespace()
                 if names.names(for: fieldNum) != nil {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
@@ -386,4 +386,29 @@ final class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         let textWithoutUnknowns = msg.textFormatString(options: encodeWithoutUnknowns)
         XCTAssertEqual(textWithoutUnknowns, "")
     }
+
+    func test_unknown_fieldnum_too_big() {
+        // The max field number is 536,870,911, so anything that takes more digits, should
+        // fail as malformed.
+
+        var opts = TextFormatDecodingOptions()
+        opts.ignoreUnknownFields = true
+
+        // Max value, will pass becuase of ignoring unknowns.
+        do {
+            let _ = try MessageTestType(textFormatString: "536870911: 1", options: opts)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        // One more digit, should fail as malformed
+        do {
+            let _ = try MessageTestType(textFormatString: "1536870911: 1", options: opts)
+            XCTFail("Shouldn't get here")
+        } catch TextFormatDecodingError.malformedText {
+            // This is what should have happened.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Follow up from the comment on adding unknown field skipping.

Since there is a max field length, we can fail out if the field number is too many digits.

Added tests to also cover this.