### PR TITLE
Fix Foundation import's access level in generated code

### DIFF
--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -96,7 +96,7 @@ class FileGenerator {
           }
         }
 
-        p.print("\(comments)import Foundation")
+        p.print("\(comments)\(generatorOptions.importDirective.snippet) Foundation")
 
         if fileDescriptor.isBundledProto {
             p.print("// 'import \(namer.swiftProtobufModuleName)' suppressed, this proto file is meant to be bundled in the runtime.")


### PR DESCRIPTION
https://github.com/apple/swift-protobuf/pull/1683 added support for access level modifiers on imports in the generated code.

`Foundation` (which is needed because `Data` is used extensively in generated protos) is imported by manually writing to the file instead of using the "compute imports" logic we use to deal with all other imports. This is because other imports are all imports coming from other generated proto files, whereas Foundation is "pure Swift" dependency.

We forgot to add the access level modifier to this `Foundation` import.
This causes issues when enabling the `InternalImportsByDefault` flag on modules that use generated protos (even when `swift-protobuf`'s `UseAccessLevelOnImports` option is enabled), because `Foundation` will be imported as `internal`, while we expose public properties of type `Data` in the generated code.

This PR adds the right `import Foundation` statement based on the import directive.