### PR TITLE
Build out the validation of google.protobuf.Any JSON support.

### DIFF
--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -24,7 +24,7 @@ extension Message {
     /// - Returns: A string containing the JSON serialization of the message.
     /// - Parameters:
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public func jsonString(
         options: JSONEncodingOptions = JSONEncodingOptions()
     ) throws -> String {
@@ -43,7 +43,7 @@ extension Message {
     /// - Returns: A `SwiftProtobufContiguousBytes` containing the JSON serialization of the message.
     /// - Parameters:
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public func jsonUTF8Bytes<Bytes: SwiftProtobufContiguousBytes>(
         options: JSONEncodingOptions = JSONEncodingOptions()
     ) throws -> Bytes {

--- a/Sources/SwiftProtobuf/Message+JSONAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions_Data.swift
@@ -54,7 +54,7 @@ extension Message {
     /// - Returns: A Data containing the JSON serialization of the message.
     /// - Parameters:
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public func jsonUTF8Data(
         options: JSONEncodingOptions = JSONEncodingOptions()
     ) throws -> Data {

--- a/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
@@ -25,7 +25,7 @@ extension Message {
     /// - Parameters:
     ///   - collection: The list of messages to encode.
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public static func jsonString<C: Collection>(
         from collection: C,
         options: JSONEncodingOptions = JSONEncodingOptions()
@@ -43,7 +43,7 @@ extension Message {
     /// - Parameters:
     ///   - collection: The list of messages to encode.
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public static func jsonUTF8Bytes<C: Collection, Bytes: SwiftProtobufContiguousBytes>(
         from collection: C,
         options: JSONEncodingOptions = JSONEncodingOptions()

--- a/Sources/SwiftProtobuf/Message+JSONArrayAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+JSONArrayAdditions_Data.swift
@@ -65,7 +65,7 @@ extension Message {
     /// - Parameters:
     ///   - collection: The list of messages to encode.
     ///   - options: The JSONEncodingOptions to use.
-    /// - Throws: ``JSONEncodingError`` if encoding fails.
+    /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public static func jsonUTF8Data<C: Collection>(
         from collection: C,
         options: JSONEncodingOptions = JSONEncodingOptions()

--- a/Sources/SwiftProtobuf/SwiftProtobufError.swift
+++ b/Sources/SwiftProtobuf/SwiftProtobufError.swift
@@ -92,6 +92,7 @@ extension SwiftProtobufError {
             case binaryDecodingError
             case binaryStreamDecodingError
             case jsonDecodingError
+            case jsonEncodingError
 
             var description: String {
                 switch self {
@@ -101,6 +102,8 @@ extension SwiftProtobufError {
                     return "Stream decoding error"
                 case .jsonDecodingError:
                     return "JSON decoding error"
+                case .jsonEncodingError:
+                    return "JSON encoding error"
                 }
             }
         }
@@ -131,6 +134,10 @@ extension SwiftProtobufError {
             Self(.jsonDecodingError)
         }
 
+        /// Errors arising from JSON encoding of messages.
+        public static var jsonEncodingError: Self {
+            Self(.jsonEncodingError)
+        }
     }
 
     /// A location within source code.
@@ -264,6 +271,48 @@ extension SwiftProtobufError {
                 location: SourceLocation(function: function, file: file, line: line)
             )
         }
+
+        /// While decoding a `google.protobuf.Any` no `@type` field but the message had other fields.
+        public static func emptyAnyTypeURL(
+            function: String = #function,
+            file: String = #fileID,
+            line: Int = #line
+        ) -> SwiftProtobufError {
+            SwiftProtobufError(
+                code: .jsonDecodingError,
+                message: "google.protobuf.Any '@type' was must be present if if the object is not empty.",
+                location: SourceLocation(function: function, file: file, line: line)
+            )
+        }
     }
 
+    /// Errors arising from JSON encoding of messages.
+    public enum JSONEncoding {
+        /// While encoding a `google.protobuf.Any` encountered a malformed `type_url` field.
+        public static func invalidAnyTypeURL(
+            type_url: String,
+            function: String = #function,
+            file: String = #fileID,
+            line: Int = #line
+        ) -> SwiftProtobufError {
+            SwiftProtobufError(
+                code: .jsonEncodingError,
+                message: "google.protobuf.Any 'type_url' was invalid: \(type_url).",
+                location: SourceLocation(function: function, file: file, line: line)
+            )
+        }
+
+        /// While encoding a `google.protobuf.Any` encountered an empty `type_url` field.
+        public static func emptyAnyTypeURL(
+            function: String = #function,
+            file: String = #fileID,
+            line: Int = #line
+        ) -> SwiftProtobufError {
+            SwiftProtobufError(
+                code: .jsonEncodingError,
+                message: "google.protobuf.Any 'type_url' was empty, only allowed for empty objects.",
+                location: SourceLocation(function: function, file: file, line: line)
+            )
+        }
+    }
 }

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -877,7 +877,7 @@ final class Test_Any: XCTestCase {
         // Upstream most langauges end up validating the type_url during encoding as well
         // as during decoding. Basically to do things, they end up looking up the type
         // in their global registries to use reflection to do things. SwiftProtobuf doesn't
-        // have a registry we can reply on being complete. So instead during encoding we
+        // have a registry we can rely on being complete. So instead during encoding we
         // do the most basic of checks. These tests help ensure those checks are working as
         // expected.
         //

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -1153,7 +1153,7 @@ final class Test_Any: XCTestCase {
     }
 
     func test_Any_nestedList() throws {
-        var start = "{\"optionalAny\":{\"@type\":\"type.googleapis.com/Someting\",\"x\":"
+        var start = "{\"optionalAny\":{\"@type\":\"type.googleapis.com/Something\",\"x\":"
         for _ in 0...10000 {
             start.append("[")
         }


### PR DESCRIPTION
The upstream major languages directly use their type registries to eagerly validate `type_url`s. This means they will fail to decode or encode JSON for a lot of cases.

The conformance tests only cover some of this so I hacked in some C++ unittests to see what errors are thrown and then made the matching cases here and expanded our error handling to duplicate the results.

The bulk of the changes are really just update comments to cover what errors are now throw (not actual code changes).