### PR TITLE
Change default of useAccessLevelOnImports to always be false

### DIFF
--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -79,11 +79,7 @@ class GeneratorOptions {
     var visibility: Visibility = .internal
     var swiftProtobufModuleName: String? = nil
     var implementationOnlyImports: Bool = false
-#if swift(>=6.0)
-    var useAccessLevelOnImports = true
-#else
     var useAccessLevelOnImports = false
-#endif
     var experimentalStripNonfunctionalCodegen: Bool = false
 
     for pair in parameter.parsedPairs {


### PR DESCRIPTION
After some discussion on `grpc-swift` after updating to the latest protobuf version and using the new `UseAccessLevelOnImports` option, we came to the conclusion that it's safer (and more consistent) to always default to `false`, regardless of the language version being used on plugin compilation.

See https://github.com/grpc/grpc-swift/pull/2047 for more information.

This PR removes the compiler flag conditionals and always defaults the plugin option to false. It's now strictly an opt-in-only feature to include access level modifiers on imports on generated code.