### PR TITLE
Update the CI swift images.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
         # seems better. This should also ensure protobuf caching changes with
         # each new image incase system in the Swift image are changed/updated.
         swift:
-        - version: 5.10.1-jammy
+        - version: 5.10.1-noble
           # No "hook", see https://github.com/apple/swift-protobuf/issues/1560 for the
           # current issue with using -warnings-as-errors on linux.
-        - version: 5.9.2-jammy
+        - version: 5.9.2-focal
           hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
-        - version: 5.8.1-jammy
+        - version: 5.8.1-focal
           hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -35,7 +35,7 @@ jobs:
         # seems better. This should also ensure protobuf caching changes with
         # each new image incase system in the Swift image are changed/updated.
         swift:
-        - 5.10.1-jammy
+        - 5.10.1-noble
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"


### PR DESCRIPTION
This moves to the latest Ubuntu for each Swift release. We were stuck somewhat behind, so hopefully this means less maintenance going forward.