### PR TITLE
Resolve some more swift-format lint issues.

### DIFF
--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor_FeatureResolution.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor_FeatureResolution.swift
@@ -611,7 +611,10 @@ final class Test_Descriptor_FeatureResolution: XCTestCase {
         XCTAssertEqual(oneofFieldFeatures.SwiftFeatureTest_test.feature2, .value3)  // Message override
         XCTAssertEqual(oneofFieldFeatures.SwiftFeatureTest_test.feature3, .value4)  // Oneof override
         XCTAssertEqual(oneofFieldFeatures.SwiftFeatureTest_test.feature4, .value5)  // "oneof_field" Field override
-        XCTAssertEqual(oneofFieldFeatures.SwiftFeatureTest_test.feature5, .value1)  // default ("not_oneof_field" Field override)
+        XCTAssertEqual(
+            oneofFieldFeatures.SwiftFeatureTest_test.feature5,  // default ("not_oneof_field" Field override)
+            .value1
+        )
         let field = context.file.messages.first!.fields[1]
         XCTAssertEqual(field.name, "not_oneof_field")
         let fieldFeatures = field.features
@@ -619,7 +622,10 @@ final class Test_Descriptor_FeatureResolution: XCTestCase {
         XCTAssertEqual(fieldFeatures.SwiftFeatureTest_test.feature1, .value2)  // File override
         XCTAssertEqual(fieldFeatures.SwiftFeatureTest_test.feature2, .value3)  // Message override
         XCTAssertEqual(fieldFeatures.SwiftFeatureTest_test.feature3, .value1)  // default (Oneof override)
-        XCTAssertEqual(fieldFeatures.SwiftFeatureTest_test.feature4, .value1)  // default ("oneof_field" Field override)
+        XCTAssertEqual(
+            fieldFeatures.SwiftFeatureTest_test.feature4,  // default ("oneof_field" Field override)
+            .value1
+        )
         XCTAssertEqual(fieldFeatures.SwiftFeatureTest_test.feature5, .value6)  // "not_oneof_field" Field override
     }
 

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -1196,10 +1196,16 @@ final class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodesAsUnknownFields([152, 1, 0])  // Wrong wire type (varint), valid as an unknown field
         assertDecodeFails([153, 1])  // Wire type 1
         assertDecodeFails([153, 1, 0])
-        assertDecodesAsUnknownFields([153, 1, 0, 0, 0, 0, 0, 0, 0, 0])  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            153, 1,  // Wrong wire type (fixed64), valid as an unknown field
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ])
         assertDecodeFails([155, 1])  // Wire type 3
         assertDecodeFails([155, 1, 0])
-        assertDecodesAsUnknownFields([155, 1, 156, 1])  // Wrong wire type (start group, end group), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            155, 1,  // Wrong wire type (start group, end group), valid as an unknown field
+            156, 1,
+        ])
         assertDecodeFails([156, 1])  // Wire type 4
         assertDecodeFails([156, 1, 0])
         assertDecodeFails([157, 1])  // Wire type 5
@@ -2600,7 +2606,10 @@ final class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertMergesAsUnknownFields([136, 7, 1], inTo: initialMsg) {
             $0.oneofUint32 == 123  // Shouldn't have gotten cleared.
         }
