### PR TITLE
Support access level on import statements

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -184,8 +184,9 @@ this will only work if the `Visibility` is set to `internal`.
 
 ##### Generation Option: `UseAccessLevelOnImports` - imports preceded by a visibility modifier (`public`, `package`, `internal`)
 
-By default, the code generator does not precede any imports with a visibility modifier.
-You can change this with the `UseAccessLevelOnImports` option:
+The default behavior depends on the Swift version the plugin is compiled with. 
+For Swift versions below 6.0 the default is `false` and the code generator does not precede any imports with a visibility modifier. 
+You can change this by explicitly setting the `UseAccessLevelOnImports` option:
 
 ```
 $ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
@@ -193,9 +194,12 @@ $ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.pro
 
 The possible values for `UseAccessLevelOnImports` are:
 
-* `false` (default): Generates plain import directives without a visibility modifier.
+* `false`: Generates plain import directives without a visibility modifier.
 * `true`: Imports of internal dependencies and any modules defined in the module
 mappings will be preceded by a visibility modifier corresponding to the visibility of the generated types - see `Visibility` option. 
+
+**Important:** It is strongly encouraged to use `internal` imports instead of `@_implementationOnly` imports. 
+Hence `UseAccessLevelOnImports` and `ImplementationOnlyImports` options exclude each other. 
 
 
 ### Building your project

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -182,6 +182,22 @@ exposed via public API, so even if `ImplementationOnlyImports` is set to `true`,
 this will only work if the `Visibility` is set to `internal`.
 
 
+##### Generation Option: `UseAccessLevelOnImports` - imports preceded by a visibility modifier (`public`, `package`, `internal`)
+
+By default, the code generator does not precede any imports with a visibility modifier.
+You can change this with the `UseAccessLevelOnImports` option:
+
+```
+$ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
+```
+
+The possible values for `UseAccessLevelOnImports` are:
+
+* `false` (default): Generates plain import directives without a visibility modifier.
+* `true`: Imports of internal dependencies and any modules defined in the module
+mappings will be preceded by a visibility modifier corresponding to the visibility of the generated types - see `Visibility` option. 
+
+
 ### Building your project
 
 After copying the `.pb.swift` files into your project, you will need

--- a/PluginExamples/Package.swift
+++ b/PluginExamples/Package.swift
@@ -7,14 +7,22 @@ let package = Package(
     dependencies: [
         .package(path: "../")
     ],
-    targets: [
+    targets: targets()
+)
+
+private func targets() -> [Target] {
+    var testDependencies: [Target.Dependency] = [
+        .target(name: "Simple"),
+        .target(name: "Nested"),
+        .target(name: "Import"),
+    ]
+#if compiler(>=5.9)
+    testDependencies.append(.target(name: "AccessLevelOnImport"))
+#endif
+    var targets: [Target] = [
         .testTarget(
             name: "ExampleTests",
-            dependencies: [
-                .target(name: "Simple"),
-                .target(name: "Nested"),
-                .target(name: "Import"),
-            ]
+            dependencies: testDependencies
         ),
         .target(
             name: "Simple",
@@ -44,4 +52,21 @@ let package = Package(
             ]
         ),
     ]
-)
+#if compiler(>=5.9)
+    targets.append(
+        .target(
+            name: "AccessLevelOnImport",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("AccessLevelOnImport"),
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        )
+    )
+#endif
+    return targets
+}

--- a/PluginExamples/Sources/AccessLevelOnImport/AccessLevelOnImport/AccessLevelOnImport.proto
+++ b/PluginExamples/Sources/AccessLevelOnImport/AccessLevelOnImport/AccessLevelOnImport.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "Dependency/Dependency.proto";
+
+message AccessLevelOnImport {
+  Dependency dependency = 1;
+}

--- a/PluginExamples/Sources/AccessLevelOnImport/Dependency/Dependency.proto
+++ b/PluginExamples/Sources/AccessLevelOnImport/Dependency/Dependency.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Dependency {
+  string name = 1;
+}

--- a/PluginExamples/Sources/AccessLevelOnImport/empty.swift
+++ b/PluginExamples/Sources/AccessLevelOnImport/empty.swift
@@ -1,0 +1,3 @@
+/// DO NOT DELETE.
+///
+/// We need to keep this file otherwise the plugin is not running.

--- a/PluginExamples/Sources/AccessLevelOnImport/swift-protobuf-config.json
+++ b/PluginExamples/Sources/AccessLevelOnImport/swift-protobuf-config.json
@@ -1,0 +1,12 @@
+{
+    "invocations": [
+        {
+            "protoFiles": [
+                "AccessLevelOnImport/AccessLevelOnImport.proto",
+                "Dependency/Dependency.proto",
+            ],
+            "visibility": "public",
+            "useAccessLevelOnImports": true
+        }
+    ]
+}

--- a/PluginExamples/Sources/ExampleTests/AccessLevelOnImportTests.swift
+++ b/PluginExamples/Sources/ExampleTests/AccessLevelOnImportTests.swift
@@ -1,0 +1,13 @@
+#if compiler(>=5.9)
+
+import AccessLevelOnImport
+import XCTest
+
+final class AccessLevelOnImportTests: XCTestCase {
+    func testAccessLevelOnImport() {
+        let access = AccessLevelOnImport.with { $0.dependency = .with { $0.name = "Dependency" } }
+        XCTAssertEqual(access.dependency.name, "Dependency")
+    }
+}
+
+#endif

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -85,6 +85,8 @@ struct SwiftProtobufPlugin {
             var fileNaming: FileNaming?
             /// Whether internal imports should be annotated as `@_implementationOnly`.
             var implementationOnlyImports: Bool?
+            /// Whether import statements should be preceded with visibility.
+            var useAccessLevelOnImports: Bool?
         }
 
         /// The path to the `protoc` binary.
@@ -186,6 +188,11 @@ struct SwiftProtobufPlugin {
         // Add the implementation only imports flag if it was set
         if let implementationOnlyImports = invocation.implementationOnlyImports {
             protocArgs.append("--swift_opt=ImplementationOnlyImports=\(implementationOnlyImports)")
+        }
+
+        // Add the useAccessLevelOnImports only imports flag if it was set
+        if let useAccessLevelOnImports = invocation.useAccessLevelOnImports {
+            protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(useAccessLevelOnImports)")
         }
 
         var inputFiles = [Path]()

--- a/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
@@ -20,7 +20,7 @@ private let defaultSwiftProtobufModuleName = "SwiftProtobuf"
 public struct ProtoFileToModuleMappings {
 
   /// Errors raised from parsing mappings
-  public enum LoadError: Error {
+  public enum LoadError: Error, Equatable {
     /// Raised if the path wasn't found.
     case failToOpen(path: String)
     /// Raised if an mapping entry in the protobuf doesn't have a module name.

--- a/Sources/protoc-gen-swift/Docs.docc/index.md
+++ b/Sources/protoc-gen-swift/Docs.docc/index.md
@@ -188,6 +188,22 @@ exposed via public API, so even if `ImplementationOnlyImports` is set to `true`,
 this will only work if the `Visibility` is set to `internal`. 
 
 
+##### Generation Option: `UseAccessLevelOnImports` - imports preceded by a visibility modifier (`public`, `package`, `internal`)
+
+By default, the code generator does not precede any imports with a visibility modifier.
+You can change this with the `UseAccessLevelOnImports` option:
+
+```
+$ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
+```
+
+The possible values for `UseAccessLevelOnImports` are:
+
+* `false` (default): Generates plain import directives without a visibility modifier.
+* `true`: Imports of internal dependencies and any modules defined in the module
+mappings will be preceded by a visibility modifier corresponding to the visibility of the generated types - see `Visibility` option. 
+
+
 ### Building your project
 
 After copying the `.pb.swift` files into your project, you will need

--- a/Sources/protoc-gen-swift/Docs.docc/index.md
+++ b/Sources/protoc-gen-swift/Docs.docc/index.md
@@ -190,8 +190,9 @@ this will only work if the `Visibility` is set to `internal`.
 
 ##### Generation Option: `UseAccessLevelOnImports` - imports preceded by a visibility modifier (`public`, `package`, `internal`)
 
-By default, the code generator does not precede any imports with a visibility modifier.
-You can change this with the `UseAccessLevelOnImports` option:
+The default behavior depends on the Swift version the plugin is compiled with. 
+For Swift versions below 6.0 the default is `false` and the code generator does not precede any imports with a visibility modifier. 
+You can change this by explicitly setting the `UseAccessLevelOnImports` option:
 
 ```
 $ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
