### PR TITLE
Add missing periods and correct the typos.

### DIFF
--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -216,7 +216,7 @@ internal class AnyMessageStorage {
       break
 
     case .contentJSON(let contentJSON, let options):
-      // contentJSON requires we have the type available for decoding
+      // contentJSON requires we have the type available for decoding.
       guard let messageType = Google_Protobuf_Any.messageType(forTypeURL: _typeURL) else {
         throw BinaryEncodingError.anyTranscodeFailure
       }

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -276,7 +276,7 @@ extension AnyMessageStorage {
           emitVerboseTextForm(visitor: &visitor, message: m, typeURL: _typeURL)
           return
         } catch {
-          // Fall through to just print the type and raw binary data
+          // Fall through to just print the type and raw binary data.
         }
       }
       if !_typeURL.isEmpty {

--- a/Sources/SwiftProtobuf/AsyncMessageSequence.swift
+++ b/Sources/SwiftProtobuf/AsyncMessageSequence.swift
@@ -135,7 +135,7 @@ public struct AsyncMessageSequence<
     mutating func readBytes(_ size: Int) async throws -> [UInt8] {
       // Even though the bytes are read in chunks, things can still hard fail if
       // there isn't enough memory to append to have all the bytes at once for
-      // parsing; but this atleast catches some possible OOM attacks.
+      // parsing; but this at least catches some possible OOM attacks.
       var bytesNeeded = size
       var buffer = [UInt8]()
       let kChunkSize = 16 * 1024 * 1024

--- a/Sources/SwiftProtobuf/AsyncMessageSequence.swift
+++ b/Sources/SwiftProtobuf/AsyncMessageSequence.swift
@@ -82,7 +82,7 @@ public struct AsyncMessageSequence<
     self.options = options
   }
 
-  /// An asynchronous iterator that produces the messages of this asynchronous sequence
+  /// An asynchronous iterator that produces the messages of this asynchronous sequence.
   public struct AsyncIterator: AsyncIteratorProtocol {
     @usableFromInline
     var iterator: Base.AsyncIterator?
@@ -105,7 +105,7 @@ public struct AsyncMessageSequence<
       self.options = options
     }
 
-    /// Asynchronously reads the next varint
+    /// Asynchronously reads the next varint.
     @inlinable
     mutating func nextVarInt() async throws -> UInt64? {
       var messageSize: UInt64 = 0

--- a/Sources/SwiftProtobuf/AsyncMessageSequence.swift
+++ b/Sources/SwiftProtobuf/AsyncMessageSequence.swift
@@ -105,7 +105,7 @@ public struct AsyncMessageSequence<
       self.options = options
     }
 
-    /// Aysnchronously reads the next varint
+    /// Asynchronously reads the next varint
     @inlinable
     mutating func nextVarInt() async throws -> UInt64? {
       var messageSize: UInt64 = 0

--- a/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
@@ -26,7 +26,7 @@ public struct BinaryDecodingOptions: Sendable {
   ///
   /// The Protobuf binary format allows unknown fields to be still parsed
   /// so the schema can be expanded without requiring all readers to be updated.
-  /// This works in part by haivng any unknown fields preserved so they can
+  /// This works in part by having any unknown fields preserved so they can
   /// be relayed on without loss. For a while the proto3 syntax definition
   /// called for unknown fields to be dropped, but that lead to problems in
   /// some case. The default is to follow the spec and keep them, but setting

--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -24,7 +24,7 @@ public struct BinaryEncodingOptions: Sendable {
     /// and implement their own serializer rather than relying on this API.
     ///
     /// If deterministic serialization is requested, map entries will be sorted
-    /// by keys in lexicographic order. This is an implementation detail
+    /// by keys in lexicographical order. This is an implementation detail
     /// and subject to change.
     public var useDeterministicOrdering: Bool = false
 

--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -24,7 +24,7 @@ public struct BinaryEncodingOptions: Sendable {
     /// and implement their own serializer rather than relying on this API.
     ///
     /// If deterministic serialization is requested, map entries will be sorted
-    /// by keys in lexographical order. This is an implementation detail
+    /// by keys in lexicographic order. This is an implementation detail
     /// and subject to change.
     public var useDeterministicOrdering: Bool = false
 

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -112,7 +112,7 @@ internal struct JSONEncoder {
         data.append(contentsOf: utf8Bytes)
     }
 
-    /// Begin a new field whose name is given as a `_NameMap.Name`
+    /// Begin a new field whose name is given as a `_NameMap.Name`.
     internal mutating func startField(name: _NameMap.Name) {
         if let s = separator {
             data.append(s)
@@ -135,7 +135,7 @@ internal struct JSONEncoder {
         separator = asciiComma
     }
 
-    /// Begin a new extension field
+    /// Begin a new extension field.
     internal mutating func startExtensionField(name: String) {
         if let s = separator {
             data.append(s)

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -245,7 +245,7 @@ internal struct JSONEncoder {
         }
     }
 
-    /// Write an Enum as an int.
+    /// Write an Enum as an Int.
     internal mutating func putEnumInt(value: Int) {
         appendInt(value: Int64(value))
     }

--- a/Sources/SwiftProtobuf/JSONEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingOptions.swift
@@ -37,7 +37,7 @@ public struct JSONEncodingOptions: Sendable {
   /// and implement their own serializer rather than relying on this API.
   ///
   /// If deterministic serialization is requested, map entries will be sorted
-  /// by keys in lexographical order. This is an implementation detail
+  /// by keys in lexicographical order. This is an implementation detail
   /// and subject to change.
   public var useDeterministicOrdering: Bool = false
 

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -430,7 +430,7 @@ internal struct JSONScanner {
     source.formIndex(after: &index)
   }
 
-  /// Skip whitespace
+  /// Skip whitespace.
   private mutating func skipWhitespace() {
     while hasMoreContent {
       let u = currentByte
@@ -842,7 +842,7 @@ internal struct JSONScanner {
       } else {
         // Couldn't parse because it had a "\" in the string,
         // so parse out the quoted string and then reparse
-        // the result to get a UInt
+        // the result to get a UInt.
         index = start
         let s = try nextQuotedString()
         let raw = s.data(using: String.Encoding.utf8)!
@@ -902,7 +902,7 @@ internal struct JSONScanner {
       } else {
         // Couldn't parse because it had a "\" in the string,
         // so parse out the quoted string and then reparse
-        // the result as an SInt
+        // the result as an SInt.
         index = start
         let s = try nextQuotedString()
         let raw = s.data(using: String.Encoding.utf8)!
@@ -1353,28 +1353,28 @@ internal struct JSONScanner {
     throw JSONDecodingError.failure
   }
 
-  /// Skip "{", throw if that's not the next character
+  /// Skip "{", throw if that's not the next character.
   internal mutating func skipRequiredObjectStart() throws {
     try skipRequiredCharacter(asciiOpenCurlyBracket) // {
     try incrementRecursionDepth()
   }
 
-  /// Skip ",", throw if that's not the next character
+  /// Skip ",", throw if that's not the next character.
   internal mutating func skipRequiredComma() throws {
     try skipRequiredCharacter(asciiComma)
   }
 
-  /// Skip ":", throw if that's not the next character
+  /// Skip ":", throw if that's not the next character.
   internal mutating func skipRequiredColon() throws {
     try skipRequiredCharacter(asciiColon)
   }
 
-  /// Skip "[", throw if that's not the next character
+  /// Skip "[", throw if that's not the next character.
   internal mutating func skipRequiredArrayStart() throws {
     try skipRequiredCharacter(asciiOpenSquareBracket) // [
   }
 
-  /// Helper for skipping optional single-character tokens
+  /// Helper for skipping optional single-character tokens.
   private mutating func skipOptionalCharacter(_ c: UInt8) -> Bool {
     skipWhitespace()
     if hasMoreContent && currentByte == c {

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -1510,7 +1510,7 @@ internal struct JSONScanner {
   //
   // It would be nice to do better, but I don't think it's critical,
   // since there are many reasons that strings (and other tokens for
-  // that matter) may be skippable but not parseable.  For example:
+  // that matter) may be skippable but not parsable.  For example:
   // Old clients that don't know new field types will skip fields
   // they don't know; newer clients may reject the same input due to
   // schema mismatches or other issues.


### PR DESCRIPTION
Add missing periods and correct the typos.