### PR TITLE
Allow TextFormat to map extreme doubles to infinity.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -826,7 +826,9 @@ internal struct TextFormatScanner {
                  asciiUpperE: // 0...9, ., +, -, e, E
                 p += 1
             case asciiLowerF, asciiUpperF: // f or F
-                let d = doubleParser.utf8ToDouble(bytes: UnsafeRawBufferPointer(start: start, count: p - start))
+                let d = doubleParser.utf8ToDouble(bytes: UnsafeRawBufferPointer(start: start,
+                                                                                count: p - start),
+                                                  finiteOnly: false)
                 // Just skip the 'f'/'F'
                 p += 1
                 skipWhitespace()
@@ -835,7 +837,9 @@ internal struct TextFormatScanner {
                 break loop
             }
         }
-        let d = doubleParser.utf8ToDouble(bytes: UnsafeRawBufferPointer(start: start, count: p - start))
+        let d = doubleParser.utf8ToDouble(bytes: UnsafeRawBufferPointer(start: start,
+                                                                        count: p - start),
+                                          finiteOnly: false)
         skipWhitespace()
         return d
     }

--- a/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
@@ -398,6 +398,16 @@ final class Test_TextFormatDecodingOptions: XCTestCase {
         // This would overload a int, but as a floating point value it will map to "inf".
         assertDecodeIgnoringUnknownsSucceeds("float", "999999999999999999999999999999999999")
 
+        // Things that round to infinity or zero, but should parse ok.
+        assertDecodeIgnoringUnknownsSucceeds("float", "1e50")
+        assertDecodeIgnoringUnknownsSucceeds("float", "-1e50")
+        assertDecodeIgnoringUnknownsSucceeds("float", "1e-50")
+        assertDecodeIgnoringUnknownsSucceeds("float", "-1e-50")
+        assertDecodeIgnoringUnknownsSucceeds("double", "1e9999")
+        assertDecodeIgnoringUnknownsSucceeds("double", "-1e9999")
+        assertDecodeIgnoringUnknownsSucceeds("double", "1e-9999")
+        assertDecodeIgnoringUnknownsSucceeds("double", "-1e-9999")
+
         assertDecodeIgnoringUnknownsSucceeds("float", "nan")
         assertDecodeIgnoringUnknownsSucceeds("float", "inf")
         assertDecodeIgnoringUnknownsSucceeds("float", "-inf")

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -355,6 +355,13 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == -Float.infinity
         }
+        // Too-large of values round to infinity
+        assertTextFormatDecodeSucceeds("optional_float: 1e50\n") {(o: MessageTestType) in
+            return o.optionalFloat == Float.infinity
+        }
+        assertTextFormatDecodeSucceeds("optional_float: -1e50\n") {(o: MessageTestType) in
+            return o.optionalFloat == -Float.infinity
+        }
         // Too-small values round to zero (not currently checked by conformance)
         assertTextFormatDecodeSucceeds("optional_float: 1e-50\n") {
             (o: MessageTestType) in
@@ -366,7 +373,7 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             XCTAssertEqual(msg.optionalFloat, 0.0)
             XCTAssertEqual(msg.optionalFloat.sign, .minus)
         } catch {
-            XCTFail("Shouldn't have throws on decode: \(error)")
+            XCTFail("Shouldn't have thrown on decode: \(error)")
         }
         // protobuf conformance requires subnormals to be handled
         assertTextFormatDecodeSucceeds("optional_float: 1.17549e-39\n") {
@@ -492,6 +499,26 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         }
         assertTextFormatDecodeSucceeds("12: 1.0\n") {(o: MessageTestType) in
             return o.optionalDouble == 1.0
+        }
+        // Too-large of values round to infinity
+        assertTextFormatDecodeSucceeds("optional_double: 1e9999\n") {(o: MessageTestType) in
+            return o.optionalDouble == Double.infinity
+        }
+        assertTextFormatDecodeSucceeds("optional_double: -1e9999\n") {(o: MessageTestType) in
+            return o.optionalDouble == -Double.infinity
+        }
+        // Too-small values round to zero (not currently checked by conformance)
+        assertTextFormatDecodeSucceeds("optional_double: 1e-9999\n") {
+            (o: MessageTestType) in
+            return o.optionalDouble == 0.0 && o.optionalDouble.sign == .plus
+        }
+        // The negative version won't really round trip, because -0.0 for proto3 counts as not set.
+        do {
+            let msg = try MessageTestType(textFormatString: "optional_double: -1e-9999\n")
+            XCTAssertEqual(msg.optionalDouble, 0.0)
+            XCTAssertEqual(msg.optionalDouble.sign, .minus)
+        } catch {
+            XCTFail("Shouldn't have thrown on decode: \(error)")
         }
         assertTextFormatDecodeSucceeds("optional_double: INFINITY\n") {(o: MessageTestType) in
             return o.optionalDouble == Double.infinity


### PR DESCRIPTION
The TextFormat spec says this is required, JSON doesn't, so for now all JSON to keep out existing behavior but bring TextFormat in line with that spec.