### PR TITLE
Silence a warning when using Xcode 16/Swift6 toolchain.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
@@ -17,8 +17,16 @@ import SwiftProtobuf
 
 /// The spec for editions calls out them being ordered and comparable.
 /// https://github.com/protocolbuffers/protobuf/blob/main/docs/design/editions/edition-naming.md
+#if compiler(>=6)
+extension Google_Protobuf_Edition: @retroactive Comparable {
+    public static func < (lhs: Google_Protobuf_Edition, rhs: Google_Protobuf_Edition) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+#else
 extension Google_Protobuf_Edition: Comparable {
     public static func < (lhs: Google_Protobuf_Edition, rhs: Google_Protobuf_Edition) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 }
+#endif


### PR DESCRIPTION
Without a Package.swift change, the new toolchain is issuing a warning about needing to flag the `Comparable` conformance as `@retroactive`, so do that.