### PR TITLE
Provide some extensions to go with the message set

### DIFF
--- a/FuzzTesting/FuzzAsyncMessageSequence.dict
+++ b/FuzzTesting/FuzzAsyncMessageSequence.dict
@@ -1,5 +1,5 @@
 # To generate the data set.
-#   FuzzTesting/make_FuzzBinary_dict Protos/fuzz_testing.proto
+#   FuzzTesting/make_FuzzBinary_dict Protos/SwiftProtobufTests/fuzz_testing.proto
 # Yes, this is the same as FuzzBinary.dict to help guide the contents of the
 # messages.
 
@@ -304,6 +304,10 @@
 "\xaa\x20"
 "\xc2\x25"
 "\xca\x25"
+"\xca\xdf\xf3\x05"
+"\x52"
+"\x82\x99\xe3\x0f"
+"\xa0\x01"
 "\xc8\x3e"
 "\xd0\x3e"
 "\xd8\x3e"

--- a/FuzzTesting/FuzzBinary.dict
+++ b/FuzzTesting/FuzzBinary.dict
@@ -1,5 +1,5 @@
 # To generate the data set.
-#   FuzzTesting/make_FuzzBinary_dict Protos/fuzz_testing.proto
+#   FuzzTesting/make_FuzzBinary_dict Protos/SwiftProtobufTests/fuzz_testing.proto
 
 # Tags for all the fields
 "\x51"
@@ -302,6 +302,10 @@
 "\xaa\x20"
 "\xc2\x25"
 "\xca\x25"
+"\xca\xdf\xf3\x05"
+"\x52"
+"\x82\x99\xe3\x0f"
+"\xa0\x01"
 "\xc8\x3e"
 "\xd0\x3e"
 "\xd8\x3e"

--- a/FuzzTesting/FuzzBinaryDelimited.dict
+++ b/FuzzTesting/FuzzBinaryDelimited.dict
@@ -1,5 +1,5 @@
 # To generate the data set.
-#   FuzzTesting/make_FuzzBinary_dict Protos/fuzz_testing.proto
+#   FuzzTesting/make_FuzzBinary_dict Protos/SwiftProtobufTests/fuzz_testing.proto
 # Yes, this is the same as FuzzBinary.dict to help guide the contents of the
 # messages.
 
@@ -304,6 +304,10 @@
 "\xaa\x20"
 "\xc2\x25"
 "\xca\x25"
+"\xca\xdf\xf3\x05"
+"\x52"
+"\x82\x99\xe3\x0f"
+"\xa0\x01"
 "\xc8\x3e"
 "\xd0\x3e"
 "\xd8\x3e"

--- a/FuzzTesting/FuzzJSON.dict
+++ b/FuzzTesting/FuzzJSON.dict
@@ -1,14 +1,17 @@
 # To generate the descriptor set.
-#   ../protobuf/src/protoc -o ~/fuzz.bin -I Protos Protos/fuzz_testing.proto
+#   ../protobuf/bazel-bin/protoc -o ~/fuzz.bin -I Protos -I Protos/upstream \
+#       SwiftProtobufTests/fuzz_testing.proto
 
 # Collect the json_names and make them keys:
 #   cat ~/fuzz.bin \
-#     | ../protobuf/src/protoc \
+#     | ../protobuf/bazel-bin/protoc \
 #         --decode=google.protobuf.FileDescriptorSet \
 #         -I ../protobuf/src \
 #         ../protobuf/src/google/protobuf/descriptor.proto \
 #     | sed -n -E 's/ *json_name: "(.*)"/"\\"\1\\":"/p' \
 #     | sort -u
+"\"aString\":"
+"\"anInt32\":"
 "\"groupField\":"
 "\"key\":"
 "\"mapBoolAnEnum\":"
@@ -198,6 +201,7 @@
 "\"mapUint64String\":"
 "\"mapUint64Uint32\":"
 "\"mapUint64Uint64\":"
+"\"messageSetExtension\":"
 "\"oneofBool\":"
 "\"oneofBytes\":"
 "\"oneofDouble\":"

