### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/Documentation/STYLE_GUIDELINES.md
+++ b/Documentation/STYLE_GUIDELINES.md
@@ -17,7 +17,7 @@ a method with a large number of generic types and/or arguments), we suggest
 two pieces of advice:
 
 1. Look to the
-   [Swift standard library](https://github.com/apple/swift/tree/main/stdlib/public/core)
+   [Swift standard library](https://github.com/swiftlang/swift/tree/main/stdlib/public/core)
    for guidance.
 1. Don't fight Xcode's auto-indenting unless doing so would make the
    formatting look horrible. Xcode has some baked-in assumptions about how

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/Sources/SwiftProtobufPluginLibrary/CodeGenerator.swift
+++ b/Sources/SwiftProtobufPluginLibrary/CodeGenerator.swift
@@ -77,7 +77,7 @@ public protocol CodeGenerator {
 
 extension CommandLine {
   /// Get the command-line arguments passed to this process in a non mutable
-  /// form. Idea from https://github.com/apple/swift/issues/66213
+  /// form. Idea from https://github.com/swiftlang/swift/issues/66213
   ///
   /// - Returns: An array of command-line arguments.
   fileprivate static let safeArguments: [String] =

--- a/Sources/protoc-gen-swift/CommandLine+Extensions.swift
+++ b/Sources/protoc-gen-swift/CommandLine+Extensions.swift
@@ -14,7 +14,7 @@ extension CommandLine {
 
   static var programName: String {
     // Get the command-line arguments passed to this process in a non mutable
-    // form. Idea from https://github.com/apple/swift/issues/66213
+    // form. Idea from https://github.com/swiftlang/swift/issues/66213
     let safeArgs: [String] =
       UnsafeBufferPointer(start: unsafeArgv, count: Int(argc)).compactMap {
         String(validatingUTF8: $0!)


### PR DESCRIPTION
### Summary:

Update links for repositories moved to the swiftlang org on GitHub

### Modifications:

Update the link
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-docc-plugin  =>  https://github.com/swiftlang/swift-docc-plugin

### Result:

Correct the reference
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-docc-plugin  =>  https://github.com/swiftlang/swift-docc-plugin
