### PR TITLE
Some swift-format lint fixes

### DIFF
--- a/Sources/SwiftProtobuf/SimpleExtensionMap.swift
+++ b/Sources/SwiftProtobuf/SimpleExtensionMap.swift
@@ -60,7 +60,7 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral {
         let fieldNumber = newValue.fieldNumber
         if let l = fields[fieldNumber] {
             let messageType = newValue.messageType
-            var newL = l.filter { return $0.messageType != messageType }
+            var newL = l.filter { $0.messageType != messageType }
             newL.append(newValue)
             fields[fieldNumber] = newL
         } else {

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -380,7 +380,7 @@ public final class FileDescriptor {
         // The compiler ensures there aren't cycles between a file and dependencies, so
         // this doesn't run the risk of creating any retain cycles that would force these
         // to have to be weak.
-        let dependencies = proto.dependency.map { return registry.fileDescriptor(named: $0)! }
+        let dependencies = proto.dependency.map { registry.fileDescriptor(named: $0)! }
         self.dependencies = dependencies
         self.publicDependencies = proto.publicDependency.map { dependencies[Int($0)] }
         self.weakDependencies = proto.weakDependency.map { dependencies[Int($0)] }
@@ -418,7 +418,7 @@ public final class FileDescriptor {
     private lazy var locationMap: [IndexPath: Google_Protobuf_SourceCodeInfo.Location] = {
         var result: [IndexPath: Google_Protobuf_SourceCodeInfo.Location] = [:]
         for loc in sourceCodeInfo.location {
-            let intList = loc.path.map { return Int($0) }
+            let intList = loc.path.map { Int($0) }
             result[IndexPath(indexes: intList)] = loc
         }
         return result
@@ -569,7 +569,7 @@ public final class Descriptor {
     /// leading subset of `oneofs` (or the same if there are no synthetic entries).
     public private(set) lazy var realOneofs: [OneofDescriptor] = {
         // Lazy because `isSynthetic` can't be called until after `bind()`.
-        return self.oneofs.filter { !$0._isSynthetic }
+        self.oneofs.filter { !$0._isSynthetic }
     }()
     /// The extension field defintions under this message.
     public let extensions: [FieldDescriptor]
@@ -590,7 +590,7 @@ public final class Descriptor {
     /// contiguious (i.e. - [(21,30),(10,20)] -> [(10,30)])
     @available(*, deprecated, message: "Please open a GitHub issue if you think functionality is missing.")
     public private(set) lazy var normalizedExtensionRanges: [Google_Protobuf_DescriptorProto.ExtensionRange] = {
-        var ordered = self.extensionRanges.sorted(by: { return $0.start < $1.start })
+        var ordered = self.extensionRanges.sorted(by: { $0.start < $1.start })
         if ordered.count > 1 {
             for i in (0..<(ordered.count - 1)).reversed() {
                 if ordered[i].end == ordered[i + 1].start {
@@ -688,7 +688,7 @@ public final class Descriptor {
         // TODO: This can skip the synthetic oneofs as no features can be set on
         // them to inherrit things.
         let oneofFeatures = proto.oneofDecl.map {
-            return featureResolver.resolve($0.options, resolvedParent: resolvedFeatures)
+            featureResolver.resolve($0.options, resolvedParent: resolvedFeatures)
         }
 
         self.messageExtensionRanges = proto.extensionRange.enumerated().map {

--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -394,10 +394,10 @@ public final class FileDescriptor {
 
         // descriptor.proto documents the files will be in deps order. That means we
         // any external reference will have been in the previous files in the set.
-        self.enums.forEach { $0.bind(file: self, registry: registry, containingType: nil) }
-        self.messages.forEach { $0.bind(file: self, registry: registry, containingType: nil) }
-        self.extensions.forEach { $0.bind(file: self, registry: registry, containingType: nil) }
-        self.services.forEach { $0.bind(file: self, registry: registry) }
+        for e in enums { e.bind(file: self, registry: registry, containingType: nil) }
+        for m in messages { m.bind(file: self, registry: registry, containingType: nil) }
+        for e in extensions { e.bind(file: self, registry: registry, containingType: nil) }
+        for s in services { s.bind(file: self, registry: registry) }
     }
 
     /// Fetch the source information for a give path. For more details on the paths
@@ -759,12 +759,12 @@ public final class Descriptor {
     fileprivate func bind(file: FileDescriptor, registry: Registry, containingType: Descriptor?) {
         _file = file
         self.containingType = containingType
-        messageExtensionRanges.forEach { $0.bind(containingType: self, registry: registry) }
-        enums.forEach { $0.bind(file: file, registry: registry, containingType: self) }
-        messages.forEach { $0.bind(file: file, registry: registry, containingType: self) }
-        fields.forEach { $0.bind(file: file, registry: registry, containingType: self) }
-        oneofs.forEach { $0.bind(registry: registry, containingType: self) }
-        extensions.forEach { $0.bind(file: file, registry: registry, containingType: self) }
+        for e in messageExtensionRanges { e.bind(containingType: self, registry: registry) }
+        for e in enums { e.bind(file: file, registry: registry, containingType: self) }
+        for m in messages { m.bind(file: file, registry: registry, containingType: self) }
+        for f in fields { f.bind(file: file, registry: registry, containingType: self) }
+        for o in oneofs { o.bind(registry: registry, containingType: self) }
+        for e in extensions { e.bind(file: file, registry: registry, containingType: self) }
 
         // Synthetic oneofs come after normal oneofs. The C++ Descriptor enforces this, only
         // here as a secondary validation because other code can rely on it.
@@ -878,7 +878,7 @@ public final class EnumDescriptor {
         // Done initializing, register ourselves.
         registry.register(enum: self)
 
-        values.forEach { $0.bind(enumType: self) }
+        for v in values { v.bind(enumType: self) }
     }
 
     fileprivate func bind(file: FileDescriptor, registry: Registry, containingType: Descriptor?) {
@@ -1461,7 +1461,7 @@ public final class ServiceDescriptor {
 
     fileprivate func bind(file: FileDescriptor, registry: Registry) {
         _file = file
-        methods.forEach { $0.bind(service: self, registry: registry) }
+        for m in methods { m.bind(service: self, registry: registry) }
     }
 }
 

--- a/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/SwiftProtobufPluginLibrary/SwiftProtobufNamer.swift
@@ -131,7 +131,7 @@ public final class SwiftProtobufNamer {
             // the names to help make the different Swift versions clear
             // which they are.
             let firstValue = enumValues.first!.number
-            let hasMultipleValues = enumValues.contains(where: { return $0.number != firstValue })
+            let hasMultipleValues = enumValues.contains(where: { $0.number != firstValue })
 
             guard hasMultipleValues else {
                 // Was the first case, all one value, just aliases that mapped

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -252,9 +252,9 @@ extension Descriptor {
     /// `extensionRanges` no longer can apply as the things have been merged.
     var _normalizedExtensionRanges: [Range<Int32>] {
         var ordered: [Range<Int32>] = self.messageExtensionRanges.sorted(by: {
-            return $0.start < $1.start
+            $0.start < $1.start
         }).map {
-            return $0.start..<$0.end
+            $0.start..<$0.end
         }
         if ordered.count > 1 {
             for i in (0..<(ordered.count - 1)).reversed() {

--- a/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
@@ -182,7 +182,7 @@ class ExtensionSetGenerator {
         }.map {
             // Now strip off the original index to just get the list of ExtensionGenerators
             // again.
-            return $0.element
+            $0.element
         }
 
         // Loop through the group list and each time a new containing type is hit,

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -162,11 +162,11 @@ class FileGenerator {
         extensionSet.add(extensionFields: fileDescriptor.extensions)
 
         let enums = fileDescriptor.enums.map {
-            return EnumGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer)
+            EnumGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer)
         }
 
         let messages = fileDescriptor.messages.map {
-            return MessageGenerator(
+            MessageGenerator(
                 descriptor: $0,
                 generatorOptions: generatorOptions,
                 namer: namer,

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -135,9 +135,7 @@ class MessageGenerator {
         // Messages that have a storage class will always need @unchecked.
         let needsUnchecked =
             storage != nil
-            || descriptor.fields.contains {
-                return $0.type == .bytes
-            }
+            || descriptor.fields.contains { $0.type == .bytes }
         conformances.append(needsUnchecked ? "@unchecked Sendable" : "Sendable")
 
         p.print(

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -215,9 +215,7 @@ class OneofGenerator {
         // Data isn't marked as Sendable on linux until Swift 5.9, so until
         // then all oneof enums with Data fields need to be manually marked as
         // @unchecked.
-        let hasBytesField = oneofDescriptor.fields.contains {
-            return $0.type == .bytes
-        }
+        let hasBytesField = oneofDescriptor.fields.contains { $0.type == .bytes }
         let sendableConformance = hasBytesField ? "@unchecked Sendable" : "Sendable"
 
         // Repeat the comment from the oneof to provide some context

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftLanguage.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_SwiftLanguage.swift
@@ -27,7 +27,7 @@ final class Test_SwiftLanguage: XCTestCase {
                 "Should be valid: \(identifier)"
             )
         }
-        let quotedCases = cases.map { return "`\($0)`" }
+        let quotedCases = cases.map { "`\($0)`" }
         for identifier in quotedCases {
             XCTAssertFalse(
                 isValidSwiftIdentifier(identifier, allowQuoted: false),
@@ -56,7 +56,7 @@ final class Test_SwiftLanguage: XCTestCase {
                 "Should NOT be valid: \(identifier)"
             )
         }
-        let quotedCases = cases.map { return "`\($0)`" }
+        let quotedCases = cases.map { "`\($0)`" }
         for identifier in cases + quotedCases {
             XCTAssertFalse(
                 isValidSwiftIdentifier(identifier, allowQuoted: false),


### PR DESCRIPTION
Seems like swift-format failed to fix some `return` cases, but also fix some things that were lint only without formatting support.