--- a/FuzzTesting/FuzzTextFormat.dict
+++ b/FuzzTesting/FuzzTextFormat.dict
@@ -1,17 +1,20 @@
 # To generate the descriptor set.
-#   ../protobuf/src/protoc -o ~/fuzz.bin -I Protos Protos/fuzz_testing.proto
+#   ../protobuf/bazel-bin/protoc -o ~/fuzz.bin -I Protos -I Protos/upstream \
+#       SwiftProtobufTests/fuzz_testing.proto
 
 # Collect the json_names and make them keys:
 #   cat ~/fuzz.bin \
-#     | ../protobuf/src/protoc \
+#     | ../protobuf/bazel-bin/protoc \
 #         --decode=google.protobuf.FileDescriptorSet \
 #         -I ../protobuf/src \
 #         ../protobuf/src/google/protobuf/descriptor.proto \
 #     | sed -n -E 's/^ *name: "(.*_.*)"/"\1:"/p' \
+#     | grep -v "fuzz_testing.proto" \
 #     | sort -u
 "RepeatedGroup_ext:"
 "SingularGroup_ext:"
-"fuzz_testing.proto:"
+"a_string:"
+"an_int32:"
 "group_field:"
 "map_bool_AnEnum:"
 "map_bool_Message:"
@@ -200,6 +203,7 @@
 "map_uint64_string:"
 "map_uint64_uint32:"
 "map_uint64_uint64:"
+"message_set_extension:"
 "oneof_bool:"
 "oneof_bytes:"
 "oneof_double:"

--- a/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
+++ b/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
@@ -1772,6 +1772,49 @@ public struct SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.Extensibl
   public var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
+/// Two extensions to go with the message_set_wire_format testing.
+public struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var aString: String {
+    get {return _aString ?? String()}
+    set {_aString = newValue}
+  }
+  /// Returns true if `aString` has been explicitly set.
+  public var hasAString: Bool {return self._aString != nil}
+  /// Clears the value of `aString`. Subsequent reads from it will return its default value.
+  public mutating func clearAString() {self._aString = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _aString: String? = nil
+}
+
+public struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var anInt32: Int32 {
+    get {return _anInt32 ?? 0}
+    set {_anInt32 = newValue}
+  }
+  /// Returns true if `anInt32` has been explicitly set.
+  public var hasAnInt32: Bool {return self._anInt32 != nil}
+  /// Clears the value of `anInt32`. Subsequent reads from it will return its default value.
+  public mutating func clearAnInt32() {self._anInt32 = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _anInt32: Int32? = nil
+}
+
 public struct SwiftProtoTesting_Fuzz_SingularGroup_ext: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1822,6 +1865,39 @@ public struct SwiftProtoTesting_Fuzz_RepeatedGroup_ext: Sendable {
 // extension fields. The names are based on the extension field name from the proto
 // declaration. To avoid naming collisions, the names are prefixed with the name of
 // the scope where the extend directive occurs.
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessage {
+
+  public var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`
+  /// has been explicitly set.
+  public var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  public mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+
+  public var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`
+  /// has been explicitly set.
+  public var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  public mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+}
 
 extension SwiftProtoTesting_Fuzz_Message {
 
@@ -2316,7 +2392,9 @@ public let SwiftProtoTesting_Fuzz_FuzzTesting_Extensions: SwiftProtobuf.SimpleEx
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_float_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_double_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_bool_ext,
-  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext
+  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension
 ]
 
 // Extension Objects - The only reason these might be needed is when manually
@@ -2575,6 +2653,24 @@ public let SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext = SwiftPro
   _protobuf_fieldNumber: 1074,
   fieldName: "swift_proto_testing.fuzz.repeated_packed_enum_ext"
 )
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+  public enum Extensions {
+    public static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 1547769,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension1"
+    )
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+  public enum Extensions {
+    public static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 4135312,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension2"
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -5122,6 +5218,78 @@ extension SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.Message, Swif
   public static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessage, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessage) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension1"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    10: .standard(proto: "a_string"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 10: try { try decoder.decodeSingularStringField(value: &self._aString) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._aString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1) -> Bool {
