### PR TITLE
Use repeat instead of break label for utf8ToString

### DIFF
--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -88,17 +88,18 @@ internal func utf8ToString(bytes: UnsafeRawPointer, count: Int) -> String? {
   // Verify that the UTF-8 is valid.
   var p = sourceEncoding.ForwardParser()
   var i = codeUnits.makeIterator()
-  Loop:
-  while true {
+  var repeatLoop: Bool
+  repeat {
+    repeatLoop = false
     switch p.parseScalar(from: &i) {
     case .valid(_):
       break
     case .error:
       return nil
     case .emptyInput:
-      break Loop
+      repeatLoop = true
     }
-  }
+  } while repeatLoop
 
   // This initializer is fast but does not reject broken
   // UTF-8 (which is why we validate the UTF-8 above).


### PR DESCRIPTION
This update doesn't change functionality, but improves the (LLVM) loop optimizer. Using labeled statement with an infinite loop created a complex nested loop, which led inefficient codegen. More importantly it could cause mis-compilation depending on a LTO flag. This patch uses a repeat command with a boolean check to make the loop simpler and more efficient.