-        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1]) {  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            137, 7,  // Wrong wire type (fixed64), valid as an unknown field
+            1, 1, 1, 1, 1, 1, 1, 1,
+        ]) {
             $0.oneofField == nil  // oneof doesn't get set.
         }
         assertMergesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1], inTo: initialMsg) {
@@ -2790,7 +2799,8 @@ final class Test_AllTypes: XCTestCase, PBTestHelpers {
             ([197, 12, 30, 0, 0, 0], "200: 0x0000001E"),  // fixed32.
 
             ([192, 12, 129, 1], "200: 129"),  //  varint of 129 (two bytes on wire).
-            ([195, 12, 11, 8, 1, 12, 196, 12], "200 {\n  1 {\n    1: 1\n  }\n}"),  // StartGroup, Field 1: StartGroup, Field 1: varint of 1, EndGroup, EndGroup.
+            // StartGroup, Field 1: StartGroup, Field 1: varint of 1, EndGroup, EndGroup.
+            ([195, 12, 11, 8, 1, 12, 196, 12], "200 {\n  1 {\n    1: 1\n  }\n}"),
         ]
 
         // Fields at the top level of the message.
@@ -2862,7 +2872,8 @@ final class Test_AllTypes: XCTestCase, PBTestHelpers {
 
             [195, 12, 11],  // StartGroup, Field 1: StartGroup.
             [195, 12, 11, 8, 1, 12],  // StartGroup, Field 1: StartGroup, Field 1: varint of 1, EndGroup.
-            [195, 12, 11, 8, 1, 196, 12],  // StartGroup, Field 1: StartGroup, Field 1: varint of 1, EndGroup (but wrong group).
+            // StartGroup, Field 1: StartGroup, Field 1: varint of 1, EndGroup (but wrong group).
+            [195, 12, 11, 8, 1, 196, 12],
         ]
 
         // Fields at the top level of the message.

--- a/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
@@ -762,10 +762,16 @@ final class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodesAsUnknownFields([152, 1, 0])  // Wrong wire type (varint), valid as an unknown field
         assertDecodeFails([153, 1])  // Wire type 1
         assertDecodeFails([153, 1, 0])
-        assertDecodesAsUnknownFields([153, 1, 0, 0, 0, 0, 0, 0, 0, 0])  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            153, 1,  // Wrong wire type (fixed64), valid as an unknown field
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ])
         assertDecodeFails([155, 1])  // Wire type 3
         assertDecodeFails([155, 1, 0])
-        assertDecodesAsUnknownFields([155, 1, 156, 1])  // Wrong wire type (start group, end group), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            155, 1,  // Wrong wire type (start group, end group), valid as an unknown field
+            156, 1,
+        ])
         assertDecodeFails([156, 1])  // Wire type 4
         assertDecodeFails([156, 1, 0])
         assertDecodeFails([157, 1])  // Wire type 5
@@ -1452,7 +1458,10 @@ final class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodesAsUnknownFields([136, 7, 1]) {  // Wrong wire type (varint), valid as an unknown field
             $0.oneofField == nil  // oneof doesn't get set.
         }
-        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1]) {  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            137, 7,  // Wrong wire type (fixed64), valid as an unknown field
+            1, 1, 1, 1, 1, 1, 1, 1,
+        ]) {
             $0.oneofField == nil  // oneof doesn't get set.
         }
         assertDecodeFails([139, 7])  // Wire type 3

--- a/Tests/SwiftProtobufTests/Test_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_Extensions.swift
@@ -104,7 +104,10 @@ final class Test_Extensions: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds([8, 99]) { $0.SwiftProtoTesting_optionalInt32Extension == 99 }
         assertDecodeFails([9])
         assertDecodeFails([9, 0])
-        assertDecodesAsUnknownFields([9, 0, 0, 0, 0, 0, 0, 0, 0])  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([
+            9,  // Wrong wire type (fixed64), valid as an unknown field
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ])
         assertDecodeFails([10])
         assertDecodesAsUnknownFields([10, 0])  // Wrong wire type (length delimited), valid as an unknown field
         assertDecodeFails([11])

--- a/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormatDecodingOptions.swift
@@ -59,7 +59,7 @@ final class Test_TextFormatDecodingOptions: XCTestCase {
         var options = TextFormatDecodingOptions()
         options.ignoreUnknownFields = true
 
-        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInputField, options: options)  // Shouldn't fail
+        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInputField, options: options)
         XCTAssertEqual(msg.textFormatString(), "optional_int32: 2\n")
 
         do {
@@ -84,7 +84,7 @@ final class Test_TextFormatDecodingOptions: XCTestCase {
             // This is what should have happened.
         }
 
-        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInputExtField, options: options)  // Shouldn't fail
+        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInputExtField, options: options)
         XCTAssertEqual(msg.textFormatString(), "optional_int32: 2\n")
     }
 
@@ -95,7 +95,7 @@ final class Test_TextFormatDecodingOptions: XCTestCase {
         options.ignoreUnknownFields = true
         options.ignoreUnknownExtensionFields = true
 
-        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInput, options: options)  // Shouldn't fail
+        let msg = try SwiftProtoTesting_TestAllTypes(textFormatString: textInput, options: options)
         XCTAssertEqual(msg.textFormatString(), "optional_int32: 2\n")
     }
 


### PR DESCRIPTION
- Remove some comments. They don't add anything and we weren't consistent on making them in all places.
- Reflow some lines to avoid end of line comments going over the line limit.