+    if lhs._aString != rhs._aString {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension2"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    20: .standard(proto: "an_int32"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 20: try { try decoder.decodeSingularInt32Field(value: &self._anInt32) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._anInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 20)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2) -> Bool {
+    if lhs._anInt32 != rhs._anInt32 {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }

--- a/Protos/SwiftProtobufTests/fuzz_testing.proto
+++ b/Protos/SwiftProtobufTests/fuzz_testing.proto
@@ -343,6 +343,20 @@ message AMessageSetMessage {
   extensions 4 to max;
 }
 
+// Two extensions to go with the message_set_wire_format testing.
+message AMessageSetMessageExtension1 {
+  extend AMessageSetMessage {
+    optional AMessageSetMessageExtension1 message_set_extension = 1547769;
+  }
+  optional string a_string = 10;
+}
+message AMessageSetMessageExtension2 {
+  extend AMessageSetMessage {
+    optional AMessageSetMessageExtension2 message_set_extension = 4135312;
+  }
+  optional int32 an_int32 = 20;
+}
+
 extend Message {
   // Singular
   optional    int32 singular_int32_ext    = 1001;

--- a/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -1772,6 +1772,49 @@ struct SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.ExtensibleMessag
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
+/// Two extensions to go with the message_set_wire_format testing.
+struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var aString: String {
+    get {return _aString ?? String()}
+    set {_aString = newValue}
+  }
+  /// Returns true if `aString` has been explicitly set.
+  var hasAString: Bool {return self._aString != nil}
+  /// Clears the value of `aString`. Subsequent reads from it will return its default value.
+  mutating func clearAString() {self._aString = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _aString: String? = nil
+}
+
+struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var anInt32: Int32 {
+    get {return _anInt32 ?? 0}
+    set {_anInt32 = newValue}
+  }
+  /// Returns true if `anInt32` has been explicitly set.
+  var hasAnInt32: Bool {return self._anInt32 != nil}
+  /// Clears the value of `anInt32`. Subsequent reads from it will return its default value.
+  mutating func clearAnInt32() {self._anInt32 = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _anInt32: Int32? = nil
+}
+
 struct SwiftProtoTesting_Fuzz_SingularGroup_ext: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1822,6 +1865,39 @@ struct SwiftProtoTesting_Fuzz_RepeatedGroup_ext: Sendable {
 // extension fields. The names are based on the extension field name from the proto
 // declaration. To avoid naming collisions, the names are prefixed with the name of
 // the scope where the extend directive occurs.
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessage {
+
+  var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`
+  /// has been explicitly set.
+  var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+
+  var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`
+  /// has been explicitly set.
+  var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+}
 
 extension SwiftProtoTesting_Fuzz_Message {
 
@@ -2316,7 +2392,9 @@ let SwiftProtoTesting_Fuzz_FuzzTesting_Extensions: SwiftProtobuf.SimpleExtension
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_float_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_double_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_bool_ext,
-  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext
+  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension
 ]
 
 // Extension Objects - The only reason these might be needed is when manually
@@ -2575,6 +2653,24 @@ let SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext = SwiftProtobuf.M
   _protobuf_fieldNumber: 1074,
   fieldName: "swift_proto_testing.fuzz.repeated_packed_enum_ext"
 )
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+  enum Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 1547769,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension1"
+    )
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+  enum Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 4135312,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension2"
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -5122,6 +5218,78 @@ extension SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.Message, Swif
   static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessage, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessage) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension1"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    10: .standard(proto: "a_string"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 10: try { try decoder.decodeSingularStringField(value: &self._aString) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._aString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1) -> Bool {
