### PR TITLE
Require Semantic Version labels on PR

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,0 +1,18 @@
+name: PR label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  semver-label-check:
+    name: Semantic version label check
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check for Semantic Version label
+        uses: apple/swift-nio/.github/actions/pull_request_semver_label_checker@main


### PR DESCRIPTION
# Motivation

In most of our other Swift Server related repos we have introduced a new labelling system that allows us to use the GitHub auto-generated release notes. With those labels the release notes are properly grouped into their SemVer impact.

# Modification

This PR adds a new pipeline that makes sure each PR has the appropriate label set before it is merged.

# Result

No more PRs without SemVer classification.