### PR TITLE
Add a blame ignore for the formatting.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore the commit where all the sources were reformatted with no other changes.
+ac8da77c937f3c98c3959f72e76184b6b577cf38


### PR DESCRIPTION
This should have github ignore things:
  https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

Locally developers still might need to do:
  git config blame.ignoreRevsFile .git-blame-ignore-revs