### PR TITLE
Rename CI checkout directory from main to swift-protobuf and update tools version in PluginExamples Package.swift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        path: main
+        path: swift-protobuf
     - name: Update and install dependencies
       # dependencies from https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
       # this step is run before get-sha because we need curl and jq for get-sha
@@ -62,10 +62,10 @@ jobs:
           ;;
         esac
     - name: Build
-      working-directory: main
+      working-directory: swift-protobuf
       run: make build ${{ matrix.swift.hook }}
     - name: Test runtime
-      working-directory: main
+      working-directory: swift-protobuf
       run: make test-runtime ${{ matrix.swift.hook }}
     - name: Cache protobuf
       id: cache-protobuf
@@ -97,16 +97,16 @@ jobs:
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -j "${NUM_CPUS}" protoc conformance_test_runner
     - name: Test plugin
-      working-directory: main
+      working-directory: swift-protobuf
       run: make test-plugin PROTOC=../protobuf/cmake_build/protoc
     - name: Test conformance
-      working-directory: main
+      working-directory: swift-protobuf
       run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner
     - name: Test SPM plugin
-      working-directory: main
+      working-directory: swift-protobuf
       run: make test-spm-plugin PROTOC=../protobuf/cmake_build/protoc
     - name: Compilation Tests
-      working-directory: main
+      working-directory: swift-protobuf
       run: make compile-tests PROTOC=../protobuf/cmake_build/protoc
 
   api-breakage:

--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -14,12 +14,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        path: main
+        path: swift-protobuf
     - name: Checkout protobufbuffers/protobuf
       uses: actions/checkout@v4
       with:
         repository: protocolbuffers/protobuf
         path: protobuf
     - name: Check Upstream Proto Files
-      working-directory: main
+      working-directory: swift-protobuf
       run: make check-proto-files

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        path: main
+        path: swift-protobuf
     - name: Update and install dependencies
       # dependencies from https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
       # this step is run before get-sha because we need curl and jq for get-sha
@@ -71,7 +71,7 @@ jobs:
       with:
         path: protobuf
         # NOTE: for refs that can float like 'main' the cache might be out of date!
-        key: ${{ runner.os }}-${{ matrix.swift}}-protobuf-${{ steps.get-sha.outputs.sha }}
+        key: ${{ runner.os }}-${{ matrix.swift }}-protobuf-${{ steps.get-sha.outputs.sha }}
     - name: Checkout protobuf repo
       if: steps.cache-protobuf.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
@@ -95,5 +95,5 @@ jobs:
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
         make -j "${NUM_CPUS}" protoc conformance_test_runner
     - name: Test conformance
-      working-directory: main
+      working-directory: swift-protobuf
       run: make test-conformance CONFORMANCE_TEST_RUNNER=../protobuf/cmake_build/conformance_test_runner

--- a/PluginExamples/Package.swift
+++ b/PluginExamples/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.8
 
 import PackageDescription
 
 let package = Package(
     name: "PluginExamples",
     dependencies: [
-        .package(name: "swift-protobuf", path: "../")
+        .package(path: "../")
     ],
     targets: [
         .testTarget(


### PR DESCRIPTION
SPM in 5.8 has trouble finding products when specifying a package name.
If the `name` argument is removed, it will default the package name to match the directory's name. In the checkout action, we check out the repo in a `main` directory, but we should rename it to `swift-protobuf` so it matches the Package's name and the package resolution works properly.