### PR TITLE
Support "-nan" in TextFormat.

### DIFF
--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -352,6 +352,7 @@ extension FieldDescriptor {
         case "inf": return "Double.infinity"
         case "-inf": return "-Double.infinity"
         case "nan": return "Double.nan"
+        case "-nan": return "Double.nan"
         default: return defaultValue
         }
       case .float:
@@ -359,6 +360,7 @@ extension FieldDescriptor {
         case "inf": return "Float.infinity"
         case "-inf": return "-Float.infinity"
         case "nan": return "Float.nan"
+        case "-nan": return "Float.nan"
         default: return defaultValue
         }
       case .string:

--- a/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
@@ -409,8 +409,13 @@ final class Test_TextFormatDecodingOptions: XCTestCase {
         assertDecodeIgnoringUnknownsSucceeds("double", "-1e-9999")
 
         assertDecodeIgnoringUnknownsSucceeds("float", "nan")
+        assertDecodeIgnoringUnknownsSucceeds("float", "-nan")
         assertDecodeIgnoringUnknownsSucceeds("float", "inf")
         assertDecodeIgnoringUnknownsSucceeds("float", "-inf")
+        assertDecodeIgnoringUnknownsSucceeds("double", "nan")
+        assertDecodeIgnoringUnknownsSucceeds("double", "-nan")
+        assertDecodeIgnoringUnknownsSucceeds("double", "inf")
+        assertDecodeIgnoringUnknownsSucceeds("double", "-inf")
     }
 
     func testIgnoreUnknown_Messages() {


### PR DESCRIPTION
As odd as it sounds, upstream supports this and there is a unittest that ensure it parses:

  https://github.com/protocolbuffers/protobuf/blob/3c03e9351c57081d0dffae120ed37497017f105c/src/google/protobuf/compiler/parser_unittest.cc#L464

It seems to have come from:

  https://github.com/protocolbuffers/protobuf/pull/15017

So make sure Swift is also able to parse it.

Also reflow some of the unknown field parsing as inf/nan don't need to be special cased with how the flow now works.