### PR TITLE
Fix FuzzTests unit tests

### DIFF
--- a/Tests/SwiftProtobufTests/Test_FuzzTests.swift
+++ b/Tests/SwiftProtobufTests/Test_FuzzTests.swift
@@ -55,7 +55,12 @@ final class Test_FuzzTests: XCTestCase {
 
   func assertTextFormatFails(_ asBytes: [UInt8], options: TextFormatDecodingOptions = TextFormatDecodingOptions(), file: XCTestFileArgType = #file, line: UInt = #line) {
     guard let str = String(data: Data(asBytes), encoding: .utf8) else {
-      XCTFail("Failed to make a string", file: file, line: line)
+      print(
+        """
+        Failed to make string (at \(file):\(line)): nothing to try and decode.
+        The fuzzer does not fail in this case and neither should we, skipping test.
+        """
+      )
       return
     }
     XCTAssertThrowsError(
@@ -75,7 +80,12 @@ final class Test_FuzzTests: XCTestCase {
 
   func assertTextFormatSucceeds(_ asBytes: [UInt8], options: TextFormatDecodingOptions = TextFormatDecodingOptions(), file: XCTestFileArgType = #file, line: UInt = #line) {
     guard let str = String(data: Data(asBytes), encoding: .utf8) else {
-      XCTFail("Failed to make a string", file: file, line: line)
+      print(
+        """
+        Failed to make string (at \(file):\(line)): nothing to try and decode.
+        The fuzzer does not fail in this case and neither should we, skipping test.
+        """
+      )
       return
     }
     XCTAssertNoThrow(


### PR DESCRIPTION
One of the assertions in the TextFormat fuzz-originated unit tests checked that we failed to decode a string built from a sequence of bytes. However, this sequence of bytes had invalid UTF8 characters. `Foundation` has improved in recent betas and now fails to build a String from this sequence (which it didn't before). This is causing the test to fail.

If the String couldn't have been constructed during fuzz testing, the test would have passed - see:
https://github.com/apple/swift-protobuf/blob/601e03a9ccff83868833f2e4268ca2650a7503c4/FuzzTesting/Sources/FuzzTextFormat/main.swift#L20

We should tolerate the String not being constructed here without failing the test, as it's the correct (and current) behaviour. This means that after this PR, assertions will be skipped when a String cannot be constructed.
However, we shouldn't simply remove the failing assertion, because in the case `Foundation` introduces this bug again, we should make sure we're failing the TextFormat decoding.