### PR TITLE
[docs] Fix typo for Xcode that is consistent with others at `PLUGIN.md`.

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -230,5 +230,5 @@ If you are using Xcode, then you should:
 
 * Add the Swift source files generated from your protos directly to your
   project.
-* Add this SwiftPM package as dependency of your xcode project:
+* Add this SwiftPM package as dependency of your Xcode project:
   [Apple Docs](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app)


### PR DESCRIPTION
The correct wording for the `Xcode` that is consistent with others at `PLUGIN.md`.