### PR TITLE
Add Swift 6 toolchains to CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         # seems better. This should also ensure protobuf caching changes with
         # each new image incase system in the Swift image are changed/updated.
         swift:
+        - version: 6.0.0-noble
+          hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
         - version: 5.10.1-noble
           # No "hook", see https://github.com/apple/swift-protobuf/issues/1560 for the
           # current issue with using -warnings-as-errors on linux.

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -35,7 +35,7 @@ jobs:
         # seems better. This should also ensure protobuf caching changes with
         # each new image incase system in the Swift image are changed/updated.
         swift:
-        - 5.10.1-noble
+        - 6.0.0-noble
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"


### PR DESCRIPTION
This does not update the Package.swift to also support a full Swift 6 mode, that can be done in the future. This just ensure things build in the current setup with the new toolchain as expected.

This does not drop 5.8 yet, we'd said policy wise we were going to only support three at a time, not sure if nio has done it yet, maybe do it with them also?