+    if lhs._aString != rhs._aString {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension2"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    20: .standard(proto: "an_int32"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 20: try { try decoder.decodeSingularInt32Field(value: &self._anInt32) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._anInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 20)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2) -> Bool {
+    if lhs._anInt32 != rhs._anInt32 {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }

--- a/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -1772,6 +1772,49 @@ struct SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.ExtensibleMessag
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
+/// Two extensions to go with the message_set_wire_format testing.
+struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var aString: String {
+    get {return _aString ?? String()}
+    set {_aString = newValue}
+  }
+  /// Returns true if `aString` has been explicitly set.
+  var hasAString: Bool {return self._aString != nil}
+  /// Clears the value of `aString`. Subsequent reads from it will return its default value.
+  mutating func clearAString() {self._aString = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _aString: String? = nil
+}
+
+struct SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var anInt32: Int32 {
+    get {return _anInt32 ?? 0}
+    set {_anInt32 = newValue}
+  }
+  /// Returns true if `anInt32` has been explicitly set.
+  var hasAnInt32: Bool {return self._anInt32 != nil}
+  /// Clears the value of `anInt32`. Subsequent reads from it will return its default value.
+  mutating func clearAnInt32() {self._anInt32 = nil}
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _anInt32: Int32? = nil
+}
+
 struct SwiftProtoTesting_Fuzz_SingularGroup_ext: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1822,6 +1865,39 @@ struct SwiftProtoTesting_Fuzz_RepeatedGroup_ext: Sendable {
 // extension fields. The names are based on the extension field name from the proto
 // declaration. To avoid naming collisions, the names are prefixed with the name of
 // the scope where the extend directive occurs.
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessage {
+
+  var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`
+  /// has been explicitly set.
+  var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension1_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension)
+  }
+
+  var SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+    get {return getExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension) ?? SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2()}
+    set {setExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension, value: newValue)}
+  }
+  /// Returns true if extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`
+  /// has been explicitly set.
+  var hasSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension: Bool {
+    return hasExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+  /// Clears the value of extension `SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftProtoTesting_Fuzz_AMessageSetMessageExtension2_messageSetExtension() {
+    clearExtensionValue(ext: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension)
+  }
+}
 
 extension SwiftProtoTesting_Fuzz_Message {
 
@@ -2316,7 +2392,9 @@ let SwiftProtoTesting_Fuzz_FuzzTesting_Extensions: SwiftProtobuf.SimpleExtension
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_float_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_double_ext,
   SwiftProtoTesting_Fuzz_Extensions_repeated_packed_bool_ext,
-  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext
+  SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1.Extensions.message_set_extension,
+  SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2.Extensions.message_set_extension
 ]
 
 // Extension Objects - The only reason these might be needed is when manually
@@ -2575,6 +2653,24 @@ let SwiftProtoTesting_Fuzz_Extensions_repeated_packed_enum_ext = SwiftProtobuf.M
   _protobuf_fieldNumber: 1074,
   fieldName: "swift_proto_testing.fuzz.repeated_packed_enum_ext"
 )
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1 {
+  enum Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 1547769,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension1"
+    )
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2 {
+  enum Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalMessageExtensionField<SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2>, SwiftProtoTesting_Fuzz_AMessageSetMessage>(
+      _protobuf_fieldNumber: 4135312,
+      fieldName: "swift_proto_testing.fuzz.AMessageSetMessageExtension2"
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -5122,6 +5218,78 @@ extension SwiftProtoTesting_Fuzz_AMessageSetMessage: SwiftProtobuf.Message, Swif
   static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessage, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessage) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     if lhs._protobuf_extensionFieldValues != rhs._protobuf_extensionFieldValues {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension1"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    10: .standard(proto: "a_string"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 10: try { try decoder.decodeSingularStringField(value: &self._aString) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._aString {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 10)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension1) -> Bool {
+    if lhs._aString != rhs._aString {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AMessageSetMessageExtension2"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    20: .standard(proto: "an_int32"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 20: try { try decoder.decodeSingularInt32Field(value: &self._anInt32) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._anInt32 {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 20)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2, rhs: SwiftProtoTesting_Fuzz_AMessageSetMessageExtension2) -> Bool {
+    if lhs._anInt32 != rhs._anInt32 {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }


### PR DESCRIPTION
Hopefully this will do a allow the fuzz testing to occational place well formed things inside the message field that uses the message_set wire format.
