### PR TITLE
Update API breakage GH actions to run for SwiftProtobufPluginLibrary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,8 @@ jobs:
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Check for API breaking changes
-      run: swift package diagnose-api-breaking-changes origin/main --products SwiftProtobuf
+      run: |
+        swift package diagnose-api-breaking-changes origin/main --breakage-allowlist-path known_api_breaks.txt
 
   api-breakage-since-last-release:
     name: Api Breakage Compared to Last Release
@@ -156,8 +157,7 @@ jobs:
       run: |
         LAST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
         echo "Checking for breaks against the tag: ${LAST_TAG}"
-        swift package diagnose-api-breaking-changes "${LAST_TAG}" --products SwiftProtobuf \
-          --breakage-allowlist-path known_api_breaks.txt
+        swift package diagnose-api-breaking-changes "${LAST_TAG}" --breakage-allowlist-path known_api_breaks.txt
 
   sanitizer_testing:
     # Using older ubuntu image due to issue with newer linux kernel images. When


### PR DESCRIPTION
We had missed to check that no API breaks had happened on the `SwiftProtobufPluginLibrary` before tagging the next minor from `main`.

Because `SwiftProtobufPluginLibrary` is a public product, I've modified the GH actions we've got to check API breaks to remove the explicit products flag, which means we'll check API breaks for all targets.