### PR TITLE
Drop docc dep.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,6 @@ let package = Package(
             targets: ["SwiftProtobufPlugin"]
         ),
     ],
-    dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0")
-    ],
     targets: [
         .target(
             name: "SwiftProtobuf",


### PR DESCRIPTION
This was added for things like the Swift Package Index, but isn't needed there any more. And swift-nio also dropped this recently (https://github.com/apple/swift-nio/pull/28510).