@@ -199,9 +200,12 @@ $ protoc --swift_opt=UseAccessLevelOnImports=[value] --swift_out=. foo/bar/*.pro
 
 The possible values for `UseAccessLevelOnImports` are:
 
-* `false` (default): Generates plain import directives without a visibility modifier.
+* `false`: Generates plain import directives without a visibility modifier.
 * `true`: Imports of internal dependencies and any modules defined in the module
 mappings will be preceded by a visibility modifier corresponding to the visibility of the generated types - see `Visibility` option. 
+
+**Important:** It is strongly encouraged to use `internal` imports instead of `@_implementationOnly` imports. 
+Hence `UseAccessLevelOnImports` and `ImplementationOnlyImports` options exclude each other. 
 
 
 ### Building your project

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -100,14 +100,13 @@ class FileGenerator {
         if fileDescriptor.isBundledProto {
             p.print("// 'import \(namer.swiftProtobufModuleName)' suppressed, this proto file is meant to be bundled in the runtime.")
         } else {
-            let directive = self.generatorOptions.implementationOnlyImports ? "@_implementationOnly import" : "import"
-            p.print("\(directive) \(namer.swiftProtobufModuleName)")
+            p.print("\(generatorOptions.importDirective.snippet) \(namer.swiftProtobufModuleName)")
         }
 
         let neededImports = fileDescriptor.computeImports(
           namer: namer,
-          reexportPublicImports: self.generatorOptions.visibility != .internal,
-          asImplementationOnly: self.generatorOptions.implementationOnlyImports)
+          directive: generatorOptions.importDirective,
+          reexportPublicImports: generatorOptions.visibility != .internal)
         if !neededImports.isEmpty {
             p.print()
             p.print(neededImports)

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -79,7 +79,11 @@ class GeneratorOptions {
     var visibility: Visibility = .internal
     var swiftProtobufModuleName: String? = nil
     var implementationOnlyImports: Bool = false
+#if swift(>=6.0)
+    var useAccessLevelOnImports = true
+#else
     var useAccessLevelOnImports = false
+#endif
     var experimentalStripNonfunctionalCodegen: Bool = false
 
     for pair in parameter.parsedPairs {

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -47,19 +47,19 @@ class GeneratorOptions {
 
     var isAccessLevel: Bool {
         switch self {
-        case .accessLevel: true
-        default: false
+        case .accessLevel: return true
+        default: return false
         }
     }
 
     var snippet: String {
       switch self {
       case let .accessLevel(visibility):
-        "\(visibility) import"
+        return "\(visibility) import"
       case .plain:
-        "import"
+        return "import"
       case .implementationOnly:
-        "@_implementationOnly import"
+        return "@_implementationOnly import"
       }
     }
   }
@@ -169,10 +169,10 @@ class GeneratorOptions {
 
     self.experimentalStripNonfunctionalCodegen = experimentalStripNonfunctionalCodegen
 
-    self.importDirective = switch (implementationOnlyImports, useAccessLevelOnImports) {
-    case (false, false): .plain
-    case (false, true): .accessLevel(visibility)
-    case (true, false): .implementationOnly
+    switch (implementationOnlyImports, useAccessLevelOnImports) {
+    case (false, false): self.importDirective = .plain
+    case (false, true): self.importDirective = .accessLevel(visibility)
+    case (true, false): self.importDirective = .implementationOnly
     case (true, true): throw GenerationError.message(message: """
       When using access levels on imports the @_implementationOnly option is unnecessary.
       Disable @_implementationOnly imports.

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -30,21 +30,36 @@ class GeneratorOptions {
     }
   }
 
-  enum Visibility {
+  enum Visibility: String {
     case `internal`
     case `public`
     case `package`
 
     init?(flag: String) {
-      switch flag.lowercased() {
-      case "internal":
-        self = .internal
-      case "public":
-        self = .public
-      case "package":
-        self = .package
-      default:
-        return nil
+      self.init(rawValue: flag.lowercased())
+    }
+  }
+
+  enum ImportDirective: Equatable {
+    case accessLevel(Visibility)
+    case plain
+    case implementationOnly
+
+    var isAccessLevel: Bool {
+        switch self {
+        case .accessLevel: true
+        default: false
+        }
+    }
+
+    var snippet: String {
+      switch self {
+      case let .accessLevel(visibility):
+        "\(visibility) import"
+      case .plain:
+        "import"
+      case .implementationOnly:
+        "@_implementationOnly import"
       }
     }
   }
@@ -52,7 +67,7 @@ class GeneratorOptions {
   let outputNaming: OutputNaming
   let protoToModuleMappings: ProtoFileToModuleMappings
   let visibility: Visibility
-  let implementationOnlyImports: Bool
+  let importDirective: ImportDirective
   let experimentalStripNonfunctionalCodegen: Bool
 
   /// A string snippet to insert for the visibility
@@ -64,6 +79,7 @@ class GeneratorOptions {
     var visibility: Visibility = .internal
     var swiftProtobufModuleName: String? = nil
     var implementationOnlyImports: Bool = false
+    var useAccessLevelOnImports = false
     var experimentalStripNonfunctionalCodegen: Bool = false
 
     for pair in parameter.parsedPairs {
@@ -98,6 +114,13 @@ class GeneratorOptions {
       case "ImplementationOnlyImports":
         if let value = Bool(pair.value) {
           implementationOnlyImports = value
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key,
+                                                      value: pair.value)
+        }
+      case "UseAccessLevelOnImports":
+        if let value = Bool(pair.value) {
+          useAccessLevelOnImports = value
         } else {
           throw GenerationError.invalidParameterValue(name: pair.key,
                                                       value: pair.value)
@@ -140,13 +163,22 @@ class GeneratorOptions {
       visibilitySourceSnippet = "package "
     }
 
-    self.implementationOnlyImports = implementationOnlyImports
     self.experimentalStripNonfunctionalCodegen = experimentalStripNonfunctionalCodegen
+
+    self.importDirective = switch (implementationOnlyImports, useAccessLevelOnImports) {
+    case (false, false): .plain
+    case (false, true): .accessLevel(visibility)
+    case (true, false): .implementationOnly
+    case (true, true): throw GenerationError.message(message: """
+      When using access levels on imports the @_implementationOnly option is unnecessary.
+      Disable @_implementationOnly imports.
+      """)
+    }
 
     // ------------------------------------------------------------------------
     // Now do "cross option" validations.
 
-    if self.implementationOnlyImports && self.visibility != .internal {
+    if implementationOnlyImports && self.visibility != .internal {
       throw GenerationError.message(message: """
         Cannot use @_implementationOnly imports when the proto visibility is public or package.
         Either change the visibility to internal, or disable @_implementationOnly imports.

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -13,19 +13,6 @@ import SwiftProtobuf
 import SwiftProtobufTestHelpers
 @testable import SwiftProtobufPluginLibrary
 
-// Support equality to simplify testing of getting the correct errors.
-extension ProtoFileToModuleMappings.LoadError: Equatable {
-  public static func ==(lhs: ProtoFileToModuleMappings.LoadError, rhs: ProtoFileToModuleMappings.LoadError) -> Bool {
-    switch (lhs, rhs) {
-    case (.entryMissingModuleName(let l), .entryMissingModuleName(let r)): return l == r
-    case (.entryHasNoProtoPaths(let l), .entryHasNoProtoPaths(let r)): return l == r
-    case (.duplicateProtoPathMapping(let l1, let l2, let l3),
-          .duplicateProtoPathMapping(let r1, let r2, let r3)): return l1 == r1 && l2 == r2 && l3 == r3
-    default: return false
-    }
-  }
-}
-
 // Helpers to make test cases.
 
 fileprivate typealias FileDescriptorProto = Google_Protobuf_FileDescriptorProto


### PR DESCRIPTION
This PR brings in the possibility to define access level on import statements generated through `ProtoPathModuleMappings` plugin option.
Access level on import statements is a new feature of Swift 6, but it can already be enabled in Swift 5.9 builds.

See https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md