### PR TITLE
Change API version back to 2

### DIFF
--- a/CompileTests/MultiModule/Sources/ImportsAPublicly/imports_a_publicly.pb.swift
+++ b/CompileTests/MultiModule/Sources/ImportsAPublicly/imports_a_publicly.pb.swift
@@ -21,8 +21,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ImportsAPublicly: Sendable {

--- a/CompileTests/MultiModule/Sources/ImportsImportsAPublicly/imports_imports_a_publicly.pb.swift
+++ b/CompileTests/MultiModule/Sources/ImportsImportsAPublicly/imports_imports_a_publicly.pb.swift
@@ -22,8 +22,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ImportsImportsAPublicly: Sendable {

--- a/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
+++ b/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public enum E: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/CompileTests/MultiModule/Tests/Test1/uses_a_transitively.pb.swift
+++ b/CompileTests/MultiModule/Tests/Test1/uses_a_transitively.pb.swift
@@ -18,8 +18,8 @@ import ImportsAPublicly
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct UsesATransitively: Sendable {

--- a/CompileTests/MultiModule/Tests/Test2/uses_a_transitively2.pb.swift
+++ b/CompileTests/MultiModule/Tests/Test2/uses_a_transitively2.pb.swift
@@ -18,8 +18,8 @@ import ImportsImportsAPublicly
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct UsesATransitively2: Sendable {

--- a/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
+++ b/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
@@ -30,8 +30,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Protos/SwiftProtobufTests/generated_swift_names_enum_cases.proto
+++ b/Protos/SwiftProtobufTests/generated_swift_names_enum_cases.proto
@@ -715,7 +715,7 @@ enum GeneratedSwiftReservedEnum {
   proto3DefaultValue = 708;
   proto3Optional = 709;
   ProtobufAPIVersionCheck = 710;
-  ProtobufAPIVersion_3 = 711;
+  ProtobufAPIVersion_2 = 711;
   ProtobufBool = 712;
   ProtobufBytes = 713;
   ProtobufDouble = 714;

--- a/Protos/SwiftProtobufTests/generated_swift_names_enums.proto
+++ b/Protos/SwiftProtobufTests/generated_swift_names_enums.proto
@@ -714,7 +714,7 @@ message GeneratedSwiftReservedEnums {
   enum proto3DefaultValue { NONE_proto3DefaultValue = 0; }
   enum proto3Optional { NONE_proto3Optional = 0; }
   enum ProtobufAPIVersionCheck { NONE_ProtobufAPIVersionCheck = 0; }
-  enum ProtobufAPIVersion_3 { NONE_ProtobufAPIVersion_3 = 0; }
+  enum ProtobufAPIVersion_2 { NONE_ProtobufAPIVersion_2 = 0; }
   enum ProtobufBool { NONE_ProtobufBool = 0; }
   enum ProtobufBytes { NONE_ProtobufBytes = 0; }
   enum ProtobufDouble { NONE_ProtobufDouble = 0; }

--- a/Protos/SwiftProtobufTests/generated_swift_names_fields.proto
+++ b/Protos/SwiftProtobufTests/generated_swift_names_fields.proto
@@ -714,7 +714,7 @@ message GeneratedSwiftReservedFields {
   int32 proto3DefaultValue = 708;
   int32 proto3Optional = 709;
   int32 ProtobufAPIVersionCheck = 710;
-  int32 ProtobufAPIVersion_3 = 711;
+  int32 ProtobufAPIVersion_2 = 711;
   int32 ProtobufBool = 712;
   int32 ProtobufBytes = 713;
   int32 ProtobufDouble = 714;

--- a/Protos/SwiftProtobufTests/generated_swift_names_messages.proto
+++ b/Protos/SwiftProtobufTests/generated_swift_names_messages.proto
@@ -714,7 +714,7 @@ message GeneratedSwiftReservedMessages {
   message proto3DefaultValue { int32 proto3DefaultValue = 1; }
   message proto3Optional { int32 proto3Optional = 1; }
   message ProtobufAPIVersionCheck { int32 ProtobufAPIVersionCheck = 1; }
-  message ProtobufAPIVersion_3 { int32 ProtobufAPIVersion_3 = 1; }
+  message ProtobufAPIVersion_2 { int32 ProtobufAPIVersion_2 = 1; }
   message ProtobufBool { int32 ProtobufBool = 1; }
   message ProtobufBytes { int32 ProtobufBytes = 1; }
   message ProtobufDouble { int32 ProtobufDouble = 1; }

--- a/Reference/CompileTests/MultiModule/Sources/ImportsAPublicly/imports_a_publicly.pb.swift
+++ b/Reference/CompileTests/MultiModule/Sources/ImportsAPublicly/imports_a_publicly.pb.swift
@@ -21,8 +21,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ImportsAPublicly: Sendable {

--- a/Reference/CompileTests/MultiModule/Sources/ImportsImportsAPublicly/imports_imports_a_publicly.pb.swift
+++ b/Reference/CompileTests/MultiModule/Sources/ImportsImportsAPublicly/imports_imports_a_publicly.pb.swift
@@ -22,8 +22,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct ImportsImportsAPublicly: Sendable {

--- a/Reference/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
+++ b/Reference/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public enum E: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/CompileTests/MultiModule/Tests/Test1/uses_a_transitively.pb.swift
+++ b/Reference/CompileTests/MultiModule/Tests/Test1/uses_a_transitively.pb.swift
@@ -18,8 +18,8 @@ import ImportsAPublicly
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct UsesATransitively: Sendable {

--- a/Reference/CompileTests/MultiModule/Tests/Test2/uses_a_transitively2.pb.swift
+++ b/Reference/CompileTests/MultiModule/Tests/Test2/uses_a_transitively2.pb.swift
@@ -18,8 +18,8 @@ import ImportsImportsAPublicly
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 public struct UsesATransitively2: Sendable {

--- a/Reference/Conformance/conformance/conformance.pb.swift
+++ b/Reference/Conformance/conformance/conformance.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Conformance_WireFormat: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/Conformance/conformance/test_protos/test_messages_edition2023.pb.swift
+++ b/Reference/Conformance/conformance/test_protos/test_messages_edition2023.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_ForeignEnumEdition2023: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/Conformance/editions/test_messages_proto2_editions.pb.swift
+++ b/Reference/Conformance/editions/test_messages_proto2_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/Conformance/editions/test_messages_proto3_editions.pb.swift
+++ b/Reference/Conformance/editions/test_messages_proto3_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/Conformance/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/Conformance/google/protobuf/test_messages_proto2.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/Conformance/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/Conformance/google/protobuf/test_messages_proto3.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobuf/google/protobuf/any.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/any.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/Reference/SwiftProtobuf/google/protobuf/api.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/api.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Api is a light-weight descriptor for an API Interface.

--- a/Reference/SwiftProtobuf/google/protobuf/descriptor.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/descriptor.pb.swift
@@ -54,8 +54,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The full set of known editions.

--- a/Reference/SwiftProtobuf/google/protobuf/duration.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/duration.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Duration represents a signed, fixed-length span of time represented

--- a/Reference/SwiftProtobuf/google/protobuf/empty.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/empty.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A generic empty message that you can re-use to avoid defining duplicated

--- a/Reference/SwiftProtobuf/google/protobuf/field_mask.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/field_mask.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:

--- a/Reference/SwiftProtobuf/google/protobuf/source_context.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/source_context.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `SourceContext` represents information about the source of a

--- a/Reference/SwiftProtobuf/google/protobuf/struct.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/struct.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `NullValue` is a singleton enumeration to represent the null value for the

--- a/Reference/SwiftProtobuf/google/protobuf/timestamp.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/timestamp.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Timestamp represents a point in time independent of any time zone or local

--- a/Reference/SwiftProtobuf/google/protobuf/type.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/type.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The syntax in which a protocol buffer element is defined.

--- a/Reference/SwiftProtobuf/google/protobuf/wrappers.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/wrappers.pb.swift
@@ -56,8 +56,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Wrapper message for `double`.

--- a/Reference/SwiftProtobufPluginLibrary/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/SwiftProtobufPluginLibrary/google/protobuf/compiler/plugin.pb.swift
@@ -36,8 +36,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The version number of protocol compiler.

--- a/Reference/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
+++ b/Reference/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
@@ -26,8 +26,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Configuration used to define the mappings for generated proto files

--- a/Reference/SwiftProtobufPluginLibraryTests/google/protobuf/unittest_delimited.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/google/protobuf/unittest_delimited.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_LengthPrefixed: Sendable {

--- a/Reference/SwiftProtobufPluginLibraryTests/google/protobuf/unittest_delimited_import.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/google/protobuf/unittest_delimited_import.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_MessageImport: Sendable {

--- a/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SDTTopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftDescriptorTest_Proto3MessageForPresence: Sendable {

--- a/Reference/SwiftProtobufPluginLibraryTests/test_features.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/test_features.pb.swift
@@ -28,8 +28,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftFeatureTest_TestFeatures: Sendable {

--- a/Reference/SwiftProtobufTests/any_test.pb.swift
+++ b/Reference/SwiftProtobufTests/any_test.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestAny: Sendable {

--- a/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -30,8 +30,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/generated_swift_names_enum_cases.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_enum_cases.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
@@ -737,7 +737,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
   case proto3DefaultValue // = 708
   case proto3Optional // = 709
   case protobufApiversionCheck // = 710
-  case protobufApiversion3 // = 711
+  case protobufApiversion2 // = 711
   case protobufBool // = 712
   case protobufBytes // = 713
   case protobufDouble // = 714
@@ -1739,7 +1739,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     case 708: self = .proto3DefaultValue
     case 709: self = .proto3Optional
     case 710: self = .protobufApiversionCheck
-    case 711: self = .protobufApiversion3
+    case 711: self = .protobufApiversion2
     case 712: self = .protobufBool
     case 713: self = .protobufBytes
     case 714: self = .protobufDouble
@@ -2742,7 +2742,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     case .proto3DefaultValue: return 708
     case .proto3Optional: return 709
     case .protobufApiversionCheck: return 710
-    case .protobufApiversion3: return 711
+    case .protobufApiversion2: return 711
     case .protobufBool: return 712
     case .protobufBytes: return 713
     case .protobufDouble: return 714
@@ -3747,7 +3747,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     .proto3DefaultValue,
     .proto3Optional,
     .protobufApiversionCheck,
-    .protobufApiversion3,
+    .protobufApiversion2,
     .protobufBool,
     .protobufBytes,
     .protobufDouble,
@@ -4749,7 +4749,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.
     708: .same(proto: "proto3DefaultValue"),
     709: .same(proto: "proto3Optional"),
     710: .same(proto: "ProtobufAPIVersionCheck"),
-    711: .same(proto: "ProtobufAPIVersion_3"),
+    711: .same(proto: "ProtobufAPIVersion_2"),
     712: .same(proto: "ProtobufBool"),
     713: .same(proto: "ProtobufBytes"),
     714: .same(proto: "ProtobufDouble"),

--- a/Reference/SwiftProtobufTests/generated_swift_names_enums.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_enums.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums: Sendable {
@@ -21331,32 +21331,32 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums: Sendable {
 
   }
 
-  enum ProtobufAPIVersion_3: SwiftProtobuf.Enum, Swift.CaseIterable {
+  enum ProtobufAPIVersion_2: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
-    case noneProtobufApiversion3 // = 0
+    case noneProtobufApiversion2 // = 0
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .noneProtobufApiversion3
+      self = .noneProtobufApiversion2
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 0: self = .noneProtobufApiversion3
+      case 0: self = .noneProtobufApiversion2
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .noneProtobufApiversion3: return 0
+      case .noneProtobufApiversion2: return 0
       case .UNRECOGNIZED(let i): return i
       }
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_3] = [
-      .noneProtobufApiversion3,
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_2] = [
+      .noneProtobufApiversion2,
     ]
 
   }
@@ -34107,9 +34107,9 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVer
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_3: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_2: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NONE_ProtobufAPIVersion_3"),
+    0: .same(proto: "NONE_ProtobufAPIVersion_2"),
   ]
 }
 

--- a/Reference/SwiftProtobufTests/generated_swift_names_fields.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_fields.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: @unchecked Sendable {
@@ -3579,9 +3579,9 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: @unchecked Send
     set {_uniqueStorage()._protobufApiversionCheck = newValue}
   }
 
-  var protobufApiversion3: Int32 {
-    get {return _storage._protobufApiversion3}
-    set {_uniqueStorage()._protobufApiversion3 = newValue}
+  var protobufApiversion2: Int32 {
+    get {return _storage._protobufApiversion2}
+    set {_uniqueStorage()._protobufApiversion2 = newValue}
   }
 
   var protobufBool: Int32 {
@@ -5718,7 +5718,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
     708: .same(proto: "proto3DefaultValue"),
     709: .same(proto: "proto3Optional"),
     710: .same(proto: "ProtobufAPIVersionCheck"),
-    711: .standard(proto: "ProtobufAPIVersion_3"),
+    711: .standard(proto: "ProtobufAPIVersion_2"),
     712: .same(proto: "ProtobufBool"),
     713: .same(proto: "ProtobufBytes"),
     714: .same(proto: "ProtobufDouble"),
@@ -6714,7 +6714,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
     var _proto3DefaultValue: Int32 = 0
     var _proto3Optional: Int32 = 0
     var _protobufApiversionCheck: Int32 = 0
-    var _protobufApiversion3: Int32 = 0
+    var _protobufApiversion2: Int32 = 0
     var _protobufBool: Int32 = 0
     var _protobufBytes: Int32 = 0
     var _protobufDouble: Int32 = 0
@@ -7721,7 +7721,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
       _proto3DefaultValue = source._proto3DefaultValue
       _proto3Optional = source._proto3Optional
       _protobufApiversionCheck = source._protobufApiversionCheck
-      _protobufApiversion3 = source._protobufApiversion3
+      _protobufApiversion2 = source._protobufApiversion2
       _protobufBool = source._protobufBool
       _protobufBytes = source._protobufBytes
       _protobufDouble = source._protobufDouble
@@ -8732,7 +8732,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
         case 708: try { try decoder.decodeSingularInt32Field(value: &_storage._proto3DefaultValue) }()
         case 709: try { try decoder.decodeSingularInt32Field(value: &_storage._proto3Optional) }()
         case 710: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversionCheck) }()
-        case 711: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversion3) }()
+        case 711: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversion2) }()
         case 712: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufBool) }()
         case 713: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufBytes) }()
         case 714: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufDouble) }()
@@ -11153,8 +11153,8 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
       if _storage._protobufApiversionCheck != 0 {
         try visitor.visitSingularInt32Field(value: _storage._protobufApiversionCheck, fieldNumber: 710)
       }
-      if _storage._protobufApiversion3 != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._protobufApiversion3, fieldNumber: 711)
+      if _storage._protobufApiversion2 != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._protobufApiversion2, fieldNumber: 711)
       }
       if _storage._protobufBool != 0 {
         try visitor.visitSingularInt32Field(value: _storage._protobufBool, fieldNumber: 712)
@@ -12721,7 +12721,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
         if _storage._proto3DefaultValue != rhs_storage._proto3DefaultValue {return false}
         if _storage._proto3Optional != rhs_storage._proto3Optional {return false}
         if _storage._protobufApiversionCheck != rhs_storage._protobufApiversionCheck {return false}
-        if _storage._protobufApiversion3 != rhs_storage._protobufApiversion3 {return false}
+        if _storage._protobufApiversion2 != rhs_storage._protobufApiversion2 {return false}
         if _storage._protobufBool != rhs_storage._protobufBool {return false}
         if _storage._protobufBytes != rhs_storage._protobufBytes {return false}
         if _storage._protobufDouble != rhs_storage._protobufDouble {return false}

--- a/Reference/SwiftProtobufTests/generated_swift_names_messages.pb.swift
+++ b/Reference/SwiftProtobufTests/generated_swift_names_messages.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages: Sendable {
@@ -8551,12 +8551,12 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages: Sendable {
     init() {}
   }
 
-  struct ProtobufAPIVersion_3: Sendable {
+  struct ProtobufAPIVersion_2: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
-    var protobufApiversion3: Int32 = 0
+    var protobufApiversion2: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -34693,10 +34693,10 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPI
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".ProtobufAPIVersion_3"
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".ProtobufAPIVersion_2"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "ProtobufAPIVersion_3"),
+    1: .standard(proto: "ProtobufAPIVersion_2"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -34705,21 +34705,21 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPI
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularInt32Field(value: &self.protobufApiversion3) }()
+      case 1: try { try decoder.decodeSingularInt32Field(value: &self.protobufApiversion2) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.protobufApiversion3 != 0 {
-      try visitor.visitSingularInt32Field(value: self.protobufApiversion3, fieldNumber: 1)
+    if self.protobufApiversion2 != 0 {
+      try visitor.visitSingularInt32Field(value: self.protobufApiversion2, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3) -> Bool {
-    if lhs.protobufApiversion3 != rhs.protobufApiversion3 {return false}
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2) -> Bool {
+    if lhs.protobufApiversion2 != rhs.protobufApiversion2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Reference/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Reference/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Reference/SwiftProtobufTests/map_unittest.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// This proto includes every type of field in both singular and repeated

--- a/Reference/SwiftProtobufTests/unittest.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest.pb.swift
@@ -54,8 +54,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_import.pb.swift
@@ -52,8 +52,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Import_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_import_public.pb.swift
@@ -48,8 +48,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Import_PublicImportMessage: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_mset.pb.swift
@@ -53,8 +53,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestMessageSetContainer: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -52,8 +52,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A message with message_set_wire_format.

--- a/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_UnknownEnum_Proto3_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_proto3_optional.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_proto3_optional.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestProto3Optional: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -48,8 +48,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestAllRequiredTypes: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_CycleFoo: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// An enum value marked as deprecated.

--- a/Reference/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// NOTE: The whole .proto file that defined this enum was marked as deprecated.

--- a/Reference/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Enum2_SwiftEnumTest: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Enum3_SwiftEnumTest: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend_Foo: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend2_MyMessage: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend3_MyMessage: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Ext4MyMessage: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Order_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage, Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Same field number appears inside and outside of the group.

--- a/Reference/SwiftProtobufTests/unittest_swift_json.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_json.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_SwiftJSONTest: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Names_EnumFieldNames: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// For issue #1084 - If the generated code compiles, things are good.

--- a/Reference/SwiftProtobufTests/unittest_swift_naming_number_prefix.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_naming_number_prefix.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct _4fun_SwiftProtoTesting_Mumble_MyMessage: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_OneOfOptionMessage1: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Merging_TestMessage: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_SwiftReservedTest: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftReservedTestExt2: Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Message2: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Message3: @unchecked Sendable {

--- a/Reference/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Test that we can include all well-known types.

--- a/Reference/protoc-gen-swiftTests/plugin_descriptor_test.pb.swift
+++ b/Reference/protoc-gen-swiftTests/plugin_descriptor_test.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// To check handling of extension ranges that are out of order.

--- a/Reference/upstream/conformance/conformance.pb.swift
+++ b/Reference/upstream/conformance/conformance.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Conformance_WireFormat: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/conformance/test_protos/test_messages_edition2023.pb.swift
+++ b/Reference/upstream/conformance/test_protos/test_messages_edition2023.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_ForeignEnumEdition2023: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/editions/golden/test_messages_proto2_editions.pb.swift
+++ b/Reference/upstream/editions/golden/test_messages_proto2_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/editions/golden/test_messages_proto3_editions.pb.swift
+++ b/Reference/upstream/editions/golden/test_messages_proto3_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/any.pb.swift
+++ b/Reference/upstream/google/protobuf/any.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/Reference/upstream/google/protobuf/any_test.pb.swift
+++ b/Reference/upstream/google/protobuf/any_test.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestAny: Sendable {

--- a/Reference/upstream/google/protobuf/api.pb.swift
+++ b/Reference/upstream/google/protobuf/api.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Api is a light-weight descriptor for an API Interface.

--- a/Reference/upstream/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/upstream/google/protobuf/compiler/plugin.pb.swift
@@ -36,8 +36,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The version number of protocol compiler.

--- a/Reference/upstream/google/protobuf/cpp_features.pb.swift
+++ b/Reference/upstream/google/protobuf/cpp_features.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Pb_CppFeatures: Sendable {

--- a/Reference/upstream/google/protobuf/descriptor.pb.swift
+++ b/Reference/upstream/google/protobuf/descriptor.pb.swift
@@ -54,8 +54,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The full set of known editions.

--- a/Reference/upstream/google/protobuf/duration.pb.swift
+++ b/Reference/upstream/google/protobuf/duration.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Duration represents a signed, fixed-length span of time represented

--- a/Reference/upstream/google/protobuf/edition_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/edition_unittest.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum EditionUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/empty.pb.swift
+++ b/Reference/upstream/google/protobuf/empty.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A generic empty message that you can re-use to avoid defining duplicated

--- a/Reference/upstream/google/protobuf/field_mask.pb.swift
+++ b/Reference/upstream/google/protobuf/field_mask.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:

--- a/Reference/upstream/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_lite_unittest.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_proto2_unittest.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/map_proto3_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_proto3_unittest.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Proto3Unittest_TestProto3BytesMap: Sendable {

--- a/Reference/upstream/google/protobuf/map_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_unittest.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/sample_messages_edition.pb.swift
+++ b/Reference/upstream/google/protobuf/sample_messages_edition.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Edition_ForeignEnumEdition: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/source_context.pb.swift
+++ b/Reference/upstream/google/protobuf/source_context.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `SourceContext` represents information about the source of a

--- a/Reference/upstream/google/protobuf/struct.pb.swift
+++ b/Reference/upstream/google/protobuf/struct.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `NullValue` is a singleton enumeration to represent the null value for the

--- a/Reference/upstream/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/upstream/google/protobuf/test_messages_proto2.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/upstream/google/protobuf/test_messages_proto3.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/timestamp.pb.swift
+++ b/Reference/upstream/google/protobuf/timestamp.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Timestamp represents a point in time independent of any time zone or local

--- a/Reference/upstream/google/protobuf/type.pb.swift
+++ b/Reference/upstream/google/protobuf/type.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The syntax in which a protocol buffer element is defined.

--- a/Reference/upstream/google/protobuf/unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest.pb.swift
@@ -31,8 +31,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_arena.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_arena.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Proto2ArenaUnittest_NestedMessage: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_custom_options.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_delimited.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_delimited.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_LengthPrefixed: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_delimited_import.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_delimited_import.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_MessageImport: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_drop_unknown_fields.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_drop_unknown_fields.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct UnittestDropUnknownFields_Foo: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestEmbedOptimizedForSize: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_empty.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_empty.pb.swift
@@ -32,6 +32,6 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }

--- a/Reference/upstream/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// clang-format off

--- a/Reference/upstream/google/protobuf/unittest_extension_set.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_extension_set.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A message with message_set_wire_format.

--- a/Reference/upstream/google/protobuf/unittest_features.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_features.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Pb_EnumFeature: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_import.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import_lite.pb.swift
@@ -27,8 +27,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_import_public.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import_public.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittestImport_PublicImportMessage: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_import_public_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import_public_lite.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittestImport_PublicImportMessageLite: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_invalid_features.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_invalid_features.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Pb_TestInvalidFeatures: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_lazy_dependencies.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lazy_dependencies.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_LazyImports_ImportedMessage: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_lazy_dependencies_custom_option.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lazy_dependencies_custom_option.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_LazyImports_LazyMessage: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_lazy_dependencies_enum.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lazy_dependencies_enum.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_LazyImports_LazyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_legacy_features.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_legacy_features.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct LegacyFeaturesUnittest_TestEditionsMessage: @unchecked Sendable {

--- a/Reference/upstream/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lite.pb.swift
@@ -27,8 +27,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -27,8 +27,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestLiteImportsNonlite: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_mset.pb.swift
@@ -30,8 +30,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestMessageSetContainer: Sendable {

--- a/Reference/upstream/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A message with message_set_wire_format.

--- a/Reference/upstream/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_no_field_presence.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_no_generic_services.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_optimize_for.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.ExtensibleMessage, Sendable {

--- a/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto3Unittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_arena.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto3ArenaLiteUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_proto3_bad_macros.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_bad_macros.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// This generates `GID_MAX`, which is a macro in some circumstances.

--- a/Reference/upstream/google/protobuf/unittest_proto3_extensions.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_extensions.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// For testing proto3 extension behaviors.

--- a/Reference/upstream/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_lite.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Proto3LiteUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_proto3_optional.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_proto3_optional.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct ProtobufUnittest_TestProto3Optional: @unchecked Sendable {

--- a/Reference/upstream/google/protobuf/unittest_retention.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_retention.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufUnittest_TopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Reference/upstream/google/protobuf/unittest_string_view.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_string_view.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// NEXT_TAG = 5;

--- a/Reference/upstream/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_well_known_types.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Test that we can include all well-known types.

--- a/Reference/upstream/google/protobuf/wrappers.pb.swift
+++ b/Reference/upstream/google/protobuf/wrappers.pb.swift
@@ -56,8 +56,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Wrapper message for `double`.

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum Conformance_WireFormat: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/Conformance/test_messages_edition2023.pb.swift
+++ b/Sources/Conformance/test_messages_edition2023.pb.swift
@@ -23,8 +23,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_ForeignEnumEdition2023: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/Conformance/test_messages_proto2_editions.pb.swift
+++ b/Sources/Conformance/test_messages_proto2_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/Conformance/test_messages_proto3_editions.pb.swift
+++ b/Sources/Conformance/test_messages_proto3_editions.pb.swift
@@ -29,8 +29,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum ProtobufTestMessages_Editions_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Sources/SwiftProtobuf/ProtobufAPIVersionCheck.swift
+++ b/Sources/SwiftProtobuf/ProtobufAPIVersionCheck.swift
@@ -31,7 +31,7 @@
 /// `Version.compatibilityVersion` in `protoc-gen-swift`. That version and this
 /// version must match for the generated protos to be compatible, so if you
 /// update one, make sure to update it here and in the associated type below.
-public protocol ProtobufAPIVersion_3 {}
+public protocol ProtobufAPIVersion_2 {}
 
 /// This protocol is expected to be implemented by a `fileprivate` type in each
 /// source file emitted by `protoc-gen-swift`. It effectively creates a binding
@@ -39,5 +39,5 @@ public protocol ProtobufAPIVersion_3 {}
 /// causing a compile-time error (with reasonable diagnostics) if they are
 /// incompatible.
 public protocol ProtobufAPIVersionCheck {
-  associatedtype Version: ProtobufAPIVersion_3
+  associatedtype Version: ProtobufAPIVersion_2
 }

--- a/Sources/SwiftProtobuf/any.pb.swift
+++ b/Sources/SwiftProtobuf/any.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Api is a light-weight descriptor for an API Interface.

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -54,8 +54,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The full set of known editions.

--- a/Sources/SwiftProtobuf/duration.pb.swift
+++ b/Sources/SwiftProtobuf/duration.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Duration represents a signed, fixed-length span of time represented

--- a/Sources/SwiftProtobuf/empty.pb.swift
+++ b/Sources/SwiftProtobuf/empty.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A generic empty message that you can re-use to avoid defining duplicated

--- a/Sources/SwiftProtobuf/field_mask.pb.swift
+++ b/Sources/SwiftProtobuf/field_mask.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `FieldMask` represents a set of symbolic field paths, for example:

--- a/Sources/SwiftProtobuf/source_context.pb.swift
+++ b/Sources/SwiftProtobuf/source_context.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `SourceContext` represents information about the source of a

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// `NullValue` is a singleton enumeration to represent the null value for the

--- a/Sources/SwiftProtobuf/timestamp.pb.swift
+++ b/Sources/SwiftProtobuf/timestamp.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A Timestamp represents a point in time independent of any time zone or local

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -46,8 +46,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The syntax in which a protocol buffer element is defined.

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -56,8 +56,8 @@ import Foundation
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck {
-  struct _3: ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Wrapper message for `double`.

--- a/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
@@ -36,8 +36,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// The version number of protocol compiler.

--- a/Sources/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
@@ -26,8 +26,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Configuration used to define the mappings for generated proto files

--- a/Sources/protoc-gen-swift/Version.swift
+++ b/Sources/protoc-gen-swift/Version.swift
@@ -25,7 +25,7 @@ struct Version {
     // library) should not be updated for *every* version of Swift Protobuf,
     // but only for those that introduce breaking changes (either behavioral
     // or API-changing).
-    static let compatibilityVersion = 3
+    static let compatibilityVersion = 2
 
     static let copyright = "Copyright (C) 2014-2017 Apple Inc. and the project authors"
 }

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobufPluginLibrary
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SDTTopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftDescriptorTest_Proto3MessageForPresence: Sendable {

--- a/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
@@ -28,8 +28,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftFeatureTest_TestFeatures: Sendable {

--- a/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_LengthPrefixed: Sendable {

--- a/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited_import.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited_import.pb.swift
@@ -16,8 +16,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct EditionsUnittest_MessageImport: Sendable {

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestAny: Sendable {

--- a/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -30,8 +30,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/generated_swift_names_enum_cases.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_enum_cases.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
@@ -737,7 +737,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
   case proto3DefaultValue // = 708
   case proto3Optional // = 709
   case protobufApiversionCheck // = 710
-  case protobufApiversion3 // = 711
+  case protobufApiversion2 // = 711
   case protobufBool // = 712
   case protobufBytes // = 713
   case protobufDouble // = 714
@@ -1739,7 +1739,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     case 708: self = .proto3DefaultValue
     case 709: self = .proto3Optional
     case 710: self = .protobufApiversionCheck
-    case 711: self = .protobufApiversion3
+    case 711: self = .protobufApiversion2
     case 712: self = .protobufBool
     case 713: self = .protobufBytes
     case 714: self = .protobufDouble
@@ -2742,7 +2742,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     case .proto3DefaultValue: return 708
     case .proto3Optional: return 709
     case .protobufApiversionCheck: return 710
-    case .protobufApiversion3: return 711
+    case .protobufApiversion2: return 711
     case .protobufBool: return 712
     case .protobufBytes: return 713
     case .protobufDouble: return 714
@@ -3747,7 +3747,7 @@ enum SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.Enum,
     .proto3DefaultValue,
     .proto3Optional,
     .protobufApiversionCheck,
-    .protobufApiversion3,
+    .protobufApiversion2,
     .protobufBool,
     .protobufBytes,
     .protobufDouble,
@@ -4749,7 +4749,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnum: SwiftProtobuf.
     708: .same(proto: "proto3DefaultValue"),
     709: .same(proto: "proto3Optional"),
     710: .same(proto: "ProtobufAPIVersionCheck"),
-    711: .same(proto: "ProtobufAPIVersion_3"),
+    711: .same(proto: "ProtobufAPIVersion_2"),
     712: .same(proto: "ProtobufBool"),
     713: .same(proto: "ProtobufBytes"),
     714: .same(proto: "ProtobufDouble"),

--- a/Tests/SwiftProtobufTests/generated_swift_names_enums.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_enums.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums: Sendable {
@@ -21331,32 +21331,32 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums: Sendable {
 
   }
 
-  enum ProtobufAPIVersion_3: SwiftProtobuf.Enum, Swift.CaseIterable {
+  enum ProtobufAPIVersion_2: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
-    case noneProtobufApiversion3 // = 0
+    case noneProtobufApiversion2 // = 0
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .noneProtobufApiversion3
+      self = .noneProtobufApiversion2
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 0: self = .noneProtobufApiversion3
+      case 0: self = .noneProtobufApiversion2
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .noneProtobufApiversion3: return 0
+      case .noneProtobufApiversion2: return 0
       case .UNRECOGNIZED(let i): return i
       }
     }
 
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_3] = [
-      .noneProtobufApiversion3,
+    static let allCases: [SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_2] = [
+      .noneProtobufApiversion2,
     ]
 
   }
@@ -34107,9 +34107,9 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVer
   ]
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_3: SwiftProtobuf._ProtoNameProviding {
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedEnums.ProtobufAPIVersion_2: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NONE_ProtobufAPIVersion_3"),
+    0: .same(proto: "NONE_ProtobufAPIVersion_2"),
   ]
 }
 

--- a/Tests/SwiftProtobufTests/generated_swift_names_fields.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_fields.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: @unchecked Sendable {
@@ -3579,9 +3579,9 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: @unchecked Send
     set {_uniqueStorage()._protobufApiversionCheck = newValue}
   }
 
-  var protobufApiversion3: Int32 {
-    get {return _storage._protobufApiversion3}
-    set {_uniqueStorage()._protobufApiversion3 = newValue}
+  var protobufApiversion2: Int32 {
+    get {return _storage._protobufApiversion2}
+    set {_uniqueStorage()._protobufApiversion2 = newValue}
   }
 
   var protobufBool: Int32 {
@@ -5718,7 +5718,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
     708: .same(proto: "proto3DefaultValue"),
     709: .same(proto: "proto3Optional"),
     710: .same(proto: "ProtobufAPIVersionCheck"),
-    711: .standard(proto: "ProtobufAPIVersion_3"),
+    711: .standard(proto: "ProtobufAPIVersion_2"),
     712: .same(proto: "ProtobufBool"),
     713: .same(proto: "ProtobufBytes"),
     714: .same(proto: "ProtobufDouble"),
@@ -6714,7 +6714,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
     var _proto3DefaultValue: Int32 = 0
     var _proto3Optional: Int32 = 0
     var _protobufApiversionCheck: Int32 = 0
-    var _protobufApiversion3: Int32 = 0
+    var _protobufApiversion2: Int32 = 0
     var _protobufBool: Int32 = 0
     var _protobufBytes: Int32 = 0
     var _protobufDouble: Int32 = 0
@@ -7721,7 +7721,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
       _proto3DefaultValue = source._proto3DefaultValue
       _proto3Optional = source._proto3Optional
       _protobufApiversionCheck = source._protobufApiversionCheck
-      _protobufApiversion3 = source._protobufApiversion3
+      _protobufApiversion2 = source._protobufApiversion2
       _protobufBool = source._protobufBool
       _protobufBytes = source._protobufBytes
       _protobufDouble = source._protobufDouble
@@ -8732,7 +8732,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
         case 708: try { try decoder.decodeSingularInt32Field(value: &_storage._proto3DefaultValue) }()
         case 709: try { try decoder.decodeSingularInt32Field(value: &_storage._proto3Optional) }()
         case 710: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversionCheck) }()
-        case 711: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversion3) }()
+        case 711: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufApiversion2) }()
         case 712: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufBool) }()
         case 713: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufBytes) }()
         case 714: try { try decoder.decodeSingularInt32Field(value: &_storage._protobufDouble) }()
@@ -11153,8 +11153,8 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
       if _storage._protobufApiversionCheck != 0 {
         try visitor.visitSingularInt32Field(value: _storage._protobufApiversionCheck, fieldNumber: 710)
       }
-      if _storage._protobufApiversion3 != 0 {
-        try visitor.visitSingularInt32Field(value: _storage._protobufApiversion3, fieldNumber: 711)
+      if _storage._protobufApiversion2 != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._protobufApiversion2, fieldNumber: 711)
       }
       if _storage._protobufBool != 0 {
         try visitor.visitSingularInt32Field(value: _storage._protobufBool, fieldNumber: 712)
@@ -12721,7 +12721,7 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedFields: SwiftProtobu
         if _storage._proto3DefaultValue != rhs_storage._proto3DefaultValue {return false}
         if _storage._proto3Optional != rhs_storage._proto3Optional {return false}
         if _storage._protobufApiversionCheck != rhs_storage._protobufApiversionCheck {return false}
-        if _storage._protobufApiversion3 != rhs_storage._protobufApiversion3 {return false}
+        if _storage._protobufApiversion2 != rhs_storage._protobufApiversion2 {return false}
         if _storage._protobufBool != rhs_storage._protobufBool {return false}
         if _storage._protobufBytes != rhs_storage._protobufBytes {return false}
         if _storage._protobufDouble != rhs_storage._protobufDouble {return false}

--- a/Tests/SwiftProtobufTests/generated_swift_names_messages.pb.swift
+++ b/Tests/SwiftProtobufTests/generated_swift_names_messages.pb.swift
@@ -20,8 +20,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages: Sendable {
@@ -8551,12 +8551,12 @@ struct SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages: Sendable {
     init() {}
   }
 
-  struct ProtobufAPIVersion_3: Sendable {
+  struct ProtobufAPIVersion_2: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
-    var protobufApiversion3: Int32 = 0
+    var protobufApiversion2: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -34693,10 +34693,10 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPI
   }
 }
 
-extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".ProtobufAPIVersion_3"
+extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.protoMessageName + ".ProtobufAPIVersion_2"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "ProtobufAPIVersion_3"),
+    1: .standard(proto: "ProtobufAPIVersion_2"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -34705,21 +34705,21 @@ extension SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPI
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularInt32Field(value: &self.protobufApiversion3) }()
+      case 1: try { try decoder.decodeSingularInt32Field(value: &self.protobufApiversion2) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.protobufApiversion3 != 0 {
-      try visitor.visitSingularInt32Field(value: self.protobufApiversion3, fieldNumber: 1)
+    if self.protobufApiversion2 != 0 {
+      try visitor.visitSingularInt32Field(value: self.protobufApiversion2, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_3) -> Bool {
-    if lhs.protobufApiversion3 != rhs.protobufApiversion3 {return false}
+  static func ==(lhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2, rhs: SwiftProtoTesting_Generated_GeneratedSwiftReservedMessages.ProtobufAPIVersion_2) -> Bool {
+    if lhs.protobufApiversion2 != rhs.protobufApiversion2 {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// This proto includes every type of field in both singular and repeated

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -54,8 +54,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -52,8 +52,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Import_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
@@ -48,8 +48,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Import_PublicImportMessage: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -53,8 +53,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestMessageSetContainer: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -52,8 +52,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// A message with message_set_wire_format.

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_UnknownEnum_Proto3_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Proto3_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_proto3_optional.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_optional.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestProto3Optional: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -48,8 +48,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_TestAllRequiredTypes: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_CycleFoo: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// An enum value marked as deprecated.

--- a/Tests/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// NOTE: The whole .proto file that defined this enum was marked as deprecated.

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Enum2_SwiftEnumTest: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Enum3_SwiftEnumTest: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend_Foo: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend2_MyMessage: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Extend3_MyMessage: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct Ext4MyMessage: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Order_TestFieldOrderings: SwiftProtobuf.ExtensibleMessage, Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Same field number appears inside and outside of the group.

--- a/Tests/SwiftProtobufTests/unittest_swift_json.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_json.pb.swift
@@ -25,8 +25,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_SwiftJSONTest: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 enum SwiftProtoTesting_Names_EnumFieldNames: SwiftProtobuf.Enum, Swift.CaseIterable {

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// For issue #1084 - If the generated code compiles, things are good.

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_number_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_number_prefix.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct _4fun_SwiftProtoTesting_Mumble_MyMessage: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_OneOfOptionMessage1: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_merging.pb.swift
@@ -34,8 +34,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Merging_TestMessage: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_SwiftReservedTest: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -32,8 +32,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftReservedTestExt2: Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Message2: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -45,8 +45,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 struct SwiftProtoTesting_Message3: @unchecked Sendable {

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -46,8 +46,8 @@ import SwiftProtobuf
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
 fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
-  struct _3: SwiftProtobuf.ProtobufAPIVersion_3 {}
-  typealias Version = _3
+  struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
+  typealias Version = _2
 }
 
 /// Test that we can include all well-known types.


### PR DESCRIPTION
## Motivation
This is the last of a set of changes to make breaking changes introduced in `main` non-breaking.

## Modifications
Because `main` had introduced breaking changes, we had to change the API version from 2 to 3 to get generated code ready for the breaking release.
However, now that releasing a breaking v2 is not imminent and we've removed all other breaking changes from main, we should revert this.

## Result
API version is back to 2.