### PR TITLE
Allow block comments for the table in the code.

### DIFF
--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -85,6 +85,7 @@ private func fromHexDigit(_ c: UnicodeScalar) -> UInt32? {
 // known as "base64url" or the "URL-safe alphabet".
 // Note that both "-" and "+" decode to 62 and "/" and "_" both
 // decode as 63.
+// swift-format-ignore: NoBlockComments
 let base64Values: [Int] = [
     /* 0x00 */ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     /* 0x10 */ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,


### PR DESCRIPTION
Switching to trailing comments doesn't read as well, and swift-format doesn't actually align all the line trailing comments, so the one line that is shorted would get it's comment indented compared to the rest so it doesn't read as well.