### PR TITLE
Strip file-level comment changes during editions codegen tests

### DIFF
--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -90,10 +90,14 @@ class FileGenerator {
         let editionPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.edition)
         let syntaxPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax)
         var commentLocation: Google_Protobuf_SourceCodeInfo.Location? = nil
-        if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {
-            commentLocation = location
-        } else if let location = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
-            commentLocation = location
+        if !self.generatorOptions.experimentalStripNonfunctionalCodegen {
+            // Comments are inherently non-functional, and may change subtly on
+            // transformations.
+            if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {
+                commentLocation = location
+            } else if let location = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
+                commentLocation = location
+            }
         }
         if let commentLocation = commentLocation {
             let comments = commentLocation.asSourceComment(

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -90,7 +90,7 @@ class FileGenerator {
         let editionPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.edition)
         let syntaxPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax)
         var commentLocation: Google_Protobuf_SourceCodeInfo.Location? = nil
-        if !self.generatorOptions.experimentalStripNonfunctionalCodegen {
+        if self.generatorOptions.experimentalStripNonfunctionalCodegen {
             // Comments are inherently non-functional, and may change subtly on
             // transformations.
         } else if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -93,11 +93,10 @@ class FileGenerator {
         if !self.generatorOptions.experimentalStripNonfunctionalCodegen {
             // Comments are inherently non-functional, and may change subtly on
             // transformations.
-            if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {
-                commentLocation = location
-            } else if let location = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
-                commentLocation = location
-            }
+        } else if let location = fileDescriptor.sourceCodeInfoLocation(path: editionPath) {
+            commentLocation = location
+        } else if let location = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
+            commentLocation = location
         }
         if let commentLocation = commentLocation {
             let comments = commentLocation.asSourceComment(


### PR DESCRIPTION
This was missed by some earlier changes, but follows the same pattern.  During some upgrades from proto2/proto3, comments may get reformatted and result in unexpected codegen diffs from non-functional code