### PR TITLE
Implicit presence on floats should look at the bitpattern.

### DIFF
--- a/Reference/Conformance/editions/test_messages_proto3_editions.pb.swift
+++ b/Reference/Conformance/editions/test_messages_proto3_editions.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Editions_Proto3_TestAllTypesProto3: SwiftProtobuf
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/Conformance/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/Conformance/google/protobuf/test_messages_proto3.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/SwiftProtobuf/google/protobuf/wrappers.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/wrappers.pb.swift
@@ -227,7 +227,7 @@ extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase, _Pro
   }
 
   func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -259,7 +259,7 @@ extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase, _Prot
   }
 
   func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1398,10 +1398,10 @@ extension SwiftProtoTesting_Test3_TestAllTypesProto3: SwiftProtobuf.Message, Swi
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -977,10 +977,10 @@ extension SwiftProtoTesting_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -1071,10 +1071,10 @@ extension SwiftProtoTesting_Message3: SwiftProtobuf.Message, SwiftProtobuf._Mess
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/editions/golden/test_messages_proto3_editions.pb.swift
+++ b/Reference/upstream/editions/golden/test_messages_proto3_editions.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Editions_Proto3_TestAllTypesProto3: SwiftProtobuf
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/upstream/google/protobuf/test_messages_proto3.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_no_field_presence.pb.swift
@@ -784,10 +784,10 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, Swi
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3.pb.swift
@@ -1023,10 +1023,10 @@ extension Proto3Unittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mes
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_arena.pb.swift
@@ -1184,10 +1184,10 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -906,10 +906,10 @@ extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProt
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_lite.pb.swift
@@ -906,10 +906,10 @@ extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Reference/upstream/google/protobuf/wrappers.pb.swift
+++ b/Reference/upstream/google/protobuf/wrappers.pb.swift
@@ -227,7 +227,7 @@ extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase, _Pro
   }
 
   func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -259,7 +259,7 @@ extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase, _Prot
   }
 
   func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Proto3_TestAllTypesProto3: SwiftProtobuf.Message,
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Sources/Conformance/test_messages_proto3_editions.pb.swift
+++ b/Sources/Conformance/test_messages_proto3_editions.pb.swift
@@ -1903,10 +1903,10 @@ extension ProtobufTestMessages_Editions_Proto3_TestAllTypesProto3: SwiftProtobuf
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -227,7 +227,7 @@ extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase, _Pro
   }
 
   public func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -259,7 +259,7 @@ extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase, _Prot
   }
 
   public func traverse<V: Visitor>(visitor: inout V) throws {
-    if self.value != 0 {
+    if self.value.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -208,9 +208,18 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
             // be visted if it is the non default value.
             switch fieldDescriptor.type {
             case .string, .bytes:
-                conditional = ("!\(varName).isEmpty")
+                conditional = "!\(varName).isEmpty"
+            case .float, .double:
+                // https://protobuf.dev/programming-guides/proto3/#default ends with:
+                //    If a float or double value is set to +0 it will not be serialized,
+                //    but -0 is considered distinct and will be serialized.
+                // Editions still ensures that implicit presence doesn't get a default
+                // value so the hardcoded zero here is safe and mirrors the upstream
+                // C++ generator:
+                // https://github.com/protocolbuffers/protobuf/blob/1b06cefe337f73ca8c78c855c02f15caf6210c9b/src/google/protobuf/compiler/cpp/message.cc#L204-L209
+                conditional = "\(varName).bitPattern != 0"
             default:
-                conditional = ("\(varName) != \(swiftDefaultValue)")
+                conditional = "\(varName) != \(swiftDefaultValue)"
             }
         }
         assert(usesLocals == generateTraverseUsesLocals)

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -367,13 +367,9 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalFloat == 0.0 && o.optionalFloat.sign == .plus
         }
-        // The negative version won't really round trip, because -0.0 for proto3 counts as not set.
-        do {
-            let msg = try MessageTestType(textFormatString: "optional_float: -1e-50\n")
-            XCTAssertEqual(msg.optionalFloat, 0.0)
-            XCTAssertEqual(msg.optionalFloat.sign, .minus)
-        } catch {
-            XCTFail("Shouldn't have thrown on decode: \(error)")
+        assertTextFormatDecodeSucceeds("optional_float: -1e-50\n") {
+            (o: MessageTestType) in
+            return o.optionalFloat == 0.0 && o.optionalFloat.sign == .minus
         }
         // protobuf conformance requires subnormals to be handled
         assertTextFormatDecodeSucceeds("optional_float: 1.17549e-39\n") {
@@ -512,13 +508,9 @@ final class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
             (o: MessageTestType) in
             return o.optionalDouble == 0.0 && o.optionalDouble.sign == .plus
         }
-        // The negative version won't really round trip, because -0.0 for proto3 counts as not set.
-        do {
-            let msg = try MessageTestType(textFormatString: "optional_double: -1e-9999\n")
-            XCTAssertEqual(msg.optionalDouble, 0.0)
-            XCTAssertEqual(msg.optionalDouble.sign, .minus)
-        } catch {
-            XCTFail("Shouldn't have thrown on decode: \(error)")
+        assertTextFormatDecodeSucceeds("optional_double: -1e-9999\n") {
+            (o: MessageTestType) in
+            return o.optionalDouble == 0.0 && o.optionalDouble.sign == .minus
         }
         assertTextFormatDecodeSucceeds("optional_double: INFINITY\n") {(o: MessageTestType) in
             return o.optionalDouble == Double.infinity

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1398,10 +1398,10 @@ extension SwiftProtoTesting_Test3_TestAllTypesProto3: SwiftProtobuf.Message, Swi
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -977,10 +977,10 @@ extension SwiftProtoTesting_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -1071,10 +1071,10 @@ extension SwiftProtoTesting_Message3: SwiftProtobuf.Message, SwiftProtobuf._Mess
       if _storage._optionalSfixed64 != 0 {
         try visitor.visitSingularSFixed64Field(value: _storage._optionalSfixed64, fieldNumber: 10)
       }
-      if _storage._optionalFloat != 0 {
+      if _storage._optionalFloat.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._optionalFloat, fieldNumber: 11)
       }
-      if _storage._optionalDouble != 0 {
+      if _storage._optionalDouble.bitPattern != 0 {
         try visitor.visitSingularDoubleField(value: _storage._optionalDouble, fieldNumber: 12)
       }
       if _storage._optionalBool != false {


### PR DESCRIPTION
https://protobuf.dev/programming-guides/proto3/#default ends with:

> If a float or double value is set to +0 it will not be serialized,
> but -0 is considered distinct and will be serialized.
