### PR TITLE
Add conversions between `Swift.Duration` and `Google_Protobuf_Duration`.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -169,6 +169,46 @@ extension Google_Protobuf_Duration {
     }
 }
 
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension Google_Protobuf_Duration {
+    /// Creates a new `Google_Protobuf_Duration` by rounding a `Duration` to
+    /// the nearest nanosecond according to the given rounding rule.
+    ///
+    /// - Parameters:
+    ///   - duration: The `Duration`.
+    ///   - rule: The rounding rule to use.
+    public init(
+        rounding duration: Duration,
+        rule: FloatingPointRoundingRule = .toNearestOrAwayFromZero
+    ) {
+        let secs = duration.components.seconds
+        let attos = duration.components.attoseconds
+        let fracNanos =
+            (Double(attos % attosPerNanosecond) / Double(attosPerNanosecond)).rounded(rule)
+        let nanos = Int32(attos / attosPerNanosecond) + Int32(fracNanos)
+        let (s, n) = normalizeForDuration(seconds: secs, nanos: nanos)
+        self.init(seconds: s, nanos: n)
+    }
+}
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension Duration {
+    /// Creates a new `Duration` that is equal to the given duration.
+    ///
+    /// Swift `Duration` has a strictly higher precision than `Google_Protobuf_Duration`
+    /// (attoseconds vs. nanoseconds, respectively), so this conversion is always
+    /// value-preserving.
+    ///
+    /// - Parameters:
+    ///   - duration: The `Google_Protobuf_Duration`.
+    public init(_ duration: Google_Protobuf_Duration) {
+        self.init(
+            secondsComponent: duration.seconds,
+            attosecondsComponent: Int64(duration.nanos) * attosPerNanosecond
+        )
+    }
+}
+
 private func normalizeForDuration(
     seconds: Int64,
     nanos: Int32

--- a/Sources/SwiftProtobuf/TimeUtils.swift
+++ b/Sources/SwiftProtobuf/TimeUtils.swift
@@ -18,6 +18,7 @@ let secondsPerDay: Int32 = 86400
 let secondsPerHour: Int32 = 3600
 let secondsPerMinute: Int32 = 60
 let nanosPerSecond: Int32 = 1_000_000_000
+let attosPerNanosecond: Int64 = 1_000_000_000
 
 internal func timeOfDayFromSecondsSince1970(seconds: Int64) -> (hh: Int32, mm: Int32, ss: Int32) {
     let secondsSinceMidnight = Int32(mod(seconds, Int64(secondsPerDay)))


### PR DESCRIPTION
I saw one of our teams recently add this extension to their code base and it makes sense to have it here.

Instead of just calling libc's `round` internally like some of the other precision-lowering conversions, I decided to make the `Duration`-to-protobuf conversion more flexible by taking a `FloatingPointRoundingRule` and having it default to standard "school room" rounding. It might be a good idea to update the other precision-lowering conversions to match (deprecating and/or defaulting the old versions as appropriate).
