### PR TITLE
Revert "Use older base image for sanitizer and fuzz testing."

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,19 +139,15 @@ jobs:
         swift package diagnose-api-breaking-changes "${LAST_TAG}" --breakage-allowlist-path known_api_breaks.txt
 
   sanitizer_testing:
-    # Using older ubuntu image due to issue with newer linux kernel images. When
-    # changing, see the "container" value below.
-    # https://github.com/apple/swift-protobuf/issues/1571
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         sanitizer: ["address", "thread"]
         swiftpm_config: ["debug", "release"]
     container:
-      # Test on the latest Swift release, but forcing the focal image to match the
-      # ubuntu issue mentioned aboce.
-      image: swift:focal
+      # Test on the latest Swift release.
+      image: swift:latest
     steps:
     - uses: actions/checkout@v4
     - name: Test
@@ -173,18 +169,14 @@ jobs:
         swift test -c ${{ matrix.swiftpm_config }} --sanitize=${{ matrix.sanitizer }} ${EXTRAS:-}
 
   fuzzing_regressions:
-    # Using older ubuntu image due to issue with newer linux kernel images. When
-    # changing, see the "container" value below.
-    # https://github.com/apple/swift-protobuf/issues/1571
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         swiftpm_config: ["debug", "release"]
     container:
-      # Test on the latest Swift release, but forcing the focal image to match the
-      # ubuntu issue mentioned aboce.
-      image: swift:focal
+      # Test on the latest Swift release.
+      image: swift:latest
     steps:
     - uses: actions/checkout@v4
     - name: Build


### PR DESCRIPTION
This reverts commit b3c2279e1acd28f7a8c384daaea7430e255f3347.