### PR TITLE
Cleaned up generated code for closed Enums

### DIFF
--- a/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
+++ b/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
@@ -20,31 +20,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public enum E: SwiftProtobuf.Enum, Swift.CaseIterable {
-  public typealias RawValue = Int
-  case unset // = 0
-  case a // = 1
-  case b // = 2
+public enum E: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case unset = 0
+  case a = 1
+  case b = 2
 
   public init() {
     self = .unset
-  }
-
-  public init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unset
-    case 1: self = .a
-    case 2: self = .b
-    default: return nil
-    }
-  }
-
-  public var rawValue: Int {
-    switch self {
-    case .unset: return 0
-    case .a: return 1
-    case .b: return 2
-    }
   }
 
 }

--- a/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
+++ b/FuzzTesting/Sources/FuzzCommon/fuzz_testing.pb.swift
@@ -35,34 +35,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  public typealias RawValue = Int
-  case zero // = 0
-  case one // = 1
-  case two // = 2
-  case three // = 3
+public enum SwiftProtoTesting_Fuzz_AnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case zero = 0
+  case one = 1
+  case two = 2
+  case three = 3
 
   public init() {
     self = .zero
-  }
-
-  public init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .zero
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  public var rawValue: Int {
-    switch self {
-    case .zero: return 0
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Reference/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
+++ b/Reference/CompileTests/MultiModule/Sources/ModuleA/a.pb.swift
@@ -20,31 +20,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public enum E: SwiftProtobuf.Enum, Swift.CaseIterable {
-  public typealias RawValue = Int
-  case unset // = 0
-  case a // = 1
-  case b // = 2
+public enum E: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case unset = 0
+  case a = 1
+  case b = 2
 
   public init() {
     self = .unset
-  }
-
-  public init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unset
-    case 1: self = .a
-    case 2: self = .b
-    default: return nil
-    }
-  }
-
-  public var rawValue: Int {
-    switch self {
-    case .unset: return 0
-    case .a: return 1
-    case .b: return 2
-    }
   }
 
 }

--- a/Reference/Conformance/editions/test_messages_proto2_editions.pb.swift
+++ b/Reference/Conformance/editions/test_messages_proto2_editions.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2: SwiftProtobuf.Ex
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Editions_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllRequiredTypesProto2: SwiftPro
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Reference/Conformance/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/Conformance/google/protobuf/test_messages_proto2.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Proto2_TestAllRequiredTypesProto2: SwiftProtobuf.Ext
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Reference/SwiftProtobuf/google/protobuf/descriptor.pb.swift
+++ b/Reference/SwiftProtobuf/google/protobuf/descriptor.pb.swift
@@ -60,79 +60,43 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck 
 }
 
 /// The full set of known editions.
-enum Google_Protobuf_Edition: Enum, Swift.CaseIterable {
-  typealias RawValue = Int
+enum Google_Protobuf_Edition: Int, Enum, Swift.CaseIterable {
 
   /// A placeholder for an unknown edition value.
-  case unknown // = 0
+  case unknown = 0
 
   /// A placeholder edition for specifying default behaviors *before* a feature
   /// was first introduced.  This is effectively an "infinite past".
-  case legacy // = 900
+  case legacy = 900
 
   /// Legacy syntax "editions".  These pre-date editions, but behave much like
   /// distinct editions.  These can't be used to specify the edition of proto
   /// files, but feature definitions must supply proto2/proto3 defaults for
   /// backwards compatibility.
-  case proto2 // = 998
-  case proto3 // = 999
+  case proto2 = 998
+  case proto3 = 999
 
   /// Editions that have been released.  The specific values are arbitrary and
   /// should not be depended on, but they will always be time-ordered for easy
   /// comparison.
-  case edition2023 // = 1000
-  case edition2024 // = 1001
+  case edition2023 = 1000
+  case edition2024 = 1001
 
   /// Placeholder editions for testing feature resolution.  These should not be
   /// used or relied on outside of tests.
-  case edition1TestOnly // = 1
-  case edition2TestOnly // = 2
-  case edition99997TestOnly // = 99997
-  case edition99998TestOnly // = 99998
-  case edition99999TestOnly // = 99999
+  case edition1TestOnly = 1
+  case edition2TestOnly = 2
+  case edition99997TestOnly = 99997
+  case edition99998TestOnly = 99998
+  case edition99999TestOnly = 99999
 
   /// Placeholder for specifying unbounded edition support.  This should only
   /// ever be used by plugins that can expect to never require any changes to
   /// support a new edition.
-  case max // = 2147483647
+  case max = 2147483647
 
   init() {
     self = .unknown
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    case 1: self = .edition1TestOnly
-    case 2: self = .edition2TestOnly
-    case 900: self = .legacy
-    case 998: self = .proto2
-    case 999: self = .proto3
-    case 1000: self = .edition2023
-    case 1001: self = .edition2024
-    case 99997: self = .edition99997TestOnly
-    case 99998: self = .edition99998TestOnly
-    case 99999: self = .edition99999TestOnly
-    case 2147483647: self = .max
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    case .edition1TestOnly: return 1
-    case .edition2TestOnly: return 2
-    case .legacy: return 900
-    case .proto2: return 998
-    case .proto3: return 999
-    case .edition2023: return 1000
-    case .edition2024: return 1001
-    case .edition99997TestOnly: return 99997
-    case .edition99998TestOnly: return 99998
-    case .edition99999TestOnly: return 99999
-    case .max: return 2147483647
-    }
   }
 
 }
@@ -451,30 +415,14 @@ struct Google_Protobuf_ExtensionRangeOptions: ExtensibleMessage, Sendable {
   var unknownFields = UnknownStorage()
 
   /// The verification state of the extension range.
-  enum VerificationState: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum VerificationState: Int, Enum, Swift.CaseIterable {
 
     /// All the extensions of the range must be declared.
-    case declaration // = 0
-    case unverified // = 1
+    case declaration = 0
+    case unverified = 1
 
     init() {
       self = .declaration
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .declaration
-      case 1: self = .unverified
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .declaration: return 0
-      case .unverified: return 1
-      }
     }
 
   }
@@ -705,134 +653,68 @@ struct Google_Protobuf_FieldDescriptorProto: Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum TypeEnum: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum TypeEnum: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors.
     /// Order is weird for historical reasons.
-    case double // = 1
-    case float // = 2
+    case double = 1
+    case float = 2
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
     /// negative values are likely.
-    case int64 // = 3
-    case uint64 // = 4
+    case int64 = 3
+    case uint64 = 4
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
     /// negative values are likely.
-    case int32 // = 5
-    case fixed64 // = 6
-    case fixed32 // = 7
-    case bool // = 8
-    case string // = 9
+    case int32 = 5
+    case fixed64 = 6
+    case fixed32 = 7
+    case bool = 8
+    case string = 9
 
     /// Tag-delimited aggregate.
     /// Group type is deprecated and not supported after google.protobuf. However, Proto3
     /// implementations should still be able to parse the group wire format and
     /// treat group fields as unknown fields.  In Editions, the group wire format
     /// can be enabled via the `message_encoding` feature.
-    case group // = 10
+    case group = 10
 
     /// Length-delimited aggregate.
-    case message // = 11
+    case message = 11
 
     /// New in version 2.
-    case bytes // = 12
-    case uint32 // = 13
-    case `enum` // = 14
-    case sfixed32 // = 15
-    case sfixed64 // = 16
+    case bytes = 12
+    case uint32 = 13
+    case `enum` = 14
+    case sfixed32 = 15
+    case sfixed64 = 16
 
     /// Uses ZigZag encoding.
-    case sint32 // = 17
+    case sint32 = 17
 
     /// Uses ZigZag encoding.
-    case sint64 // = 18
+    case sint64 = 18
 
     init() {
       self = .double
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .double
-      case 2: self = .float
-      case 3: self = .int64
-      case 4: self = .uint64
-      case 5: self = .int32
-      case 6: self = .fixed64
-      case 7: self = .fixed32
-      case 8: self = .bool
-      case 9: self = .string
-      case 10: self = .group
-      case 11: self = .message
-      case 12: self = .bytes
-      case 13: self = .uint32
-      case 14: self = .enum
-      case 15: self = .sfixed32
-      case 16: self = .sfixed64
-      case 17: self = .sint32
-      case 18: self = .sint64
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .double: return 1
-      case .float: return 2
-      case .int64: return 3
-      case .uint64: return 4
-      case .int32: return 5
-      case .fixed64: return 6
-      case .fixed32: return 7
-      case .bool: return 8
-      case .string: return 9
-      case .group: return 10
-      case .message: return 11
-      case .bytes: return 12
-      case .uint32: return 13
-      case .enum: return 14
-      case .sfixed32: return 15
-      case .sfixed64: return 16
-      case .sint32: return 17
-      case .sint64: return 18
-      }
-    }
-
   }
 
-  enum Label: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum Label: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors
-    case `optional` // = 1
-    case repeated // = 3
+    case `optional` = 1
+    case repeated = 3
 
     /// The required label is only allowed in google.protobuf.  In proto3 and Editions
     /// it's explicitly prohibited.  In Editions, the `field_presence` feature
     /// can be used to get this behavior.
-    case `required` // = 2
+    case `required` = 2
 
     init() {
       self = .optional
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .optional
-      case 2: self = .required
-      case 3: self = .repeated
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .optional: return 1
-      case .required: return 2
-      case .repeated: return 3
-      }
     }
 
   }
@@ -1384,37 +1266,19 @@ struct Google_Protobuf_FileOptions: ExtensibleMessage, @unchecked Sendable {
   var unknownFields = UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  enum OptimizeMode: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum OptimizeMode: Int, Enum, Swift.CaseIterable {
 
     /// Generate complete code for parsing, serialization,
-    case speed // = 1
+    case speed = 1
 
     /// etc.
-    case codeSize // = 2
+    case codeSize = 2
 
     /// Generate code using MessageLite and the lite runtime.
-    case liteRuntime // = 3
+    case liteRuntime = 3
 
     init() {
       self = .speed
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .speed
-      case 2: self = .codeSize
-      case 3: self = .liteRuntime
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .speed: return 1
-      case .codeSize: return 2
-      case .liteRuntime: return 3
-      }
     }
 
   }
@@ -1745,11 +1609,10 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum CType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum CType: Int, Enum, Swift.CaseIterable {
 
     /// Default mode.
-    case string // = 0
+    case string = 0
 
     /// The option [ctype=CORD] may be applied to a non-repeated field of type
     /// "bytes". It indicates that in C++, the data should be stored in a Cord
@@ -1757,93 +1620,40 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
     /// fragmentation. It may also allow better performance when parsing from a
     /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
     /// alias the original buffer.
-    case cord // = 1
-    case stringPiece // = 2
+    case cord = 1
+    case stringPiece = 2
 
     init() {
       self = .string
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .string
-      case 1: self = .cord
-      case 2: self = .stringPiece
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .string: return 0
-      case .cord: return 1
-      case .stringPiece: return 2
-      }
-    }
-
   }
 
-  enum JSType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum JSType: Int, Enum, Swift.CaseIterable {
 
     /// Use the default type.
-    case jsNormal // = 0
+    case jsNormal = 0
 
     /// Use JavaScript strings.
-    case jsString // = 1
+    case jsString = 1
 
     /// Use JavaScript numbers.
-    case jsNumber // = 2
+    case jsNumber = 2
 
     init() {
       self = .jsNormal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .jsNormal
-      case 1: self = .jsString
-      case 2: self = .jsNumber
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .jsNormal: return 0
-      case .jsString: return 1
-      case .jsNumber: return 2
-      }
-    }
-
   }
 
   /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
-  enum OptionRetention: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case retentionUnknown // = 0
-    case retentionRuntime // = 1
-    case retentionSource // = 2
+  enum OptionRetention: Int, Enum, Swift.CaseIterable {
+    case retentionUnknown = 0
+    case retentionRuntime = 1
+    case retentionSource = 2
 
     init() {
       self = .retentionUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .retentionUnknown
-      case 1: self = .retentionRuntime
-      case 2: self = .retentionSource
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .retentionUnknown: return 0
-      case .retentionRuntime: return 1
-      case .retentionSource: return 2
-      }
     }
 
   }
@@ -1851,52 +1661,20 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
   /// This indicates the types of entities that the field may apply to when used
   /// as an option. If it is unset, then the field may be freely used as an
   /// option on any kind of entity.
-  enum OptionTargetType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case targetTypeUnknown // = 0
-    case targetTypeFile // = 1
-    case targetTypeExtensionRange // = 2
-    case targetTypeMessage // = 3
-    case targetTypeField // = 4
-    case targetTypeOneof // = 5
-    case targetTypeEnum // = 6
-    case targetTypeEnumEntry // = 7
-    case targetTypeService // = 8
-    case targetTypeMethod // = 9
+  enum OptionTargetType: Int, Enum, Swift.CaseIterable {
+    case targetTypeUnknown = 0
+    case targetTypeFile = 1
+    case targetTypeExtensionRange = 2
+    case targetTypeMessage = 3
+    case targetTypeField = 4
+    case targetTypeOneof = 5
+    case targetTypeEnum = 6
+    case targetTypeEnumEntry = 7
+    case targetTypeService = 8
+    case targetTypeMethod = 9
 
     init() {
       self = .targetTypeUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .targetTypeUnknown
-      case 1: self = .targetTypeFile
-      case 2: self = .targetTypeExtensionRange
-      case 3: self = .targetTypeMessage
-      case 4: self = .targetTypeField
-      case 5: self = .targetTypeOneof
-      case 6: self = .targetTypeEnum
-      case 7: self = .targetTypeEnumEntry
-      case 8: self = .targetTypeService
-      case 9: self = .targetTypeMethod
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .targetTypeUnknown: return 0
-      case .targetTypeFile: return 1
-      case .targetTypeExtensionRange: return 2
-      case .targetTypeMessage: return 3
-      case .targetTypeField: return 4
-      case .targetTypeOneof: return 5
-      case .targetTypeEnum: return 6
-      case .targetTypeEnumEntry: return 7
-      case .targetTypeService: return 8
-      case .targetTypeMethod: return 9
-      }
     }
 
   }
@@ -2261,35 +2039,17 @@ struct Google_Protobuf_MethodOptions: ExtensibleMessage, Sendable {
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  enum IdempotencyLevel: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case idempotencyUnknown // = 0
+  enum IdempotencyLevel: Int, Enum, Swift.CaseIterable {
+    case idempotencyUnknown = 0
 
     /// implies idempotent
-    case noSideEffects // = 1
+    case noSideEffects = 1
 
     /// idempotent, but may have side effects
-    case idempotent // = 2
+    case idempotent = 2
 
     init() {
       self = .idempotencyUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .idempotencyUnknown
-      case 1: self = .noSideEffects
-      case 2: self = .idempotent
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .idempotencyUnknown: return 0
-      case .noSideEffects: return 1
-      case .idempotent: return 2
-      }
     }
 
   }
@@ -2486,179 +2246,69 @@ struct Google_Protobuf_FeatureSet: ExtensibleMessage, Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum FieldPresence: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case explicit // = 1
-    case implicit // = 2
-    case legacyRequired // = 3
+  enum FieldPresence: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case explicit = 1
+    case implicit = 2
+    case legacyRequired = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .explicit
-      case 2: self = .implicit
-      case 3: self = .legacyRequired
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .explicit: return 1
-      case .implicit: return 2
-      case .legacyRequired: return 3
-      }
     }
 
   }
 
-  enum EnumType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case `open` // = 1
-    case closed // = 2
+  enum EnumType: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case `open` = 1
+    case closed = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .open
-      case 2: self = .closed
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .open: return 1
-      case .closed: return 2
-      }
     }
 
   }
 
-  enum RepeatedFieldEncoding: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case packed // = 1
-    case expanded // = 2
+  enum RepeatedFieldEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case packed = 1
+    case expanded = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .packed
-      case 2: self = .expanded
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .packed: return 1
-      case .expanded: return 2
-      }
     }
 
   }
 
-  enum Utf8Validation: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case verify // = 2
-    case none // = 3
+  enum Utf8Validation: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case verify = 2
+    case none = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 2: self = .verify
-      case 3: self = .none
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .verify: return 2
-      case .none: return 3
-      }
     }
 
   }
 
-  enum MessageEncoding: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case lengthPrefixed // = 1
-    case delimited // = 2
+  enum MessageEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case lengthPrefixed = 1
+    case delimited = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .lengthPrefixed
-      case 2: self = .delimited
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .lengthPrefixed: return 1
-      case .delimited: return 2
-      }
     }
 
   }
 
-  enum JsonFormat: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case allow // = 1
-    case legacyBestEffort // = 2
+  enum JsonFormat: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case allow = 1
+    case legacyBestEffort = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .allow
-      case 2: self = .legacyBestEffort
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .allow: return 1
-      case .legacyBestEffort: return 2
-      }
     }
 
   }
@@ -3002,37 +2652,19 @@ struct Google_Protobuf_GeneratedCodeInfo: Sendable {
 
     /// Represents the identified object's effect on the element in the original
     /// .proto file.
-    enum Semantic: Enum, Swift.CaseIterable {
-      typealias RawValue = Int
+    enum Semantic: Int, Enum, Swift.CaseIterable {
 
       /// There is no effect or the effect is indescribable.
-      case none // = 0
+      case none = 0
 
       /// The element is set or otherwise mutated.
-      case set // = 1
+      case set = 1
 
       /// An alias to the element is returned.
-      case alias // = 2
+      case alias = 2
 
       init() {
         self = .none
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .none
-        case 1: self = .set
-        case 2: self = .alias
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .none: return 0
-        case .set: return 1
-        case .alias: return 2
-        }
       }
 
     }

--- a/Reference/SwiftProtobufPluginLibrary/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/SwiftProtobufPluginLibrary/google/protobuf/compiler/plugin.pb.swift
@@ -224,31 +224,13 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Sync with code_generator.h.
-  enum Feature: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case none // = 0
-    case proto3Optional // = 1
-    case supportsEditions // = 2
+  enum Feature: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case none = 0
+    case proto3Optional = 1
+    case supportsEditions = 2
 
     init() {
       self = .none
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .none
-      case 1: self = .proto3Optional
-      case 2: self = .supportsEditions
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .none: return 0
-      case .proto3Optional: return 1
-      case .supportsEditions: return 2
-      }
     }
 
   }

--- a/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
@@ -36,31 +36,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SDTTopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case valueZero // = 0
-  case valueOne // = 1
-  case valueTwo // = 2
+enum SDTTopLevelEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case valueZero = 0
+  case valueOne = 1
+  case valueTwo = 2
 
   init() {
     self = .valueZero
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .valueZero
-    case 1: self = .valueOne
-    case 2: self = .valueTwo
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .valueZero: return 0
-    case .valueOne: return 1
-    case .valueTwo: return 2
-    }
   }
 
 }
@@ -135,31 +117,13 @@ struct SDTTopLevelMessage: @unchecked Sendable {
 
   }
 
-  enum SubEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case subValue0 // = 0
-    case subValue1 // = 1
-    case subValue2 // = 2
+  enum SubEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case subValue0 = 0
+    case subValue1 = 1
+    case subValue2 = 2
 
     init() {
       self = .subValue0
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .subValue0
-      case 1: self = .subValue1
-      case 2: self = .subValue2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .subValue0: return 0
-      case .subValue1: return 1
-      case .subValue2: return 2
-      }
     }
 
   }

--- a/Reference/SwiftProtobufPluginLibraryTests/test_features.pb.swift
+++ b/Reference/SwiftProtobufPluginLibraryTests/test_features.pb.swift
@@ -84,43 +84,17 @@ struct SwiftFeatureTest_TestFeatures: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case value1 // = 1
-    case value2 // = 2
-    case value3 // = 3
-    case value4 // = 4
-    case value5 // = 5
-    case value6 // = 6
+  enum EnumFeature: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unknown = 0
+    case value1 = 1
+    case value2 = 2
+    case value3 = 3
+    case value4 = 4
+    case value5 = 5
+    case value6 = 6
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .value1
-      case 2: self = .value2
-      case 3: self = .value3
-      case 4: self = .value4
-      case 5: self = .value5
-      case 6: self = .value6
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .value1: return 1
-      case .value2: return 2
-      case .value3: return 3
-      case .value4: return 4
-      case .value5: return 5
-      case .value6: return 6
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Reference/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -35,34 +35,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case zero // = 0
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_Fuzz_AnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case zero = 0
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .zero
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .zero
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .zero: return 0
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Reference/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -50,63 +50,25 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum SwiftProtoTesting_Proto2MapEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
-  }
-
 }
 
-enum SwiftProtoTesting_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case eProto2MapEnumFoo // = 0
-  case eProto2MapEnumBar // = 1
-  case eProto2MapEnumBaz // = 2
-  case eProto2MapEnumExtra // = 3
+enum SwiftProtoTesting_Proto2MapEnumPlusExtra: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case eProto2MapEnumFoo = 0
+  case eProto2MapEnumBar = 1
+  case eProto2MapEnumBaz = 2
+  case eProto2MapEnumExtra = 3
 
   init() {
     self = .eProto2MapEnumFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .eProto2MapEnumFoo
-    case 1: self = .eProto2MapEnumBar
-    case 2: self = .eProto2MapEnumBaz
-    case 3: self = .eProto2MapEnumExtra
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .eProto2MapEnumFoo: return 0
-    case .eProto2MapEnumBar: return 1
-    case .eProto2MapEnumBaz: return 2
-    case .eProto2MapEnumExtra: return 3
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/unittest.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest.pb.swift
@@ -59,63 +59,27 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 4
-  case foreignBar // = 5
-  case foreignBaz // = 6
+enum SwiftProtoTesting_ForeignEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 4
+  case foreignBar = 5
+  case foreignBaz = 6
 
   init() {
     self = .foreignFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 4: self = .foreignFoo
-    case 5: self = .foreignBar
-    case 6: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 4
-    case .foreignBar: return 5
-    case .foreignBaz: return 6
-    }
-  }
-
 }
 
 /// Test an enum that has multiple values with the same number.
-enum SwiftProtoTesting_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo1 // = 1
-  case bar1 // = 2
-  case baz // = 3
+enum SwiftProtoTesting_TestEnumWithDupValue: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo1 = 1
+  case bar1 = 2
+  case baz = 3
   static let foo2 = foo1
   static let bar2 = bar1
 
   init() {
     self = .foo1
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .foo1
-    case 2: self = .bar1
-    case 3: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo1: return 1
-    case .bar1: return 2
-    case .baz: return 3
-    }
   }
 
 }
@@ -728,36 +692,16 @@ struct SwiftProtoTesting_TestAllTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_import.pb.swift
@@ -56,31 +56,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Import_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case importFoo // = 7
-  case importBar // = 8
-  case importBaz // = 9
+enum SwiftProtoTesting_Import_ImportEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case importFoo = 7
+  case importBar = 8
+  case importBaz = 9
 
   init() {
     self = .importFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 7: self = .importFoo
-    case 8: self = .importBar
-    case 9: self = .importBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .importFoo: return 7
-    case .importBar: return 8
-    case .importBaz: return 9
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -50,31 +50,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -529,36 +529,16 @@ struct SwiftProtoTesting_TestAllRequiredTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -675,25 +655,11 @@ struct SwiftProtoTesting_TestSomeRequiredTypes: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 1
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
@@ -37,37 +37,19 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// An enum value marked as deprecated.
-enum SwiftProtoTesting_Deprecated_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
+enum SwiftProtoTesting_Deprecated_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
 
   /// Enum comment
   ///
   /// NOTE: This enum value was marked as deprecated in the .proto file
-  case two // = 2
+  case two = 2
 
   /// NOTE: This enum value was marked as deprecated in the .proto file
-  case three // = 3
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }
@@ -75,31 +57,13 @@ enum SwiftProtoTesting_Deprecated_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable
 /// Whole enum marked as deprecated.
 ///
 /// NOTE: This enum was marked as deprecated in the .proto file.
-enum SwiftProtoTesting_Deprecated_MyEnum2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_Deprecated_MyEnum2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
@@ -37,31 +37,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// NOTE: The whole .proto file that defined this enum was marked as deprecated.
-enum SwiftProtoTesting_DeprecatedFile_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_DeprecatedFile_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Reference/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -70,25 +70,11 @@ struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-      typealias RawValue = Int
-      case foo // = 0
+    enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+      case foo = 0
 
       init() {
         self = .foo
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .foo
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .foo: return 0
-        }
       }
 
     }
@@ -114,25 +100,11 @@ struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-      typealias RawValue = Int
-      case foo // = 0
+    enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+      case foo = 0
 
       init() {
         self = .foo
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .foo
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .foo: return 0
-        }
       }
 
     }

--- a/Reference/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
@@ -65,106 +65,42 @@ struct SwiftProtoTesting_Enum2_SwiftEnumTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumTest1: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case firstValue // = 1
-    case secondValue // = 2
+  enum EnumTest1: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case firstValue = 1
+    case secondValue = 2
 
     init() {
       self = .firstValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .firstValue
-      case 2: self = .secondValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .firstValue: return 1
-      case .secondValue: return 2
-      }
-    }
-
   }
 
-  enum EnumTest2: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case firstValue // = 1
-    case secondValue // = 2
+  enum EnumTest2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case firstValue = 1
+    case secondValue = 2
 
     init() {
       self = .firstValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .firstValue
-      case 2: self = .secondValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .firstValue: return 1
-      case .secondValue: return 2
-      }
-    }
-
   }
 
-  enum EnumTestNoStem: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case enumTestNoStem1 // = 1
-    case enumTestNoStem2 // = 2
+  enum EnumTestNoStem: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case enumTestNoStem1 = 1
+    case enumTestNoStem2 = 2
 
     init() {
       self = .enumTestNoStem1
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .enumTestNoStem1
-      case 2: self = .enumTestNoStem2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .enumTestNoStem1: return 1
-      case .enumTestNoStem2: return 2
-      }
-    }
-
   }
 
-  enum EnumTestReservedWord: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `var` // = 1
-    case notReserved // = 2
+  enum EnumTestReservedWord: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `var` = 1
+    case notReserved = 2
 
     init() {
       self = .var
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .var
-      case 2: self = .notReserved
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .var: return 1
-      case .notReserved: return 2
-      }
     }
 
   }
@@ -181,35 +117,17 @@ struct SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumWithAlias: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo1 // = 1
+  enum EnumWithAlias: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo1 = 1
     static let foo2 = foo1
 
     /// out of value order to test allCases
-    case baz1 // = 3
-    case bar1 // = 2
+    case baz1 = 3
+    case bar1 = 2
     static let bar2 = bar1
 
     init() {
       self = .foo1
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo1
-      case 2: self = .bar1
-      case 3: self = .baz1
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo1: return 1
-      case .bar1: return 2
-      case .baz1: return 3
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -38,655 +38,226 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Names_EnumFieldNames: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case a // = 0
-  case string // = 1
-  case int // = 2
-  case double // = 3
-  case float // = 4
-  case uint // = 5
-  case hashValue_ // = 6
-  case description_ // = 7
-  case debugDescription_ // = 8
-  case swift // = 9
-  case unrecognized // = 10
-  case `class` // = 11
-  case `deinit` // = 12
-  case `enum` // = 13
-  case `extension` // = 14
-  case `func` // = 15
-  case `import` // = 16
-  case init_ // = 17
-  case `inout` // = 18
-  case `internal` // = 19
-  case `let` // = 20
-  case `operator` // = 21
-  case `private` // = 22
-  case `protocol` // = 23
-  case `public` // = 24
-  case `static` // = 25
-  case `struct` // = 26
-  case `subscript` // = 27
-  case `typealias` // = 28
-  case `var` // = 29
-  case `break` // = 30
-  case `case` // = 31
-  case `continue` // = 32
-  case `default` // = 33
-  case `defer` // = 34
-  case `do` // = 35
-  case `else` // = 36
-  case `fallthrough` // = 37
-  case `for` // = 38
-  case `guard` // = 39
-  case `if` // = 40
-  case `in` // = 41
-  case `repeat` // = 42
-  case `return` // = 43
-  case `switch` // = 44
-  case `where` // = 45
-  case `while` // = 46
-  case `as` // = 47
-  case `catch` // = 48
-  case dynamicType_ // = 49
-  case `false` // = 50
-  case `is` // = 51
-  case `nil` // = 52
-  case `rethrows` // = 53
-  case `super` // = 54
-  case self_ // = 55
-  case `throw` // = 57
-  case `throws` // = 58
-  case `true` // = 59
-  case `try` // = 60
-  case _Column__ // = 61
-  case _File__ // = 62
-  case _Function__ // = 63
-  case _Line__ // = 64
-  case ___ // = 65
-  case `associativity` // = 66
-  case convenience // = 67
-  case dynamic // = 68
-  case didSet // = 69
-  case final // = 70
-  case get // = 71
-  case infix // = 72
-  case indirect // = 73
-  case lazy // = 74
-  case left // = 75
-  case mutating // = 76
-  case none // = 77
-  case nonmutating // = 78
-  case `optional` // = 79
-  case override // = 80
-  case postfix // = 81
-  case precedence // = 82
-  case prefix // = 83
-  case `required` // = 85
-  case right // = 86
-  case set // = 87
-  case type // = 88
-  case unowned // = 89
-  case weak // = 90
-  case willSet // = 91
+enum SwiftProtoTesting_Names_EnumFieldNames: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case a = 0
+  case string = 1
+  case int = 2
+  case double = 3
+  case float = 4
+  case uint = 5
+  case hashValue_ = 6
+  case description_ = 7
+  case debugDescription_ = 8
+  case swift = 9
+  case unrecognized = 10
+  case `class` = 11
+  case `deinit` = 12
+  case `enum` = 13
+  case `extension` = 14
+  case `func` = 15
+  case `import` = 16
+  case init_ = 17
+  case `inout` = 18
+  case `internal` = 19
+  case `let` = 20
+  case `operator` = 21
+  case `private` = 22
+  case `protocol` = 23
+  case `public` = 24
+  case `static` = 25
+  case `struct` = 26
+  case `subscript` = 27
+  case `typealias` = 28
+  case `var` = 29
+  case `break` = 30
+  case `case` = 31
+  case `continue` = 32
+  case `default` = 33
+  case `defer` = 34
+  case `do` = 35
+  case `else` = 36
+  case `fallthrough` = 37
+  case `for` = 38
+  case `guard` = 39
+  case `if` = 40
+  case `in` = 41
+  case `repeat` = 42
+  case `return` = 43
+  case `switch` = 44
+  case `where` = 45
+  case `while` = 46
+  case `as` = 47
+  case `catch` = 48
+  case dynamicType_ = 49
+  case `false` = 50
+  case `is` = 51
+  case `nil` = 52
+  case `rethrows` = 53
+  case `super` = 54
+  case self_ = 55
+  case `throw` = 57
+  case `throws` = 58
+  case `true` = 59
+  case `try` = 60
+  case _Column__ = 61
+  case _File__ = 62
+  case _Function__ = 63
+  case _Line__ = 64
+  case ___ = 65
+  case `associativity` = 66
+  case convenience = 67
+  case dynamic = 68
+  case didSet = 69
+  case final = 70
+  case get = 71
+  case infix = 72
+  case indirect = 73
+  case lazy = 74
+  case left = 75
+  case mutating = 76
+  case none = 77
+  case nonmutating = 78
+  case `optional` = 79
+  case override = 80
+  case postfix = 81
+  case precedence = 82
+  case prefix = 83
+  case `required` = 85
+  case right = 86
+  case set = 87
+  case type = 88
+  case unowned = 89
+  case weak = 90
+  case willSet = 91
 
   ///    id = 92;
-  case cmd // = 93
-  case out // = 96
-  case bycopy // = 98
-  case byref // = 99
-  case oneway // = 100
-  case and // = 102
-  case andEq // = 103
-  case alignas // = 104
-  case alignof // = 105
-  case asm // = 106
-  case auto // = 107
-  case bitand // = 108
-  case bitor // = 109
-  case bool // = 110
-  case char // = 114
-  case char16T // = 115
-  case char32T // = 116
-  case compl // = 118
-  case const // = 119
-  case constexpr // = 120
-  case constCast // = 121
-  case decltype // = 123
-  case delete // = 125
-  case dynamicCast // = 127
-  case explicit // = 130
-  case export // = 131
-  case extern // = 132
-  case friend // = 136
-  case goto // = 137
-  case inline // = 139
-  case long // = 141
-  case mutable // = 142
-  case namespace // = 143
-  case new // = 144
-  case noexcept // = 145
-  case not // = 146
-  case notEq // = 147
-  case nullptr // = 148
-  case or // = 150
-  case orEq // = 151
-  case protected // = 153
-  case register // = 155
-  case reinterpretCast // = 156
-  case short // = 158
-  case signed // = 159
-  case sizeof // = 160
-  case staticAssert // = 162
-  case staticCast // = 163
-  case template // = 166
-  case this // = 167
-  case threadLocal // = 168
-  case typedef // = 172
-  case typeid // = 173
-  case typename // = 174
-  case union // = 175
-  case unsigned // = 176
-  case using // = 177
-  case virtual // = 178
-  case void // = 179
-  case volatile // = 180
-  case wcharT // = 181
-  case xor // = 183
-  case xorEq // = 184
-  case restrict // = 185
-  case category // = 186
-  case ivar // = 187
-  case method // = 188
-  case finalize // = 192
-  case hash // = 193
-  case dealloc // = 194
-  case superclass // = 197
-  case retain // = 198
-  case release // = 199
-  case autorelease // = 200
-  case retainCount // = 201
-  case zone // = 202
-  case isProxy // = 203
-  case copy // = 204
-  case mutableCopy // = 205
-  case classForCoder // = 206
-  case clear // = 207
-  case data // = 208
-  case delimitedData // = 209
-  case descriptor // = 210
-  case extensionRegistry // = 211
-  case extensionsCurrentlySet // = 212
-  case isInitialized // = 213
-  case serializedSize // = 214
-  case sortedExtensionsInUse // = 215
-  case unknownFields // = 216
-  case fixed // = 217
-  case fract // = 218
-  case size // = 219
-  case logicalAddress // = 220
-  case physicalAddress // = 221
-  case byteCount // = 222
-  case byteOffset // = 223
-  case duration // = 224
-  case absoluteTime // = 225
-  case optionBits // = 226
-  case itemCount // = 227
-  case pbversion // = 228
-  case scriptCode // = 229
-  case langCode // = 230
-  case regionCode // = 231
-  case ostype // = 232
-  case processSerialNumber // = 233
-  case point // = 234
-  case rect // = 235
-  case fixedPoint // = 236
-  case fixedRect // = 237
-  case style // = 238
-  case styleParameter // = 239
-  case styleField // = 240
-  case timeScale // = 241
-  case timeBase // = 242
-  case timeRecord // = 243
-  case extensions // = 244
+  case cmd = 93
+  case out = 96
+  case bycopy = 98
+  case byref = 99
+  case oneway = 100
+  case and = 102
+  case andEq = 103
+  case alignas = 104
+  case alignof = 105
+  case asm = 106
+  case auto = 107
+  case bitand = 108
+  case bitor = 109
+  case bool = 110
+  case char = 114
+  case char16T = 115
+  case char32T = 116
+  case compl = 118
+  case const = 119
+  case constexpr = 120
+  case constCast = 121
+  case decltype = 123
+  case delete = 125
+  case dynamicCast = 127
+  case explicit = 130
+  case export = 131
+  case extern = 132
+  case friend = 136
+  case goto = 137
+  case inline = 139
+  case long = 141
+  case mutable = 142
+  case namespace = 143
+  case new = 144
+  case noexcept = 145
+  case not = 146
+  case notEq = 147
+  case nullptr = 148
+  case or = 150
+  case orEq = 151
+  case protected = 153
+  case register = 155
+  case reinterpretCast = 156
+  case short = 158
+  case signed = 159
+  case sizeof = 160
+  case staticAssert = 162
+  case staticCast = 163
+  case template = 166
+  case this = 167
+  case threadLocal = 168
+  case typedef = 172
+  case typeid = 173
+  case typename = 174
+  case union = 175
+  case unsigned = 176
+  case using = 177
+  case virtual = 178
+  case void = 179
+  case volatile = 180
+  case wcharT = 181
+  case xor = 183
+  case xorEq = 184
+  case restrict = 185
+  case category = 186
+  case ivar = 187
+  case method = 188
+  case finalize = 192
+  case hash = 193
+  case dealloc = 194
+  case superclass = 197
+  case retain = 198
+  case release = 199
+  case autorelease = 200
+  case retainCount = 201
+  case zone = 202
+  case isProxy = 203
+  case copy = 204
+  case mutableCopy = 205
+  case classForCoder = 206
+  case clear = 207
+  case data = 208
+  case delimitedData = 209
+  case descriptor = 210
+  case extensionRegistry = 211
+  case extensionsCurrentlySet = 212
+  case isInitialized = 213
+  case serializedSize = 214
+  case sortedExtensionsInUse = 215
+  case unknownFields = 216
+  case fixed = 217
+  case fract = 218
+  case size = 219
+  case logicalAddress = 220
+  case physicalAddress = 221
+  case byteCount = 222
+  case byteOffset = 223
+  case duration = 224
+  case absoluteTime = 225
+  case optionBits = 226
+  case itemCount = 227
+  case pbversion = 228
+  case scriptCode = 229
+  case langCode = 230
+  case regionCode = 231
+  case ostype = 232
+  case processSerialNumber = 233
+  case point = 234
+  case rect = 235
+  case fixedPoint = 236
+  case fixedRect = 237
+  case style = 238
+  case styleParameter = 239
+  case styleField = 240
+  case timeScale = 241
+  case timeBase = 242
+  case timeRecord = 243
+  case extensions = 244
 
   init() {
     self = .a
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .a
-    case 1: self = .string
-    case 2: self = .int
-    case 3: self = .double
-    case 4: self = .float
-    case 5: self = .uint
-    case 6: self = .hashValue_
-    case 7: self = .description_
-    case 8: self = .debugDescription_
-    case 9: self = .swift
-    case 10: self = .unrecognized
-    case 11: self = .class
-    case 12: self = .deinit
-    case 13: self = .enum
-    case 14: self = .extension
-    case 15: self = .func
-    case 16: self = .import
-    case 17: self = .init_
-    case 18: self = .inout
-    case 19: self = .internal
-    case 20: self = .let
-    case 21: self = .operator
-    case 22: self = .private
-    case 23: self = .protocol
-    case 24: self = .public
-    case 25: self = .static
-    case 26: self = .struct
-    case 27: self = .subscript
-    case 28: self = .typealias
-    case 29: self = .var
-    case 30: self = .break
-    case 31: self = .case
-    case 32: self = .continue
-    case 33: self = .default
-    case 34: self = .defer
-    case 35: self = .do
-    case 36: self = .else
-    case 37: self = .fallthrough
-    case 38: self = .for
-    case 39: self = .guard
-    case 40: self = .if
-    case 41: self = .in
-    case 42: self = .repeat
-    case 43: self = .return
-    case 44: self = .switch
-    case 45: self = .where
-    case 46: self = .while
-    case 47: self = .as
-    case 48: self = .catch
-    case 49: self = .dynamicType_
-    case 50: self = .false
-    case 51: self = .is
-    case 52: self = .nil
-    case 53: self = .rethrows
-    case 54: self = .super
-    case 55: self = .self_
-    case 57: self = .throw
-    case 58: self = .throws
-    case 59: self = .true
-    case 60: self = .try
-    case 61: self = ._Column__
-    case 62: self = ._File__
-    case 63: self = ._Function__
-    case 64: self = ._Line__
-    case 65: self = .___
-    case 66: self = .associativity
-    case 67: self = .convenience
-    case 68: self = .dynamic
-    case 69: self = .didSet
-    case 70: self = .final
-    case 71: self = .get
-    case 72: self = .infix
-    case 73: self = .indirect
-    case 74: self = .lazy
-    case 75: self = .left
-    case 76: self = .mutating
-    case 77: self = .none
-    case 78: self = .nonmutating
-    case 79: self = .optional
-    case 80: self = .override
-    case 81: self = .postfix
-    case 82: self = .precedence
-    case 83: self = .prefix
-    case 85: self = .required
-    case 86: self = .right
-    case 87: self = .set
-    case 88: self = .type
-    case 89: self = .unowned
-    case 90: self = .weak
-    case 91: self = .willSet
-    case 93: self = .cmd
-    case 96: self = .out
-    case 98: self = .bycopy
-    case 99: self = .byref
-    case 100: self = .oneway
-    case 102: self = .and
-    case 103: self = .andEq
-    case 104: self = .alignas
-    case 105: self = .alignof
-    case 106: self = .asm
-    case 107: self = .auto
-    case 108: self = .bitand
-    case 109: self = .bitor
-    case 110: self = .bool
-    case 114: self = .char
-    case 115: self = .char16T
-    case 116: self = .char32T
-    case 118: self = .compl
-    case 119: self = .const
-    case 120: self = .constexpr
-    case 121: self = .constCast
-    case 123: self = .decltype
-    case 125: self = .delete
-    case 127: self = .dynamicCast
-    case 130: self = .explicit
-    case 131: self = .export
-    case 132: self = .extern
-    case 136: self = .friend
-    case 137: self = .goto
-    case 139: self = .inline
-    case 141: self = .long
-    case 142: self = .mutable
-    case 143: self = .namespace
-    case 144: self = .new
-    case 145: self = .noexcept
-    case 146: self = .not
-    case 147: self = .notEq
-    case 148: self = .nullptr
-    case 150: self = .or
-    case 151: self = .orEq
-    case 153: self = .protected
-    case 155: self = .register
-    case 156: self = .reinterpretCast
-    case 158: self = .short
-    case 159: self = .signed
-    case 160: self = .sizeof
-    case 162: self = .staticAssert
-    case 163: self = .staticCast
-    case 166: self = .template
-    case 167: self = .this
-    case 168: self = .threadLocal
-    case 172: self = .typedef
-    case 173: self = .typeid
-    case 174: self = .typename
-    case 175: self = .union
-    case 176: self = .unsigned
-    case 177: self = .using
-    case 178: self = .virtual
-    case 179: self = .void
-    case 180: self = .volatile
-    case 181: self = .wcharT
-    case 183: self = .xor
-    case 184: self = .xorEq
-    case 185: self = .restrict
-    case 186: self = .category
-    case 187: self = .ivar
-    case 188: self = .method
-    case 192: self = .finalize
-    case 193: self = .hash
-    case 194: self = .dealloc
-    case 197: self = .superclass
-    case 198: self = .retain
-    case 199: self = .release
-    case 200: self = .autorelease
-    case 201: self = .retainCount
-    case 202: self = .zone
-    case 203: self = .isProxy
-    case 204: self = .copy
-    case 205: self = .mutableCopy
-    case 206: self = .classForCoder
-    case 207: self = .clear
-    case 208: self = .data
-    case 209: self = .delimitedData
-    case 210: self = .descriptor
-    case 211: self = .extensionRegistry
-    case 212: self = .extensionsCurrentlySet
-    case 213: self = .isInitialized
-    case 214: self = .serializedSize
-    case 215: self = .sortedExtensionsInUse
-    case 216: self = .unknownFields
-    case 217: self = .fixed
-    case 218: self = .fract
-    case 219: self = .size
-    case 220: self = .logicalAddress
-    case 221: self = .physicalAddress
-    case 222: self = .byteCount
-    case 223: self = .byteOffset
-    case 224: self = .duration
-    case 225: self = .absoluteTime
-    case 226: self = .optionBits
-    case 227: self = .itemCount
-    case 228: self = .pbversion
-    case 229: self = .scriptCode
-    case 230: self = .langCode
-    case 231: self = .regionCode
-    case 232: self = .ostype
-    case 233: self = .processSerialNumber
-    case 234: self = .point
-    case 235: self = .rect
-    case 236: self = .fixedPoint
-    case 237: self = .fixedRect
-    case 238: self = .style
-    case 239: self = .styleParameter
-    case 240: self = .styleField
-    case 241: self = .timeScale
-    case 242: self = .timeBase
-    case 243: self = .timeRecord
-    case 244: self = .extensions
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .a: return 0
-    case .string: return 1
-    case .int: return 2
-    case .double: return 3
-    case .float: return 4
-    case .uint: return 5
-    case .hashValue_: return 6
-    case .description_: return 7
-    case .debugDescription_: return 8
-    case .swift: return 9
-    case .unrecognized: return 10
-    case .class: return 11
-    case .deinit: return 12
-    case .enum: return 13
-    case .extension: return 14
-    case .func: return 15
-    case .import: return 16
-    case .init_: return 17
-    case .inout: return 18
-    case .internal: return 19
-    case .let: return 20
-    case .operator: return 21
-    case .private: return 22
-    case .protocol: return 23
-    case .public: return 24
-    case .static: return 25
-    case .struct: return 26
-    case .subscript: return 27
-    case .typealias: return 28
-    case .var: return 29
-    case .break: return 30
-    case .case: return 31
-    case .continue: return 32
-    case .default: return 33
-    case .defer: return 34
-    case .do: return 35
-    case .else: return 36
-    case .fallthrough: return 37
-    case .for: return 38
-    case .guard: return 39
-    case .if: return 40
-    case .in: return 41
-    case .repeat: return 42
-    case .return: return 43
-    case .switch: return 44
-    case .where: return 45
-    case .while: return 46
-    case .as: return 47
-    case .catch: return 48
-    case .dynamicType_: return 49
-    case .false: return 50
-    case .is: return 51
-    case .nil: return 52
-    case .rethrows: return 53
-    case .super: return 54
-    case .self_: return 55
-    case .throw: return 57
-    case .throws: return 58
-    case .true: return 59
-    case .try: return 60
-    case ._Column__: return 61
-    case ._File__: return 62
-    case ._Function__: return 63
-    case ._Line__: return 64
-    case .___: return 65
-    case .associativity: return 66
-    case .convenience: return 67
-    case .dynamic: return 68
-    case .didSet: return 69
-    case .final: return 70
-    case .get: return 71
-    case .infix: return 72
-    case .indirect: return 73
-    case .lazy: return 74
-    case .left: return 75
-    case .mutating: return 76
-    case .none: return 77
-    case .nonmutating: return 78
-    case .optional: return 79
-    case .override: return 80
-    case .postfix: return 81
-    case .precedence: return 82
-    case .prefix: return 83
-    case .required: return 85
-    case .right: return 86
-    case .set: return 87
-    case .type: return 88
-    case .unowned: return 89
-    case .weak: return 90
-    case .willSet: return 91
-    case .cmd: return 93
-    case .out: return 96
-    case .bycopy: return 98
-    case .byref: return 99
-    case .oneway: return 100
-    case .and: return 102
-    case .andEq: return 103
-    case .alignas: return 104
-    case .alignof: return 105
-    case .asm: return 106
-    case .auto: return 107
-    case .bitand: return 108
-    case .bitor: return 109
-    case .bool: return 110
-    case .char: return 114
-    case .char16T: return 115
-    case .char32T: return 116
-    case .compl: return 118
-    case .const: return 119
-    case .constexpr: return 120
-    case .constCast: return 121
-    case .decltype: return 123
-    case .delete: return 125
-    case .dynamicCast: return 127
-    case .explicit: return 130
-    case .export: return 131
-    case .extern: return 132
-    case .friend: return 136
-    case .goto: return 137
-    case .inline: return 139
-    case .long: return 141
-    case .mutable: return 142
-    case .namespace: return 143
-    case .new: return 144
-    case .noexcept: return 145
-    case .not: return 146
-    case .notEq: return 147
-    case .nullptr: return 148
-    case .or: return 150
-    case .orEq: return 151
-    case .protected: return 153
-    case .register: return 155
-    case .reinterpretCast: return 156
-    case .short: return 158
-    case .signed: return 159
-    case .sizeof: return 160
-    case .staticAssert: return 162
-    case .staticCast: return 163
-    case .template: return 166
-    case .this: return 167
-    case .threadLocal: return 168
-    case .typedef: return 172
-    case .typeid: return 173
-    case .typename: return 174
-    case .union: return 175
-    case .unsigned: return 176
-    case .using: return 177
-    case .virtual: return 178
-    case .void: return 179
-    case .volatile: return 180
-    case .wcharT: return 181
-    case .xor: return 183
-    case .xorEq: return 184
-    case .restrict: return 185
-    case .category: return 186
-    case .ivar: return 187
-    case .method: return 188
-    case .finalize: return 192
-    case .hash: return 193
-    case .dealloc: return 194
-    case .superclass: return 197
-    case .retain: return 198
-    case .release: return 199
-    case .autorelease: return 200
-    case .retainCount: return 201
-    case .zone: return 202
-    case .isProxy: return 203
-    case .copy: return 204
-    case .mutableCopy: return 205
-    case .classForCoder: return 206
-    case .clear: return 207
-    case .data: return 208
-    case .delimitedData: return 209
-    case .descriptor: return 210
-    case .extensionRegistry: return 211
-    case .extensionsCurrentlySet: return 212
-    case .isInitialized: return 213
-    case .serializedSize: return 214
-    case .sortedExtensionsInUse: return 215
-    case .unknownFields: return 216
-    case .fixed: return 217
-    case .fract: return 218
-    case .size: return 219
-    case .logicalAddress: return 220
-    case .physicalAddress: return 221
-    case .byteCount: return 222
-    case .byteOffset: return 223
-    case .duration: return 224
-    case .absoluteTime: return 225
-    case .optionBits: return 226
-    case .itemCount: return 227
-    case .pbversion: return 228
-    case .scriptCode: return 229
-    case .langCode: return 230
-    case .regionCode: return 231
-    case .ostype: return 232
-    case .processSerialNumber: return 233
-    case .point: return 234
-    case .rect: return 235
-    case .fixedPoint: return 236
-    case .fixedRect: return 237
-    case .style: return 238
-    case .styleParameter: return 239
-    case .styleField: return 240
-    case .timeScale: return 241
-    case .timeBase: return 242
-    case .timeRecord: return 243
-    case .extensions: return 244
-    }
-  }
-
 }
 
-enum SwiftProtoTesting_Names_EnumFieldNames2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case aa // = 0
+enum SwiftProtoTesting_Names_EnumFieldNames2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case aa = 0
 
   /// protoc no longer allows enum naming that would differ only in underscores.
   /// Initial commit:
@@ -695,25 +266,10 @@ enum SwiftProtoTesting_Names_EnumFieldNames2: SwiftProtobuf.Enum, Swift.CaseIter
   ///   https://github.com/protocolbuffers/protobuf/pull/2204
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
-  case ____ // = 1065
+  case ____ = 1065
 
   init() {
     self = .aa
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .aa
-    case 1065: self = .____
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .aa: return 0
-    case .____: return 1065
-    }
   }
 
 }
@@ -7251,4855 +6807,1901 @@ struct SwiftProtoTesting_Names_EnumNames: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum StringEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aString // = 0
+  enum StringEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aString = 0
 
     init() {
       self = .aString
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aString
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aString: return 0
-      }
-    }
-
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aProtocol // = 0
+  enum ProtocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aProtocol = 0
 
     init() {
       self = .aProtocol
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aProtocol
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aProtocol: return 0
-      }
-    }
-
   }
 
-  enum IntEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aInt // = 0
+  enum IntEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aInt = 0
 
     init() {
       self = .aInt
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aInt
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aInt: return 0
-      }
-    }
-
   }
 
-  enum DoubleEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aDouble // = 0
+  enum DoubleEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aDouble = 0
 
     init() {
       self = .aDouble
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aDouble
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aDouble: return 0
-      }
-    }
-
   }
 
-  enum FloatEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFloat // = 0
+  enum FloatEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFloat = 0
 
     init() {
       self = .aFloat
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFloat
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFloat: return 0
-      }
-    }
-
   }
 
-  enum UIntEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aUint // = 0
+  enum UIntEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aUint = 0
 
     init() {
       self = .aUint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aUint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aUint: return 0
-      }
-    }
-
   }
 
-  enum hashValueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ahashValue // = 0
+  enum hashValueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ahashValue = 0
 
     init() {
       self = .ahashValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ahashValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ahashValue: return 0
-      }
-    }
-
   }
 
-  enum descriptionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adescription // = 0
+  enum descriptionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adescription = 0
 
     init() {
       self = .adescription
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adescription
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adescription: return 0
-      }
-    }
-
   }
 
-  enum debugDescriptionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adebugDescription // = 0
+  enum debugDescriptionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adebugDescription = 0
 
     init() {
       self = .adebugDescription
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adebugDescription
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adebugDescription: return 0
-      }
-    }
-
   }
 
-  enum SwiftEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aSwift // = 0
+  enum SwiftEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aSwift = 0
 
     init() {
       self = .aSwift
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aSwift
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aSwift: return 0
-      }
-    }
-
   }
 
-  enum UNRECOGNIZED: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aUnrecognized // = 0
+  enum UNRECOGNIZED: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aUnrecognized = 0
 
     init() {
       self = .aUnrecognized
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aUnrecognized
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aUnrecognized: return 0
-      }
-    }
-
   }
 
-  enum classEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclass // = 0
+  enum classEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclass = 0
 
     init() {
       self = .aclass
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclass
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclass: return 0
-      }
-    }
-
   }
 
-  enum deinitEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adeinit // = 0
+  enum deinitEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adeinit = 0
 
     init() {
       self = .adeinit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adeinit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adeinit: return 0
-      }
-    }
-
   }
 
-  enum enumEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aenum // = 0
+  enum enumEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aenum = 0
 
     init() {
       self = .aenum
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aenum
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aenum: return 0
-      }
-    }
-
   }
 
-  enum extensionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextension // = 0
+  enum extensionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextension = 0
 
     init() {
       self = .aextension
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextension
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextension: return 0
-      }
-    }
-
   }
 
-  enum funcEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afunc // = 0
+  enum funcEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afunc = 0
 
     init() {
       self = .afunc
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afunc
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afunc: return 0
-      }
-    }
-
   }
 
-  enum importEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aimport // = 0
+  enum importEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aimport = 0
 
     init() {
       self = .aimport
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aimport
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aimport: return 0
-      }
-    }
-
   }
 
-  enum initEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainit // = 0
+  enum initEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainit = 0
 
     init() {
       self = .ainit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainit: return 0
-      }
-    }
-
   }
 
-  enum inoutEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainout // = 0
+  enum inoutEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainout = 0
 
     init() {
       self = .ainout
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainout
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainout: return 0
-      }
-    }
-
   }
 
-  enum internalEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainternal // = 0
+  enum internalEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainternal = 0
 
     init() {
       self = .ainternal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainternal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainternal: return 0
-      }
-    }
-
   }
 
-  enum letEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case alet // = 0
+  enum letEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case alet = 0
 
     init() {
       self = .alet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .alet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .alet: return 0
-      }
-    }
-
   }
 
-  enum operatorEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoperator // = 0
+  enum operatorEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoperator = 0
 
     init() {
       self = .aoperator
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoperator
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoperator: return 0
-      }
-    }
-
   }
 
-  enum privateEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprivate // = 0
+  enum privateEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprivate = 0
 
     init() {
       self = .aprivate
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprivate
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprivate: return 0
-      }
-    }
-
   }
 
-  enum protocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprotocol // = 0
+  enum protocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprotocol = 0
 
     init() {
       self = .aprotocol
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprotocol
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprotocol: return 0
-      }
-    }
-
   }
 
-  enum publicEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case apublic // = 0
+  enum publicEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case apublic = 0
 
     init() {
       self = .apublic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .apublic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .apublic: return 0
-      }
-    }
-
   }
 
-  enum staticEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astatic // = 0
+  enum staticEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astatic = 0
 
     init() {
       self = .astatic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astatic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astatic: return 0
-      }
-    }
-
   }
 
-  enum structEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astruct // = 0
+  enum structEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astruct = 0
 
     init() {
       self = .astruct
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astruct
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astruct: return 0
-      }
-    }
-
   }
 
-  enum subscriptEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asubscript // = 0
+  enum subscriptEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asubscript = 0
 
     init() {
       self = .asubscript
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asubscript
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asubscript: return 0
-      }
-    }
-
   }
 
-  enum typealiasEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypealias // = 0
+  enum typealiasEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypealias = 0
 
     init() {
       self = .atypealias
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypealias
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypealias: return 0
-      }
-    }
-
   }
 
-  enum varEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avar // = 0
+  enum varEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avar = 0
 
     init() {
       self = .avar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avar: return 0
-      }
-    }
-
   }
 
-  enum breakEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abreak // = 0
+  enum breakEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abreak = 0
 
     init() {
       self = .abreak
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abreak
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abreak: return 0
-      }
-    }
-
   }
 
-  enum caseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acase // = 0
+  enum caseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acase = 0
 
     init() {
       self = .acase
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acase
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acase: return 0
-      }
-    }
-
   }
 
-  enum continueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acontinue // = 0
+  enum continueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acontinue = 0
 
     init() {
       self = .acontinue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acontinue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acontinue: return 0
-      }
-    }
-
   }
 
-  enum defaultEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adefault // = 0
+  enum defaultEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adefault = 0
 
     init() {
       self = .adefault
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adefault
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adefault: return 0
-      }
-    }
-
   }
 
-  enum deferEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adefer // = 0
+  enum deferEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adefer = 0
 
     init() {
       self = .adefer
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adefer
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adefer: return 0
-      }
-    }
-
   }
 
-  enum doEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ado // = 0
+  enum doEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ado = 0
 
     init() {
       self = .ado
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ado
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ado: return 0
-      }
-    }
-
   }
 
-  enum elseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aelse // = 0
+  enum elseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aelse = 0
 
     init() {
       self = .aelse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aelse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aelse: return 0
-      }
-    }
-
   }
 
-  enum fallthroughEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afallthrough // = 0
+  enum fallthroughEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afallthrough = 0
 
     init() {
       self = .afallthrough
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afallthrough
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afallthrough: return 0
-      }
-    }
-
   }
 
-  enum forEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afor // = 0
+  enum forEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afor = 0
 
     init() {
       self = .afor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afor: return 0
-      }
-    }
-
   }
 
-  enum guardEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aguard // = 0
+  enum guardEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aguard = 0
 
     init() {
       self = .aguard
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aguard
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aguard: return 0
-      }
-    }
-
   }
 
-  enum ifEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aif // = 0
+  enum ifEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aif = 0
 
     init() {
       self = .aif
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aif
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aif: return 0
-      }
-    }
-
   }
 
-  enum inEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ain // = 0
+  enum inEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ain = 0
 
     init() {
       self = .ain
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ain
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ain: return 0
-      }
-    }
-
   }
 
-  enum repeatEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arepeat // = 0
+  enum repeatEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arepeat = 0
 
     init() {
       self = .arepeat
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arepeat
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arepeat: return 0
-      }
-    }
-
   }
 
-  enum returnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case areturn // = 0
+  enum returnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case areturn = 0
 
     init() {
       self = .areturn
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .areturn
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .areturn: return 0
-      }
-    }
-
   }
 
-  enum switchEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aswitch // = 0
+  enum switchEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aswitch = 0
 
     init() {
       self = .aswitch
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aswitch
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aswitch: return 0
-      }
-    }
-
   }
 
-  enum whereEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awhere // = 0
+  enum whereEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awhere = 0
 
     init() {
       self = .awhere
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awhere
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awhere: return 0
-      }
-    }
-
   }
 
-  enum whileEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awhile // = 0
+  enum whileEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awhile = 0
 
     init() {
       self = .awhile
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awhile
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awhile: return 0
-      }
-    }
-
   }
 
-  enum asEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aas // = 0
+  enum asEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aas = 0
 
     init() {
       self = .aas
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aas
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aas: return 0
-      }
-    }
-
   }
 
-  enum catchEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acatch // = 0
+  enum catchEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acatch = 0
 
     init() {
       self = .acatch
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acatch
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acatch: return 0
-      }
-    }
-
   }
 
-  enum dynamicTypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamicType // = 0
+  enum dynamicTypeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamicType = 0
 
     init() {
       self = .adynamicType
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamicType
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamicType: return 0
-      }
-    }
-
   }
 
-  enum falseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afalse // = 0
+  enum falseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afalse = 0
 
     init() {
       self = .afalse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afalse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afalse: return 0
-      }
-    }
-
   }
 
-  enum isEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ais // = 0
+  enum isEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ais = 0
 
     init() {
       self = .ais
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ais
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ais: return 0
-      }
-    }
-
   }
 
-  enum nilEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anil // = 0
+  enum nilEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anil = 0
 
     init() {
       self = .anil
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anil
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anil: return 0
-      }
-    }
-
   }
 
-  enum rethrowsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arethrows // = 0
+  enum rethrowsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arethrows = 0
 
     init() {
       self = .arethrows
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arethrows
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arethrows: return 0
-      }
-    }
-
   }
 
-  enum superEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asuper // = 0
+  enum superEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asuper = 0
 
     init() {
       self = .asuper
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asuper
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asuper: return 0
-      }
-    }
-
   }
 
-  enum selfEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aself // = 0
+  enum selfEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aself = 0
 
     init() {
       self = .aself
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aself
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aself: return 0
-      }
-    }
-
   }
 
-  enum throwEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athrow // = 0
+  enum throwEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athrow = 0
 
     init() {
       self = .athrow
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athrow
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athrow: return 0
-      }
-    }
-
   }
 
-  enum throwsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athrows // = 0
+  enum throwsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athrows = 0
 
     init() {
       self = .athrows
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athrows
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athrows: return 0
-      }
-    }
-
   }
 
-  enum trueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atrue // = 0
+  enum trueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atrue = 0
 
     init() {
       self = .atrue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atrue: return 0
-      }
-    }
-
   }
 
-  enum tryEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atry // = 0
+  enum tryEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atry = 0
 
     init() {
       self = .atry
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atry
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atry: return 0
-      }
-    }
-
   }
 
-  enum __COLUMN__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Column__ // = 0
+  enum __COLUMN__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Column__ = 0
 
     init() {
       self = .a_Column__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Column__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Column__: return 0
-      }
-    }
-
   }
 
-  enum __FILE__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_File__ // = 0
+  enum __FILE__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_File__ = 0
 
     init() {
       self = .a_File__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_File__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_File__: return 0
-      }
-    }
-
   }
 
-  enum __FUNCTION__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Function__ // = 0
+  enum __FUNCTION__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Function__ = 0
 
     init() {
       self = .a_Function__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Function__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Function__: return 0
-      }
-    }
-
   }
 
-  enum __LINE__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Line__ // = 0
+  enum __LINE__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Line__ = 0
 
     init() {
       self = .a_Line__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Line__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Line__: return 0
-      }
-    }
-
   }
 
-  enum _Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_ // = 0
+  enum _Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_ = 0
 
     init() {
       self = .a_
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_: return 0
-      }
-    }
-
   }
 
-  enum __Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a__ // = 0
+  enum __Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a__ = 0
 
     init() {
       self = .a__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a__: return 0
-      }
-    }
-
   }
 
-  enum associativity: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aassociativity // = 0
+  enum associativity: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aassociativity = 0
 
     init() {
       self = .aassociativity
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aassociativity
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aassociativity: return 0
-      }
-    }
-
   }
 
-  enum convenience: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconvenience // = 0
+  enum convenience: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconvenience = 0
 
     init() {
       self = .aconvenience
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconvenience
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconvenience: return 0
-      }
-    }
-
   }
 
-  enum dynamic: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamic // = 0
+  enum dynamic: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamic = 0
 
     init() {
       self = .adynamic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamic: return 0
-      }
-    }
-
   }
 
-  enum didSet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adidSet // = 0
+  enum didSet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adidSet = 0
 
     init() {
       self = .adidSet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adidSet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adidSet: return 0
-      }
-    }
-
   }
 
-  enum final: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afinal // = 0
+  enum final: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afinal = 0
 
     init() {
       self = .afinal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afinal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afinal: return 0
-      }
-    }
-
   }
 
-  enum get: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aget // = 0
+  enum get: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aget = 0
 
     init() {
       self = .aget
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aget
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aget: return 0
-      }
-    }
-
   }
 
-  enum infix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainfix // = 0
+  enum infix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainfix = 0
 
     init() {
       self = .ainfix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainfix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainfix: return 0
-      }
-    }
-
   }
 
-  enum indirect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aindirect // = 0
+  enum indirect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aindirect = 0
 
     init() {
       self = .aindirect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aindirect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aindirect: return 0
-      }
-    }
-
   }
 
-  enum lazy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case alazy // = 0
+  enum lazy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case alazy = 0
 
     init() {
       self = .alazy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .alazy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .alazy: return 0
-      }
-    }
-
   }
 
-  enum left: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aleft // = 0
+  enum left: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aleft = 0
 
     init() {
       self = .aleft
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aleft
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aleft: return 0
-      }
-    }
-
   }
 
-  enum mutating: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutating // = 0
+  enum mutating: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutating = 0
 
     init() {
       self = .amutating
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutating
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutating: return 0
-      }
-    }
-
   }
 
-  enum none: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anone // = 0
+  enum none: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anone = 0
 
     init() {
       self = .anone
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anone
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anone: return 0
-      }
-    }
-
   }
 
-  enum nonmutating: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anonmutating // = 0
+  enum nonmutating: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anonmutating = 0
 
     init() {
       self = .anonmutating
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anonmutating
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anonmutating: return 0
-      }
-    }
-
   }
 
-  enum optional: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoptional // = 0
+  enum optional: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoptional = 0
 
     init() {
       self = .aoptional
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoptional
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoptional: return 0
-      }
-    }
-
   }
 
-  enum override: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoverride // = 0
+  enum override: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoverride = 0
 
     init() {
       self = .aoverride
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoverride
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoverride: return 0
-      }
-    }
-
   }
 
-  enum postfix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case apostfix // = 0
+  enum postfix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case apostfix = 0
 
     init() {
       self = .apostfix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .apostfix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .apostfix: return 0
-      }
-    }
-
   }
 
-  enum precedence: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprecedence // = 0
+  enum precedence: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprecedence = 0
 
     init() {
       self = .aprecedence
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprecedence
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprecedence: return 0
-      }
-    }
-
   }
 
-  enum prefix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprefix // = 0
+  enum prefix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprefix = 0
 
     init() {
       self = .aprefix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprefix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprefix: return 0
-      }
-    }
-
   }
 
-  enum required: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arequired // = 0
+  enum required: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arequired = 0
 
     init() {
       self = .arequired
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arequired
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arequired: return 0
-      }
-    }
-
   }
 
-  enum right: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aright // = 0
+  enum right: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aright = 0
 
     init() {
       self = .aright
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aright
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aright: return 0
-      }
-    }
-
   }
 
-  enum set: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aset // = 0
+  enum set: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aset = 0
 
     init() {
       self = .aset
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aset
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aset: return 0
-      }
-    }
-
   }
 
-  enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aType // = 0
+  enum TypeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aType = 0
 
     init() {
       self = .aType
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aType
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aType: return 0
-      }
-    }
-
   }
 
-  enum unowned: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunowned // = 0
+  enum unowned: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunowned = 0
 
     init() {
       self = .aunowned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunowned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunowned: return 0
-      }
-    }
-
   }
 
-  enum weak: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aweak // = 0
+  enum weak: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aweak = 0
 
     init() {
       self = .aweak
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aweak
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aweak: return 0
-      }
-    }
-
   }
 
-  enum willSet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awillSet // = 0
+  enum willSet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awillSet = 0
 
     init() {
       self = .awillSet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awillSet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awillSet: return 0
-      }
-    }
-
   }
 
-  enum id: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aid // = 0
+  enum id: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aid = 0
 
     init() {
       self = .aid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aid: return 0
-      }
-    }
-
   }
 
-  enum _cmd: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aCmd // = 0
+  enum _cmd: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aCmd = 0
 
     init() {
       self = .aCmd
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aCmd
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aCmd: return 0
-      }
-    }
-
   }
 
-  enum out: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aout // = 0
+  enum out: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aout = 0
 
     init() {
       self = .aout
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aout
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aout: return 0
-      }
-    }
-
   }
 
-  enum bycopy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abycopy // = 0
+  enum bycopy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abycopy = 0
 
     init() {
       self = .abycopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abycopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abycopy: return 0
-      }
-    }
-
   }
 
-  enum byref: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abyref // = 0
+  enum byref: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abyref = 0
 
     init() {
       self = .abyref
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abyref
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abyref: return 0
-      }
-    }
-
   }
 
-  enum oneway: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoneway // = 0
+  enum oneway: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoneway = 0
 
     init() {
       self = .aoneway
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoneway
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoneway: return 0
-      }
-    }
-
   }
 
-  enum and: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aand // = 0
+  enum and: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aand = 0
 
     init() {
       self = .aand
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aand
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aand: return 0
-      }
-    }
-
   }
 
-  enum and_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aandEq // = 0
+  enum and_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aandEq = 0
 
     init() {
       self = .aandEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aandEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aandEq: return 0
-      }
-    }
-
   }
 
-  enum alignas: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aalignas // = 0
+  enum alignas: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aalignas = 0
 
     init() {
       self = .aalignas
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aalignas
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aalignas: return 0
-      }
-    }
-
   }
 
-  enum alignof: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aalignof // = 0
+  enum alignof: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aalignof = 0
 
     init() {
       self = .aalignof
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aalignof
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aalignof: return 0
-      }
-    }
-
   }
 
-  enum asm: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aasm // = 0
+  enum asm: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aasm = 0
 
     init() {
       self = .aasm
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aasm
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aasm: return 0
-      }
-    }
-
   }
 
-  enum auto: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aauto // = 0
+  enum auto: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aauto = 0
 
     init() {
       self = .aauto
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aauto
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aauto: return 0
-      }
-    }
-
   }
 
-  enum bitand: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abitand // = 0
+  enum bitand: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abitand = 0
 
     init() {
       self = .abitand
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abitand
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abitand: return 0
-      }
-    }
-
   }
 
-  enum bitor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abitor // = 0
+  enum bitor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abitor = 0
 
     init() {
       self = .abitor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abitor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abitor: return 0
-      }
-    }
-
   }
 
-  enum bool: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abool // = 0
+  enum bool: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abool = 0
 
     init() {
       self = .abool
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abool
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abool: return 0
-      }
-    }
-
   }
 
-  enum char: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar // = 0
+  enum char: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar = 0
 
     init() {
       self = .achar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar: return 0
-      }
-    }
-
   }
 
-  enum char16_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar16T // = 0
+  enum char16_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar16T = 0
 
     init() {
       self = .achar16T
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar16T
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar16T: return 0
-      }
-    }
-
   }
 
-  enum char32_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar32T // = 0
+  enum char32_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar32T = 0
 
     init() {
       self = .achar32T
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar32T
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar32T: return 0
-      }
-    }
-
   }
 
-  enum compl: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acompl // = 0
+  enum compl: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acompl = 0
 
     init() {
       self = .acompl
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acompl
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acompl: return 0
-      }
-    }
-
   }
 
-  enum const: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconst // = 0
+  enum const: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconst = 0
 
     init() {
       self = .aconst
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconst
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconst: return 0
-      }
-    }
-
   }
 
-  enum constexpr: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconstexpr // = 0
+  enum constexpr: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconstexpr = 0
 
     init() {
       self = .aconstexpr
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconstexpr
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconstexpr: return 0
-      }
-    }
-
   }
 
-  enum const_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconstCast // = 0
+  enum const_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconstCast = 0
 
     init() {
       self = .aconstCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconstCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconstCast: return 0
-      }
-    }
-
   }
 
-  enum decltype: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adecltype // = 0
+  enum decltype: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adecltype = 0
 
     init() {
       self = .adecltype
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adecltype
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adecltype: return 0
-      }
-    }
-
   }
 
-  enum delete: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adelete // = 0
+  enum delete: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adelete = 0
 
     init() {
       self = .adelete
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adelete
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adelete: return 0
-      }
-    }
-
   }
 
-  enum dynamic_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamicCast // = 0
+  enum dynamic_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamicCast = 0
 
     init() {
       self = .adynamicCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamicCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamicCast: return 0
-      }
-    }
-
   }
 
-  enum explicit: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aexplicit // = 0
+  enum explicit: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aexplicit = 0
 
     init() {
       self = .aexplicit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aexplicit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aexplicit: return 0
-      }
-    }
-
   }
 
-  enum export: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aexport // = 0
+  enum export: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aexport = 0
 
     init() {
       self = .aexport
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aexport
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aexport: return 0
-      }
-    }
-
   }
 
-  enum extern: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextern // = 0
+  enum extern: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextern = 0
 
     init() {
       self = .aextern
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextern
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextern: return 0
-      }
-    }
-
   }
 
-  enum friend: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afriend // = 0
+  enum friend: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afriend = 0
 
     init() {
       self = .afriend
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afriend
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afriend: return 0
-      }
-    }
-
   }
 
-  enum goto: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case agoto // = 0
+  enum goto: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case agoto = 0
 
     init() {
       self = .agoto
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .agoto
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .agoto: return 0
-      }
-    }
-
   }
 
-  enum inline: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainline // = 0
+  enum inline: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainline = 0
 
     init() {
       self = .ainline
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainline
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainline: return 0
-      }
-    }
-
   }
 
-  enum long: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case along // = 0
+  enum long: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case along = 0
 
     init() {
       self = .along
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .along
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .along: return 0
-      }
-    }
-
   }
 
-  enum mutable: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutable // = 0
+  enum mutable: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutable = 0
 
     init() {
       self = .amutable
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutable
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutable: return 0
-      }
-    }
-
   }
 
-  enum namespace: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anamespace // = 0
+  enum namespace: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anamespace = 0
 
     init() {
       self = .anamespace
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anamespace
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anamespace: return 0
-      }
-    }
-
   }
 
-  enum new: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anew // = 0
+  enum new: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anew = 0
 
     init() {
       self = .anew
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anew
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anew: return 0
-      }
-    }
-
   }
 
-  enum noexcept: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anoexcept // = 0
+  enum noexcept: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anoexcept = 0
 
     init() {
       self = .anoexcept
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anoexcept
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anoexcept: return 0
-      }
-    }
-
   }
 
-  enum not: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anot // = 0
+  enum not: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anot = 0
 
     init() {
       self = .anot
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anot
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anot: return 0
-      }
-    }
-
   }
 
-  enum not_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anotEq // = 0
+  enum not_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anotEq = 0
 
     init() {
       self = .anotEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anotEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anotEq: return 0
-      }
-    }
-
   }
 
-  enum nullptr: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anullptr // = 0
+  enum nullptr: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anullptr = 0
 
     init() {
       self = .anullptr
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anullptr
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anullptr: return 0
-      }
-    }
-
   }
 
-  enum or: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aor // = 0
+  enum or: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aor = 0
 
     init() {
       self = .aor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aor: return 0
-      }
-    }
-
   }
 
-  enum or_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aorEq // = 0
+  enum or_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aorEq = 0
 
     init() {
       self = .aorEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aorEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aorEq: return 0
-      }
-    }
-
   }
 
-  enum protected: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprotected // = 0
+  enum protected: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprotected = 0
 
     init() {
       self = .aprotected
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprotected
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprotected: return 0
-      }
-    }
-
   }
 
-  enum register: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aregister // = 0
+  enum register: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aregister = 0
 
     init() {
       self = .aregister
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aregister
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aregister: return 0
-      }
-    }
-
   }
 
-  enum reinterpret_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case areinterpretCast // = 0
+  enum reinterpret_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case areinterpretCast = 0
 
     init() {
       self = .areinterpretCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .areinterpretCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .areinterpretCast: return 0
-      }
-    }
-
   }
 
-  enum short: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ashort // = 0
+  enum short: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ashort = 0
 
     init() {
       self = .ashort
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ashort
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ashort: return 0
-      }
-    }
-
   }
 
-  enum signed: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asigned // = 0
+  enum signed: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asigned = 0
 
     init() {
       self = .asigned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asigned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asigned: return 0
-      }
-    }
-
   }
 
-  enum sizeof: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asizeof // = 0
+  enum sizeof: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asizeof = 0
 
     init() {
       self = .asizeof
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asizeof
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asizeof: return 0
-      }
-    }
-
   }
 
-  enum static_assert: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astaticAssert // = 0
+  enum static_assert: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astaticAssert = 0
 
     init() {
       self = .astaticAssert
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astaticAssert
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astaticAssert: return 0
-      }
-    }
-
   }
 
-  enum static_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astaticCast // = 0
+  enum static_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astaticCast = 0
 
     init() {
       self = .astaticCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astaticCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astaticCast: return 0
-      }
-    }
-
   }
 
-  enum template: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atemplate // = 0
+  enum template: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atemplate = 0
 
     init() {
       self = .atemplate
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atemplate
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atemplate: return 0
-      }
-    }
-
   }
 
-  enum this: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athis // = 0
+  enum this: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athis = 0
 
     init() {
       self = .athis
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athis
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athis: return 0
-      }
-    }
-
   }
 
-  enum thread_local: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athreadLocal // = 0
+  enum thread_local: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athreadLocal = 0
 
     init() {
       self = .athreadLocal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athreadLocal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athreadLocal: return 0
-      }
-    }
-
   }
 
-  enum typedef: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypedef // = 0
+  enum typedef: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypedef = 0
 
     init() {
       self = .atypedef
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypedef
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypedef: return 0
-      }
-    }
-
   }
 
-  enum typeid: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypeid // = 0
+  enum typeid: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypeid = 0
 
     init() {
       self = .atypeid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypeid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypeid: return 0
-      }
-    }
-
   }
 
-  enum typename: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypename // = 0
+  enum typename: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypename = 0
 
     init() {
       self = .atypename
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypename
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypename: return 0
-      }
-    }
-
   }
 
-  enum union: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunion // = 0
+  enum union: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunion = 0
 
     init() {
       self = .aunion
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunion
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunion: return 0
-      }
-    }
-
   }
 
-  enum unsigned: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunsigned // = 0
+  enum unsigned: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunsigned = 0
 
     init() {
       self = .aunsigned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunsigned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunsigned: return 0
-      }
-    }
-
   }
 
-  enum using: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ausing // = 0
+  enum using: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ausing = 0
 
     init() {
       self = .ausing
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ausing
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ausing: return 0
-      }
-    }
-
   }
 
-  enum virtual: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avirtual // = 0
+  enum virtual: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avirtual = 0
 
     init() {
       self = .avirtual
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avirtual
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avirtual: return 0
-      }
-    }
-
   }
 
-  enum void: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avoid // = 0
+  enum void: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avoid = 0
 
     init() {
       self = .avoid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avoid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avoid: return 0
-      }
-    }
-
   }
 
-  enum volatile: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avolatile // = 0
+  enum volatile: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avolatile = 0
 
     init() {
       self = .avolatile
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avolatile
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avolatile: return 0
-      }
-    }
-
   }
 
-  enum wchar_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awcharT // = 0
+  enum wchar_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awcharT = 0
 
     init() {
       self = .awcharT
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awcharT
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awcharT: return 0
-      }
-    }
-
   }
 
-  enum xor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case axor // = 0
+  enum xor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case axor = 0
 
     init() {
       self = .axor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .axor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .axor: return 0
-      }
-    }
-
   }
 
-  enum xor_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case axorEq // = 0
+  enum xor_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case axorEq = 0
 
     init() {
       self = .axorEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .axorEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .axorEq: return 0
-      }
-    }
-
   }
 
-  enum restrict: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arestrict // = 0
+  enum restrict: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arestrict = 0
 
     init() {
       self = .arestrict
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arestrict
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arestrict: return 0
-      }
-    }
-
   }
 
-  enum Category: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aCategory // = 0
+  enum Category: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aCategory = 0
 
     init() {
       self = .aCategory
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aCategory
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aCategory: return 0
-      }
-    }
-
   }
 
-  enum Ivar: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aIvar // = 0
+  enum Ivar: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aIvar = 0
 
     init() {
       self = .aIvar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aIvar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aIvar: return 0
-      }
-    }
-
   }
 
-  enum Method: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aMethod // = 0
+  enum Method: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aMethod = 0
 
     init() {
       self = .aMethod
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aMethod
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aMethod: return 0
-      }
-    }
-
   }
 
-  enum finalize: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afinalize // = 0
+  enum finalize: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afinalize = 0
 
     init() {
       self = .afinalize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afinalize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afinalize: return 0
-      }
-    }
-
   }
 
-  enum hash: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ahash // = 0
+  enum hash: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ahash = 0
 
     init() {
       self = .ahash
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ahash
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ahash: return 0
-      }
-    }
-
   }
 
-  enum dealloc: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adealloc // = 0
+  enum dealloc: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adealloc = 0
 
     init() {
       self = .adealloc
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adealloc
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adealloc: return 0
-      }
-    }
-
   }
 
-  enum superclass: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asuperclass // = 0
+  enum superclass: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asuperclass = 0
 
     init() {
       self = .asuperclass
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asuperclass
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asuperclass: return 0
-      }
-    }
-
   }
 
-  enum retain: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aretain // = 0
+  enum retain: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aretain = 0
 
     init() {
       self = .aretain
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aretain
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aretain: return 0
-      }
-    }
-
   }
 
-  enum release: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arelease // = 0
+  enum release: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arelease = 0
 
     init() {
       self = .arelease
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arelease
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arelease: return 0
-      }
-    }
-
   }
 
-  enum autorelease: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aautorelease // = 0
+  enum autorelease: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aautorelease = 0
 
     init() {
       self = .aautorelease
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aautorelease
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aautorelease: return 0
-      }
-    }
-
   }
 
-  enum retainCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aretainCount // = 0
+  enum retainCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aretainCount = 0
 
     init() {
       self = .aretainCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aretainCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aretainCount: return 0
-      }
-    }
-
   }
 
-  enum zone: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case azone // = 0
+  enum zone: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case azone = 0
 
     init() {
       self = .azone
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .azone
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .azone: return 0
-      }
-    }
-
   }
 
-  enum isProxy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aisProxy // = 0
+  enum isProxy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aisProxy = 0
 
     init() {
       self = .aisProxy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aisProxy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aisProxy: return 0
-      }
-    }
-
   }
 
-  enum copy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acopy // = 0
+  enum copy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acopy = 0
 
     init() {
       self = .acopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acopy: return 0
-      }
-    }
-
   }
 
-  enum mutableCopy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutableCopy // = 0
+  enum mutableCopy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutableCopy = 0
 
     init() {
       self = .amutableCopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutableCopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutableCopy: return 0
-      }
-    }
-
   }
 
-  enum classForCoder: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclassForCoder // = 0
+  enum classForCoder: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclassForCoder = 0
 
     init() {
       self = .aclassForCoder
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclassForCoder
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclassForCoder: return 0
-      }
-    }
-
   }
 
-  enum clear: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclear // = 0
+  enum clear: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclear = 0
 
     init() {
       self = .aclear
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclear
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclear: return 0
-      }
-    }
-
   }
 
-  enum data: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adata // = 0
+  enum data: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adata = 0
 
     init() {
       self = .adata
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adata
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adata: return 0
-      }
-    }
-
   }
 
-  enum delimitedData: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adelimitedData // = 0
+  enum delimitedData: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adelimitedData = 0
 
     init() {
       self = .adelimitedData
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adelimitedData
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adelimitedData: return 0
-      }
-    }
-
   }
 
-  enum descriptor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adescriptor // = 0
+  enum descriptor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adescriptor = 0
 
     init() {
       self = .adescriptor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adescriptor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adescriptor: return 0
-      }
-    }
-
   }
 
-  enum extensionRegistry: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextensionRegistry // = 0
+  enum extensionRegistry: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextensionRegistry = 0
 
     init() {
       self = .aextensionRegistry
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextensionRegistry
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextensionRegistry: return 0
-      }
-    }
-
   }
 
-  enum extensionsCurrentlySet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextensionsCurrentlySet // = 0
+  enum extensionsCurrentlySet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextensionsCurrentlySet = 0
 
     init() {
       self = .aextensionsCurrentlySet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextensionsCurrentlySet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextensionsCurrentlySet: return 0
-      }
-    }
-
   }
 
-  enum isInitializedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aisInitialized // = 0
+  enum isInitializedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aisInitialized = 0
 
     init() {
       self = .aisInitialized
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aisInitialized
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aisInitialized: return 0
-      }
-    }
-
   }
 
-  enum serializedSize: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aserializedSize // = 0
+  enum serializedSize: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aserializedSize = 0
 
     init() {
       self = .aserializedSize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aserializedSize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aserializedSize: return 0
-      }
-    }
-
   }
 
-  enum sortedExtensionsInUse: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asortedExtensionsInUse // = 0
+  enum sortedExtensionsInUse: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asortedExtensionsInUse = 0
 
     init() {
       self = .asortedExtensionsInUse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asortedExtensionsInUse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asortedExtensionsInUse: return 0
-      }
-    }
-
   }
 
-  enum unknownFieldsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunknownFields // = 0
+  enum unknownFieldsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunknownFields = 0
 
     init() {
       self = .aunknownFields
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunknownFields
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunknownFields: return 0
-      }
-    }
-
   }
 
-  enum Fixed: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixed // = 0
+  enum Fixed: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixed = 0
 
     init() {
       self = .aFixed
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixed
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixed: return 0
-      }
-    }
-
   }
 
-  enum Fract: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFract // = 0
+  enum Fract: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFract = 0
 
     init() {
       self = .aFract
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFract
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFract: return 0
-      }
-    }
-
   }
 
-  enum Size: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aSize // = 0
+  enum Size: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aSize = 0
 
     init() {
       self = .aSize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aSize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aSize: return 0
-      }
-    }
-
   }
 
-  enum LogicalAddress: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aLogicalAddress // = 0
+  enum LogicalAddress: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aLogicalAddress = 0
 
     init() {
       self = .aLogicalAddress
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aLogicalAddress
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aLogicalAddress: return 0
-      }
-    }
-
   }
 
-  enum PhysicalAddress: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPhysicalAddress // = 0
+  enum PhysicalAddress: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPhysicalAddress = 0
 
     init() {
       self = .aPhysicalAddress
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPhysicalAddress
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPhysicalAddress: return 0
-      }
-    }
-
   }
 
-  enum ByteCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aByteCount // = 0
+  enum ByteCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aByteCount = 0
 
     init() {
       self = .aByteCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aByteCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aByteCount: return 0
-      }
-    }
-
   }
 
-  enum ByteOffset: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aByteOffset // = 0
+  enum ByteOffset: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aByteOffset = 0
 
     init() {
       self = .aByteOffset
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aByteOffset
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aByteOffset: return 0
-      }
-    }
-
   }
 
-  enum Duration: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aDuration // = 0
+  enum Duration: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aDuration = 0
 
     init() {
       self = .aDuration
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aDuration
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aDuration: return 0
-      }
-    }
-
   }
 
-  enum AbsoluteTime: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aAbsoluteTime // = 0
+  enum AbsoluteTime: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aAbsoluteTime = 0
 
     init() {
       self = .aAbsoluteTime
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aAbsoluteTime
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aAbsoluteTime: return 0
-      }
-    }
-
   }
 
-  enum OptionBits: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aOptionBits // = 0
+  enum OptionBits: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aOptionBits = 0
 
     init() {
       self = .aOptionBits
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aOptionBits
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aOptionBits: return 0
-      }
-    }
-
   }
 
-  enum ItemCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aItemCount // = 0
+  enum ItemCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aItemCount = 0
 
     init() {
       self = .aItemCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aItemCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aItemCount: return 0
-      }
-    }
-
   }
 
-  enum PBVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPbversion // = 0
+  enum PBVersion: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPbversion = 0
 
     init() {
       self = .aPbversion
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPbversion
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPbversion: return 0
-      }
-    }
-
   }
 
-  enum ScriptCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aScriptCode // = 0
+  enum ScriptCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aScriptCode = 0
 
     init() {
       self = .aScriptCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aScriptCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aScriptCode: return 0
-      }
-    }
-
   }
 
-  enum LangCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aLangCode // = 0
+  enum LangCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aLangCode = 0
 
     init() {
       self = .aLangCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aLangCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aLangCode: return 0
-      }
-    }
-
   }
 
-  enum RegionCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aRegionCode // = 0
+  enum RegionCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aRegionCode = 0
 
     init() {
       self = .aRegionCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aRegionCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aRegionCode: return 0
-      }
-    }
-
   }
 
-  enum OSType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aOstype // = 0
+  enum OSType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aOstype = 0
 
     init() {
       self = .aOstype
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aOstype
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aOstype: return 0
-      }
-    }
-
   }
 
-  enum ProcessSerialNumber: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aProcessSerialNumber // = 0
+  enum ProcessSerialNumber: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aProcessSerialNumber = 0
 
     init() {
       self = .aProcessSerialNumber
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aProcessSerialNumber
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aProcessSerialNumber: return 0
-      }
-    }
-
   }
 
-  enum Point: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPoint // = 0
+  enum Point: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPoint = 0
 
     init() {
       self = .aPoint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPoint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPoint: return 0
-      }
-    }
-
   }
 
-  enum Rect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aRect // = 0
+  enum Rect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aRect = 0
 
     init() {
       self = .aRect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aRect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aRect: return 0
-      }
-    }
-
   }
 
-  enum FixedPoint: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixedPoint // = 0
+  enum FixedPoint: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixedPoint = 0
 
     init() {
       self = .aFixedPoint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixedPoint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixedPoint: return 0
-      }
-    }
-
   }
 
-  enum FixedRect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixedRect // = 0
+  enum FixedRect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixedRect = 0
 
     init() {
       self = .aFixedRect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixedRect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixedRect: return 0
-      }
-    }
-
   }
 
-  enum Style: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyle // = 0
+  enum Style: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyle = 0
 
     init() {
       self = .aStyle
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyle
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyle: return 0
-      }
-    }
-
   }
 
-  enum StyleParameter: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyleParameter // = 0
+  enum StyleParameter: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyleParameter = 0
 
     init() {
       self = .aStyleParameter
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyleParameter
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyleParameter: return 0
-      }
-    }
-
   }
 
-  enum StyleField: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyleField // = 0
+  enum StyleField: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyleField = 0
 
     init() {
       self = .aStyleField
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyleField
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyleField: return 0
-      }
-    }
-
   }
 
-  enum TimeScale: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeScale // = 0
+  enum TimeScale: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeScale = 0
 
     init() {
       self = .aTimeScale
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeScale
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeScale: return 0
-      }
-    }
-
   }
 
-  enum TimeBase: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeBase // = 0
+  enum TimeBase: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeBase = 0
 
     init() {
       self = .aTimeBase
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeBase
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeBase: return 0
-      }
-    }
-
   }
 
-  enum TimeRecord: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeRecord // = 0
+  enum TimeRecord: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeRecord = 0
 
     init() {
       self = .aTimeRecord
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeRecord
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeRecord: return 0
-      }
-    }
-
   }
 
-  enum Extension: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aExtension // = 0
+  enum Extension: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aExtension = 0
 
     init() {
       self = .aExtension
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aExtension
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aExtension: return 0
-      }
-    }
-
   }
 
-  enum ExtensionsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aExtensions // = 0
+  enum ExtensionsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aExtensions = 0
 
     init() {
       self = .aExtensions
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aExtensions
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aExtensions: return 0
-      }
     }
 
   }
@@ -12769,42 +9371,22 @@ struct SwiftProtoTesting_Names_ValidIdentifiers: Sendable {
 
   }
 
-  enum TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum TestEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
 
     /// Won't prefix strip
-    case testEnum0 // = 0
+    case testEnum0 = 0
 
     /// Will prefix strip
-    case first // = 1
+    case first = 1
 
     /// Leading underscore & number, keeps that.
-    case _2 // = 2
+    case _2 = 2
 
     /// Leading underscore & number, keeps that.
-    case _3Value // = 3
+    case _3Value = 3
 
     init() {
       self = .testEnum0
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .testEnum0
-      case 1: self = .first
-      case 2: self = ._2
-      case 3: self = ._3Value
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .testEnum0: return 0
-      case .first: return 1
-      case ._2: return 2
-      case ._3Value: return 3
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -118,63 +118,25 @@ struct SwiftProtoTesting_SwiftReservedTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case double // = 1
-    case json // = 2
-    case `class` // = 3
-    case ___ // = 4
-    case self_ // = 5
-    case type // = 6
+  enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case double = 1
+    case json = 2
+    case `class` = 3
+    case ___ = 4
+    case self_ = 5
+    case type = 6
 
     init() {
       self = .double
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .double
-      case 2: self = .json
-      case 3: self = .class
-      case 4: self = .___
-      case 5: self = .self_
-      case 6: self = .type
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .double: return 1
-      case .json: return 2
-      case .class: return 3
-      case .___: return 4
-      case .self_: return 5
-      case .type: return 6
-      }
-    }
-
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a // = 1
+  enum ProtocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a = 1
 
     init() {
       self = .a
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .a
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a: return 1
-      }
     }
 
   }

--- a/Reference/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -576,34 +576,14 @@ struct SwiftProtoTesting_Message2: @unchecked Sendable {
 
   }
 
-  enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
-    case extra2 // = 20
+  enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
+    case extra2 = 20
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      case 20: self = .extra2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      case .extra2: return 20
-      }
     }
 
   }

--- a/Reference/upstream/editions/golden/test_messages_proto2_editions.pb.swift
+++ b/Reference/upstream/editions/golden/test_messages_proto2_editions.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2: SwiftProtobuf.Ex
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Editions_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllRequiredTypesProto2: SwiftPro
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/upstream/google/protobuf/compiler/plugin.pb.swift
@@ -224,31 +224,13 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Sync with code_generator.h.
-  enum Feature: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case none // = 0
-    case proto3Optional // = 1
-    case supportsEditions // = 2
+  enum Feature: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case none = 0
+    case proto3Optional = 1
+    case supportsEditions = 2
 
     init() {
       self = .none
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .none
-      case 1: self = .proto3Optional
-      case 2: self = .supportsEditions
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .none: return 0
-      case .proto3Optional: return 1
-      case .supportsEditions: return 2
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/cpp_features.pb.swift
+++ b/Reference/upstream/google/protobuf/cpp_features.pb.swift
@@ -65,34 +65,14 @@ struct Pb_CppFeatures: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum StringType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case view // = 1
-    case cord // = 2
-    case string // = 3
+  enum StringType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unknown = 0
+    case view = 1
+    case cord = 2
+    case string = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .view
-      case 2: self = .cord
-      case 3: self = .string
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .view: return 1
-      case .cord: return 2
-      case .string: return 3
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/descriptor.pb.swift
+++ b/Reference/upstream/google/protobuf/descriptor.pb.swift
@@ -60,79 +60,43 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck 
 }
 
 /// The full set of known editions.
-enum Google_Protobuf_Edition: Enum, Swift.CaseIterable {
-  typealias RawValue = Int
+enum Google_Protobuf_Edition: Int, Enum, Swift.CaseIterable {
 
   /// A placeholder for an unknown edition value.
-  case unknown // = 0
+  case unknown = 0
 
   /// A placeholder edition for specifying default behaviors *before* a feature
   /// was first introduced.  This is effectively an "infinite past".
-  case legacy // = 900
+  case legacy = 900
 
   /// Legacy syntax "editions".  These pre-date editions, but behave much like
   /// distinct editions.  These can't be used to specify the edition of proto
   /// files, but feature definitions must supply proto2/proto3 defaults for
   /// backwards compatibility.
-  case proto2 // = 998
-  case proto3 // = 999
+  case proto2 = 998
+  case proto3 = 999
 
   /// Editions that have been released.  The specific values are arbitrary and
   /// should not be depended on, but they will always be time-ordered for easy
   /// comparison.
-  case edition2023 // = 1000
-  case edition2024 // = 1001
+  case edition2023 = 1000
+  case edition2024 = 1001
 
   /// Placeholder editions for testing feature resolution.  These should not be
   /// used or relied on outside of tests.
-  case edition1TestOnly // = 1
-  case edition2TestOnly // = 2
-  case edition99997TestOnly // = 99997
-  case edition99998TestOnly // = 99998
-  case edition99999TestOnly // = 99999
+  case edition1TestOnly = 1
+  case edition2TestOnly = 2
+  case edition99997TestOnly = 99997
+  case edition99998TestOnly = 99998
+  case edition99999TestOnly = 99999
 
   /// Placeholder for specifying unbounded edition support.  This should only
   /// ever be used by plugins that can expect to never require any changes to
   /// support a new edition.
-  case max // = 2147483647
+  case max = 2147483647
 
   init() {
     self = .unknown
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    case 1: self = .edition1TestOnly
-    case 2: self = .edition2TestOnly
-    case 900: self = .legacy
-    case 998: self = .proto2
-    case 999: self = .proto3
-    case 1000: self = .edition2023
-    case 1001: self = .edition2024
-    case 99997: self = .edition99997TestOnly
-    case 99998: self = .edition99998TestOnly
-    case 99999: self = .edition99999TestOnly
-    case 2147483647: self = .max
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    case .edition1TestOnly: return 1
-    case .edition2TestOnly: return 2
-    case .legacy: return 900
-    case .proto2: return 998
-    case .proto3: return 999
-    case .edition2023: return 1000
-    case .edition2024: return 1001
-    case .edition99997TestOnly: return 99997
-    case .edition99998TestOnly: return 99998
-    case .edition99999TestOnly: return 99999
-    case .max: return 2147483647
-    }
   }
 
 }
@@ -451,30 +415,14 @@ struct Google_Protobuf_ExtensionRangeOptions: ExtensibleMessage, Sendable {
   var unknownFields = UnknownStorage()
 
   /// The verification state of the extension range.
-  enum VerificationState: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum VerificationState: Int, Enum, Swift.CaseIterable {
 
     /// All the extensions of the range must be declared.
-    case declaration // = 0
-    case unverified // = 1
+    case declaration = 0
+    case unverified = 1
 
     init() {
       self = .declaration
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .declaration
-      case 1: self = .unverified
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .declaration: return 0
-      case .unverified: return 1
-      }
     }
 
   }
@@ -705,134 +653,68 @@ struct Google_Protobuf_FieldDescriptorProto: Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum TypeEnum: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum TypeEnum: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors.
     /// Order is weird for historical reasons.
-    case double // = 1
-    case float // = 2
+    case double = 1
+    case float = 2
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
     /// negative values are likely.
-    case int64 // = 3
-    case uint64 // = 4
+    case int64 = 3
+    case uint64 = 4
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
     /// negative values are likely.
-    case int32 // = 5
-    case fixed64 // = 6
-    case fixed32 // = 7
-    case bool // = 8
-    case string // = 9
+    case int32 = 5
+    case fixed64 = 6
+    case fixed32 = 7
+    case bool = 8
+    case string = 9
 
     /// Tag-delimited aggregate.
     /// Group type is deprecated and not supported after google.protobuf. However, Proto3
     /// implementations should still be able to parse the group wire format and
     /// treat group fields as unknown fields.  In Editions, the group wire format
     /// can be enabled via the `message_encoding` feature.
-    case group // = 10
+    case group = 10
 
     /// Length-delimited aggregate.
-    case message // = 11
+    case message = 11
 
     /// New in version 2.
-    case bytes // = 12
-    case uint32 // = 13
-    case `enum` // = 14
-    case sfixed32 // = 15
-    case sfixed64 // = 16
+    case bytes = 12
+    case uint32 = 13
+    case `enum` = 14
+    case sfixed32 = 15
+    case sfixed64 = 16
 
     /// Uses ZigZag encoding.
-    case sint32 // = 17
+    case sint32 = 17
 
     /// Uses ZigZag encoding.
-    case sint64 // = 18
+    case sint64 = 18
 
     init() {
       self = .double
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .double
-      case 2: self = .float
-      case 3: self = .int64
-      case 4: self = .uint64
-      case 5: self = .int32
-      case 6: self = .fixed64
-      case 7: self = .fixed32
-      case 8: self = .bool
-      case 9: self = .string
-      case 10: self = .group
-      case 11: self = .message
-      case 12: self = .bytes
-      case 13: self = .uint32
-      case 14: self = .enum
-      case 15: self = .sfixed32
-      case 16: self = .sfixed64
-      case 17: self = .sint32
-      case 18: self = .sint64
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .double: return 1
-      case .float: return 2
-      case .int64: return 3
-      case .uint64: return 4
-      case .int32: return 5
-      case .fixed64: return 6
-      case .fixed32: return 7
-      case .bool: return 8
-      case .string: return 9
-      case .group: return 10
-      case .message: return 11
-      case .bytes: return 12
-      case .uint32: return 13
-      case .enum: return 14
-      case .sfixed32: return 15
-      case .sfixed64: return 16
-      case .sint32: return 17
-      case .sint64: return 18
-      }
-    }
-
   }
 
-  enum Label: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum Label: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors
-    case `optional` // = 1
-    case repeated // = 3
+    case `optional` = 1
+    case repeated = 3
 
     /// The required label is only allowed in google.protobuf.  In proto3 and Editions
     /// it's explicitly prohibited.  In Editions, the `field_presence` feature
     /// can be used to get this behavior.
-    case `required` // = 2
+    case `required` = 2
 
     init() {
       self = .optional
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .optional
-      case 2: self = .required
-      case 3: self = .repeated
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .optional: return 1
-      case .required: return 2
-      case .repeated: return 3
-      }
     }
 
   }
@@ -1384,37 +1266,19 @@ struct Google_Protobuf_FileOptions: ExtensibleMessage, @unchecked Sendable {
   var unknownFields = UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  enum OptimizeMode: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum OptimizeMode: Int, Enum, Swift.CaseIterable {
 
     /// Generate complete code for parsing, serialization,
-    case speed // = 1
+    case speed = 1
 
     /// etc.
-    case codeSize // = 2
+    case codeSize = 2
 
     /// Generate code using MessageLite and the lite runtime.
-    case liteRuntime // = 3
+    case liteRuntime = 3
 
     init() {
       self = .speed
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .speed
-      case 2: self = .codeSize
-      case 3: self = .liteRuntime
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .speed: return 1
-      case .codeSize: return 2
-      case .liteRuntime: return 3
-      }
     }
 
   }
@@ -1745,11 +1609,10 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum CType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum CType: Int, Enum, Swift.CaseIterable {
 
     /// Default mode.
-    case string // = 0
+    case string = 0
 
     /// The option [ctype=CORD] may be applied to a non-repeated field of type
     /// "bytes". It indicates that in C++, the data should be stored in a Cord
@@ -1757,93 +1620,40 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
     /// fragmentation. It may also allow better performance when parsing from a
     /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
     /// alias the original buffer.
-    case cord // = 1
-    case stringPiece // = 2
+    case cord = 1
+    case stringPiece = 2
 
     init() {
       self = .string
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .string
-      case 1: self = .cord
-      case 2: self = .stringPiece
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .string: return 0
-      case .cord: return 1
-      case .stringPiece: return 2
-      }
-    }
-
   }
 
-  enum JSType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum JSType: Int, Enum, Swift.CaseIterable {
 
     /// Use the default type.
-    case jsNormal // = 0
+    case jsNormal = 0
 
     /// Use JavaScript strings.
-    case jsString // = 1
+    case jsString = 1
 
     /// Use JavaScript numbers.
-    case jsNumber // = 2
+    case jsNumber = 2
 
     init() {
       self = .jsNormal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .jsNormal
-      case 1: self = .jsString
-      case 2: self = .jsNumber
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .jsNormal: return 0
-      case .jsString: return 1
-      case .jsNumber: return 2
-      }
-    }
-
   }
 
   /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
-  enum OptionRetention: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case retentionUnknown // = 0
-    case retentionRuntime // = 1
-    case retentionSource // = 2
+  enum OptionRetention: Int, Enum, Swift.CaseIterable {
+    case retentionUnknown = 0
+    case retentionRuntime = 1
+    case retentionSource = 2
 
     init() {
       self = .retentionUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .retentionUnknown
-      case 1: self = .retentionRuntime
-      case 2: self = .retentionSource
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .retentionUnknown: return 0
-      case .retentionRuntime: return 1
-      case .retentionSource: return 2
-      }
     }
 
   }
@@ -1851,52 +1661,20 @@ struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendable {
   /// This indicates the types of entities that the field may apply to when used
   /// as an option. If it is unset, then the field may be freely used as an
   /// option on any kind of entity.
-  enum OptionTargetType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case targetTypeUnknown // = 0
-    case targetTypeFile // = 1
-    case targetTypeExtensionRange // = 2
-    case targetTypeMessage // = 3
-    case targetTypeField // = 4
-    case targetTypeOneof // = 5
-    case targetTypeEnum // = 6
-    case targetTypeEnumEntry // = 7
-    case targetTypeService // = 8
-    case targetTypeMethod // = 9
+  enum OptionTargetType: Int, Enum, Swift.CaseIterable {
+    case targetTypeUnknown = 0
+    case targetTypeFile = 1
+    case targetTypeExtensionRange = 2
+    case targetTypeMessage = 3
+    case targetTypeField = 4
+    case targetTypeOneof = 5
+    case targetTypeEnum = 6
+    case targetTypeEnumEntry = 7
+    case targetTypeService = 8
+    case targetTypeMethod = 9
 
     init() {
       self = .targetTypeUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .targetTypeUnknown
-      case 1: self = .targetTypeFile
-      case 2: self = .targetTypeExtensionRange
-      case 3: self = .targetTypeMessage
-      case 4: self = .targetTypeField
-      case 5: self = .targetTypeOneof
-      case 6: self = .targetTypeEnum
-      case 7: self = .targetTypeEnumEntry
-      case 8: self = .targetTypeService
-      case 9: self = .targetTypeMethod
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .targetTypeUnknown: return 0
-      case .targetTypeFile: return 1
-      case .targetTypeExtensionRange: return 2
-      case .targetTypeMessage: return 3
-      case .targetTypeField: return 4
-      case .targetTypeOneof: return 5
-      case .targetTypeEnum: return 6
-      case .targetTypeEnumEntry: return 7
-      case .targetTypeService: return 8
-      case .targetTypeMethod: return 9
-      }
     }
 
   }
@@ -2261,35 +2039,17 @@ struct Google_Protobuf_MethodOptions: ExtensibleMessage, Sendable {
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  enum IdempotencyLevel: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case idempotencyUnknown // = 0
+  enum IdempotencyLevel: Int, Enum, Swift.CaseIterable {
+    case idempotencyUnknown = 0
 
     /// implies idempotent
-    case noSideEffects // = 1
+    case noSideEffects = 1
 
     /// idempotent, but may have side effects
-    case idempotent // = 2
+    case idempotent = 2
 
     init() {
       self = .idempotencyUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .idempotencyUnknown
-      case 1: self = .noSideEffects
-      case 2: self = .idempotent
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .idempotencyUnknown: return 0
-      case .noSideEffects: return 1
-      case .idempotent: return 2
-      }
     }
 
   }
@@ -2486,179 +2246,69 @@ struct Google_Protobuf_FeatureSet: ExtensibleMessage, Sendable {
 
   var unknownFields = UnknownStorage()
 
-  enum FieldPresence: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case explicit // = 1
-    case implicit // = 2
-    case legacyRequired // = 3
+  enum FieldPresence: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case explicit = 1
+    case implicit = 2
+    case legacyRequired = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .explicit
-      case 2: self = .implicit
-      case 3: self = .legacyRequired
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .explicit: return 1
-      case .implicit: return 2
-      case .legacyRequired: return 3
-      }
     }
 
   }
 
-  enum EnumType: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case `open` // = 1
-    case closed // = 2
+  enum EnumType: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case `open` = 1
+    case closed = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .open
-      case 2: self = .closed
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .open: return 1
-      case .closed: return 2
-      }
     }
 
   }
 
-  enum RepeatedFieldEncoding: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case packed // = 1
-    case expanded // = 2
+  enum RepeatedFieldEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case packed = 1
+    case expanded = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .packed
-      case 2: self = .expanded
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .packed: return 1
-      case .expanded: return 2
-      }
     }
 
   }
 
-  enum Utf8Validation: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case verify // = 2
-    case none // = 3
+  enum Utf8Validation: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case verify = 2
+    case none = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 2: self = .verify
-      case 3: self = .none
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .verify: return 2
-      case .none: return 3
-      }
     }
 
   }
 
-  enum MessageEncoding: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case lengthPrefixed // = 1
-    case delimited // = 2
+  enum MessageEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case lengthPrefixed = 1
+    case delimited = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .lengthPrefixed
-      case 2: self = .delimited
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .lengthPrefixed: return 1
-      case .delimited: return 2
-      }
     }
 
   }
 
-  enum JsonFormat: Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case allow // = 1
-    case legacyBestEffort // = 2
+  enum JsonFormat: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case allow = 1
+    case legacyBestEffort = 2
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .allow
-      case 2: self = .legacyBestEffort
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .allow: return 1
-      case .legacyBestEffort: return 2
-      }
     }
 
   }
@@ -3002,37 +2652,19 @@ struct Google_Protobuf_GeneratedCodeInfo: Sendable {
 
     /// Represents the identified object's effect on the element in the original
     /// .proto file.
-    enum Semantic: Enum, Swift.CaseIterable {
-      typealias RawValue = Int
+    enum Semantic: Int, Enum, Swift.CaseIterable {
 
       /// There is no effect or the effect is indescribable.
-      case none // = 0
+      case none = 0
 
       /// The element is set or otherwise mutated.
-      case set // = 1
+      case set = 1
 
       /// An alias to the element is returned.
-      case alias // = 2
+      case alias = 2
 
       init() {
         self = .none
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .none
-        case 1: self = .set
-        case 2: self = .alias
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .none: return 0
-        case .set: return 1
-        case .alias: return 2
-        }
       }
 
     }

--- a/Reference/upstream/google/protobuf/edition_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/edition_unittest.pb.swift
@@ -37,70 +37,35 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum EditionUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 4
-  case foreignBar // = 5
-  case foreignBaz // = 6
+enum EditionUnittest_ForeignEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 4
+  case foreignBar = 5
+  case foreignBaz = 6
 
   /// (1 << 32) to generate a 64b bitmask would be incorrect.
-  case foreignBax // = 32
+  case foreignBax = 32
 
   init() {
     self = .foreignFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 4: self = .foreignFoo
-    case 5: self = .foreignBar
-    case 6: self = .foreignBaz
-    case 32: self = .foreignBax
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 4
-    case .foreignBar: return 5
-    case .foreignBaz: return 6
-    case .foreignBax: return 32
-    }
-  }
-
 }
 
-enum EditionUnittest_TestReservedEnumFields: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case unknown // = 0
+enum EditionUnittest_TestReservedEnumFields: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case unknown = 0
 
   init() {
     self = .unknown
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    }
-  }
-
 }
 
 /// Test an enum that has multiple values with the same number.
-enum EditionUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case dupUnknown1 // = 0
-  case dupFoo1 // = 1
-  case dupBar1 // = 2
-  case dupBaz // = 3
+enum EditionUnittest_TestEnumWithDupValue: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case dupUnknown1 = 0
+  case dupFoo1 = 1
+  case dupBar1 = 2
+  case dupBaz = 3
   static let dupUnknown2 = dupUnknown1
   static let dupFoo2 = dupFoo1
   static let dupBar2 = dupBar1
@@ -109,388 +74,129 @@ enum EditionUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterabl
     self = .dupUnknown1
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .dupUnknown1
-    case 1: self = .dupFoo1
-    case 2: self = .dupBar1
-    case 3: self = .dupBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .dupUnknown1: return 0
-    case .dupFoo1: return 1
-    case .dupBar1: return 2
-    case .dupBaz: return 3
-    }
-  }
-
 }
 
 /// Test an enum with large, unordered values.
-enum EditionUnittest_TestSparseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case sparseA // = 123
-  case sparseB // = 62374
-  case sparseC // = 12589234
-  case sparseD // = -15
-  case sparseE // = -53452
-  case sparseF // = 0
-  case sparseG // = 2
+enum EditionUnittest_TestSparseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case sparseA = 123
+  case sparseB = 62374
+  case sparseC = 12589234
+  case sparseD = -15
+  case sparseE = -53452
+  case sparseF = 0
+  case sparseG = 2
 
   init() {
     self = .sparseA
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case -53452: self = .sparseE
-    case -15: self = .sparseD
-    case 0: self = .sparseF
-    case 2: self = .sparseG
-    case 123: self = .sparseA
-    case 62374: self = .sparseB
-    case 12589234: self = .sparseC
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .sparseE: return -53452
-    case .sparseD: return -15
-    case .sparseF: return 0
-    case .sparseG: return 2
-    case .sparseA: return 123
-    case .sparseB: return 62374
-    case .sparseC: return 12589234
-    }
-  }
-
 }
 
-enum EditionUnittest_VeryLargeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case enumLabelDefault // = 0
-  case enumLabel1 // = 1
-  case enumLabel2 // = 2
-  case enumLabel3 // = 3
-  case enumLabel4 // = 4
-  case enumLabel5 // = 5
-  case enumLabel6 // = 6
-  case enumLabel7 // = 7
-  case enumLabel8 // = 8
-  case enumLabel9 // = 9
-  case enumLabel10 // = 10
-  case enumLabel11 // = 11
-  case enumLabel12 // = 12
-  case enumLabel13 // = 13
-  case enumLabel14 // = 14
-  case enumLabel15 // = 15
-  case enumLabel16 // = 16
-  case enumLabel17 // = 17
-  case enumLabel18 // = 18
-  case enumLabel19 // = 19
-  case enumLabel20 // = 20
-  case enumLabel21 // = 21
-  case enumLabel22 // = 22
-  case enumLabel23 // = 23
-  case enumLabel24 // = 24
-  case enumLabel25 // = 25
-  case enumLabel26 // = 26
-  case enumLabel27 // = 27
-  case enumLabel28 // = 28
-  case enumLabel29 // = 29
-  case enumLabel30 // = 30
-  case enumLabel31 // = 31
-  case enumLabel32 // = 32
-  case enumLabel33 // = 33
-  case enumLabel34 // = 34
-  case enumLabel35 // = 35
-  case enumLabel36 // = 36
-  case enumLabel37 // = 37
-  case enumLabel38 // = 38
-  case enumLabel39 // = 39
-  case enumLabel40 // = 40
-  case enumLabel41 // = 41
-  case enumLabel42 // = 42
-  case enumLabel43 // = 43
-  case enumLabel44 // = 44
-  case enumLabel45 // = 45
-  case enumLabel46 // = 46
-  case enumLabel47 // = 47
-  case enumLabel48 // = 48
-  case enumLabel49 // = 49
-  case enumLabel50 // = 50
-  case enumLabel51 // = 51
-  case enumLabel52 // = 52
-  case enumLabel53 // = 53
-  case enumLabel54 // = 54
-  case enumLabel55 // = 55
-  case enumLabel56 // = 56
-  case enumLabel57 // = 57
-  case enumLabel58 // = 58
-  case enumLabel59 // = 59
-  case enumLabel60 // = 60
-  case enumLabel61 // = 61
-  case enumLabel62 // = 62
-  case enumLabel63 // = 63
-  case enumLabel64 // = 64
-  case enumLabel65 // = 65
-  case enumLabel66 // = 66
-  case enumLabel67 // = 67
-  case enumLabel68 // = 68
-  case enumLabel69 // = 69
-  case enumLabel70 // = 70
-  case enumLabel71 // = 71
-  case enumLabel72 // = 72
-  case enumLabel73 // = 73
-  case enumLabel74 // = 74
-  case enumLabel75 // = 75
-  case enumLabel76 // = 76
-  case enumLabel77 // = 77
-  case enumLabel78 // = 78
-  case enumLabel79 // = 79
-  case enumLabel80 // = 80
-  case enumLabel81 // = 81
-  case enumLabel82 // = 82
-  case enumLabel83 // = 83
-  case enumLabel84 // = 84
-  case enumLabel85 // = 85
-  case enumLabel86 // = 86
-  case enumLabel87 // = 87
-  case enumLabel88 // = 88
-  case enumLabel89 // = 89
-  case enumLabel90 // = 90
-  case enumLabel91 // = 91
-  case enumLabel92 // = 92
-  case enumLabel93 // = 93
-  case enumLabel94 // = 94
-  case enumLabel95 // = 95
-  case enumLabel96 // = 96
-  case enumLabel97 // = 97
-  case enumLabel98 // = 98
-  case enumLabel99 // = 99
-  case enumLabel100 // = 100
+enum EditionUnittest_VeryLargeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case enumLabelDefault = 0
+  case enumLabel1 = 1
+  case enumLabel2 = 2
+  case enumLabel3 = 3
+  case enumLabel4 = 4
+  case enumLabel5 = 5
+  case enumLabel6 = 6
+  case enumLabel7 = 7
+  case enumLabel8 = 8
+  case enumLabel9 = 9
+  case enumLabel10 = 10
+  case enumLabel11 = 11
+  case enumLabel12 = 12
+  case enumLabel13 = 13
+  case enumLabel14 = 14
+  case enumLabel15 = 15
+  case enumLabel16 = 16
+  case enumLabel17 = 17
+  case enumLabel18 = 18
+  case enumLabel19 = 19
+  case enumLabel20 = 20
+  case enumLabel21 = 21
+  case enumLabel22 = 22
+  case enumLabel23 = 23
+  case enumLabel24 = 24
+  case enumLabel25 = 25
+  case enumLabel26 = 26
+  case enumLabel27 = 27
+  case enumLabel28 = 28
+  case enumLabel29 = 29
+  case enumLabel30 = 30
+  case enumLabel31 = 31
+  case enumLabel32 = 32
+  case enumLabel33 = 33
+  case enumLabel34 = 34
+  case enumLabel35 = 35
+  case enumLabel36 = 36
+  case enumLabel37 = 37
+  case enumLabel38 = 38
+  case enumLabel39 = 39
+  case enumLabel40 = 40
+  case enumLabel41 = 41
+  case enumLabel42 = 42
+  case enumLabel43 = 43
+  case enumLabel44 = 44
+  case enumLabel45 = 45
+  case enumLabel46 = 46
+  case enumLabel47 = 47
+  case enumLabel48 = 48
+  case enumLabel49 = 49
+  case enumLabel50 = 50
+  case enumLabel51 = 51
+  case enumLabel52 = 52
+  case enumLabel53 = 53
+  case enumLabel54 = 54
+  case enumLabel55 = 55
+  case enumLabel56 = 56
+  case enumLabel57 = 57
+  case enumLabel58 = 58
+  case enumLabel59 = 59
+  case enumLabel60 = 60
+  case enumLabel61 = 61
+  case enumLabel62 = 62
+  case enumLabel63 = 63
+  case enumLabel64 = 64
+  case enumLabel65 = 65
+  case enumLabel66 = 66
+  case enumLabel67 = 67
+  case enumLabel68 = 68
+  case enumLabel69 = 69
+  case enumLabel70 = 70
+  case enumLabel71 = 71
+  case enumLabel72 = 72
+  case enumLabel73 = 73
+  case enumLabel74 = 74
+  case enumLabel75 = 75
+  case enumLabel76 = 76
+  case enumLabel77 = 77
+  case enumLabel78 = 78
+  case enumLabel79 = 79
+  case enumLabel80 = 80
+  case enumLabel81 = 81
+  case enumLabel82 = 82
+  case enumLabel83 = 83
+  case enumLabel84 = 84
+  case enumLabel85 = 85
+  case enumLabel86 = 86
+  case enumLabel87 = 87
+  case enumLabel88 = 88
+  case enumLabel89 = 89
+  case enumLabel90 = 90
+  case enumLabel91 = 91
+  case enumLabel92 = 92
+  case enumLabel93 = 93
+  case enumLabel94 = 94
+  case enumLabel95 = 95
+  case enumLabel96 = 96
+  case enumLabel97 = 97
+  case enumLabel98 = 98
+  case enumLabel99 = 99
+  case enumLabel100 = 100
 
   init() {
     self = .enumLabelDefault
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .enumLabelDefault
-    case 1: self = .enumLabel1
-    case 2: self = .enumLabel2
-    case 3: self = .enumLabel3
-    case 4: self = .enumLabel4
-    case 5: self = .enumLabel5
-    case 6: self = .enumLabel6
-    case 7: self = .enumLabel7
-    case 8: self = .enumLabel8
-    case 9: self = .enumLabel9
-    case 10: self = .enumLabel10
-    case 11: self = .enumLabel11
-    case 12: self = .enumLabel12
-    case 13: self = .enumLabel13
-    case 14: self = .enumLabel14
-    case 15: self = .enumLabel15
-    case 16: self = .enumLabel16
-    case 17: self = .enumLabel17
-    case 18: self = .enumLabel18
-    case 19: self = .enumLabel19
-    case 20: self = .enumLabel20
-    case 21: self = .enumLabel21
-    case 22: self = .enumLabel22
-    case 23: self = .enumLabel23
-    case 24: self = .enumLabel24
-    case 25: self = .enumLabel25
-    case 26: self = .enumLabel26
-    case 27: self = .enumLabel27
-    case 28: self = .enumLabel28
-    case 29: self = .enumLabel29
-    case 30: self = .enumLabel30
-    case 31: self = .enumLabel31
-    case 32: self = .enumLabel32
-    case 33: self = .enumLabel33
-    case 34: self = .enumLabel34
-    case 35: self = .enumLabel35
-    case 36: self = .enumLabel36
-    case 37: self = .enumLabel37
-    case 38: self = .enumLabel38
-    case 39: self = .enumLabel39
-    case 40: self = .enumLabel40
-    case 41: self = .enumLabel41
-    case 42: self = .enumLabel42
-    case 43: self = .enumLabel43
-    case 44: self = .enumLabel44
-    case 45: self = .enumLabel45
-    case 46: self = .enumLabel46
-    case 47: self = .enumLabel47
-    case 48: self = .enumLabel48
-    case 49: self = .enumLabel49
-    case 50: self = .enumLabel50
-    case 51: self = .enumLabel51
-    case 52: self = .enumLabel52
-    case 53: self = .enumLabel53
-    case 54: self = .enumLabel54
-    case 55: self = .enumLabel55
-    case 56: self = .enumLabel56
-    case 57: self = .enumLabel57
-    case 58: self = .enumLabel58
-    case 59: self = .enumLabel59
-    case 60: self = .enumLabel60
-    case 61: self = .enumLabel61
-    case 62: self = .enumLabel62
-    case 63: self = .enumLabel63
-    case 64: self = .enumLabel64
-    case 65: self = .enumLabel65
-    case 66: self = .enumLabel66
-    case 67: self = .enumLabel67
-    case 68: self = .enumLabel68
-    case 69: self = .enumLabel69
-    case 70: self = .enumLabel70
-    case 71: self = .enumLabel71
-    case 72: self = .enumLabel72
-    case 73: self = .enumLabel73
-    case 74: self = .enumLabel74
-    case 75: self = .enumLabel75
-    case 76: self = .enumLabel76
-    case 77: self = .enumLabel77
-    case 78: self = .enumLabel78
-    case 79: self = .enumLabel79
-    case 80: self = .enumLabel80
-    case 81: self = .enumLabel81
-    case 82: self = .enumLabel82
-    case 83: self = .enumLabel83
-    case 84: self = .enumLabel84
-    case 85: self = .enumLabel85
-    case 86: self = .enumLabel86
-    case 87: self = .enumLabel87
-    case 88: self = .enumLabel88
-    case 89: self = .enumLabel89
-    case 90: self = .enumLabel90
-    case 91: self = .enumLabel91
-    case 92: self = .enumLabel92
-    case 93: self = .enumLabel93
-    case 94: self = .enumLabel94
-    case 95: self = .enumLabel95
-    case 96: self = .enumLabel96
-    case 97: self = .enumLabel97
-    case 98: self = .enumLabel98
-    case 99: self = .enumLabel99
-    case 100: self = .enumLabel100
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .enumLabelDefault: return 0
-    case .enumLabel1: return 1
-    case .enumLabel2: return 2
-    case .enumLabel3: return 3
-    case .enumLabel4: return 4
-    case .enumLabel5: return 5
-    case .enumLabel6: return 6
-    case .enumLabel7: return 7
-    case .enumLabel8: return 8
-    case .enumLabel9: return 9
-    case .enumLabel10: return 10
-    case .enumLabel11: return 11
-    case .enumLabel12: return 12
-    case .enumLabel13: return 13
-    case .enumLabel14: return 14
-    case .enumLabel15: return 15
-    case .enumLabel16: return 16
-    case .enumLabel17: return 17
-    case .enumLabel18: return 18
-    case .enumLabel19: return 19
-    case .enumLabel20: return 20
-    case .enumLabel21: return 21
-    case .enumLabel22: return 22
-    case .enumLabel23: return 23
-    case .enumLabel24: return 24
-    case .enumLabel25: return 25
-    case .enumLabel26: return 26
-    case .enumLabel27: return 27
-    case .enumLabel28: return 28
-    case .enumLabel29: return 29
-    case .enumLabel30: return 30
-    case .enumLabel31: return 31
-    case .enumLabel32: return 32
-    case .enumLabel33: return 33
-    case .enumLabel34: return 34
-    case .enumLabel35: return 35
-    case .enumLabel36: return 36
-    case .enumLabel37: return 37
-    case .enumLabel38: return 38
-    case .enumLabel39: return 39
-    case .enumLabel40: return 40
-    case .enumLabel41: return 41
-    case .enumLabel42: return 42
-    case .enumLabel43: return 43
-    case .enumLabel44: return 44
-    case .enumLabel45: return 45
-    case .enumLabel46: return 46
-    case .enumLabel47: return 47
-    case .enumLabel48: return 48
-    case .enumLabel49: return 49
-    case .enumLabel50: return 50
-    case .enumLabel51: return 51
-    case .enumLabel52: return 52
-    case .enumLabel53: return 53
-    case .enumLabel54: return 54
-    case .enumLabel55: return 55
-    case .enumLabel56: return 56
-    case .enumLabel57: return 57
-    case .enumLabel58: return 58
-    case .enumLabel59: return 59
-    case .enumLabel60: return 60
-    case .enumLabel61: return 61
-    case .enumLabel62: return 62
-    case .enumLabel63: return 63
-    case .enumLabel64: return 64
-    case .enumLabel65: return 65
-    case .enumLabel66: return 66
-    case .enumLabel67: return 67
-    case .enumLabel68: return 68
-    case .enumLabel69: return 69
-    case .enumLabel70: return 70
-    case .enumLabel71: return 71
-    case .enumLabel72: return 72
-    case .enumLabel73: return 73
-    case .enumLabel74: return 74
-    case .enumLabel75: return 75
-    case .enumLabel76: return 76
-    case .enumLabel77: return 77
-    case .enumLabel78: return 78
-    case .enumLabel79: return 79
-    case .enumLabel80: return 80
-    case .enumLabel81: return 81
-    case .enumLabel82: return 82
-    case .enumLabel83: return 83
-    case .enumLabel84: return 84
-    case .enumLabel85: return 85
-    case .enumLabel86: return 86
-    case .enumLabel87: return 87
-    case .enumLabel88: return 88
-    case .enumLabel89: return 89
-    case .enumLabel90: return 90
-    case .enumLabel91: return 91
-    case .enumLabel92: return 92
-    case .enumLabel93: return 93
-    case .enumLabel94: return 94
-    case .enumLabel95: return 95
-    case .enumLabel96: return 96
-    case .enumLabel97: return 97
-    case .enumLabel98: return 98
-    case .enumLabel99: return 99
-    case .enumLabel100: return 100
-    }
   }
 
 }
@@ -1139,36 +845,16 @@ struct EditionUnittest_TestAllTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -1863,36 +1549,16 @@ struct EditionUnittest_TestRequiredEnumNoMask: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 2
-    case bar // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 2
+    case bar = 100
 
     /// Intentionally negative.
-    case baz // = -1
+    case baz = -1
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .baz
-      case 0: self = .unspecified
-      case 2: self = .foo
-      case 100: self = .bar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .baz: return -1
-      case .unspecified: return 0
-      case .foo: return 2
-      case .bar: return 100
-      }
     }
 
   }
@@ -1948,34 +1614,14 @@ struct EditionUnittest_TestRequiredEnumMulti: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 100
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 100: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 100
-      }
     }
 
   }
@@ -2061,34 +1707,14 @@ struct EditionUnittest_TestRequiredNoMaskMulti: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 100
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 100: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 100
-      }
     }
 
   }
@@ -4582,34 +4208,14 @@ struct EditionUnittest_TestOneof2: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unknown = 0
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -4925,34 +4531,14 @@ struct EditionUnittest_TestDynamicExtensions: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum DynamicEnumType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case dynamicUnknown // = 0
-    case dynamicFoo // = 2200
-    case dynamicBar // = 2201
-    case dynamicBaz // = 2202
+  enum DynamicEnumType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case dynamicUnknown = 0
+    case dynamicFoo = 2200
+    case dynamicBar = 2201
+    case dynamicBaz = 2202
 
     init() {
       self = .dynamicUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .dynamicUnknown
-      case 2200: self = .dynamicFoo
-      case 2201: self = .dynamicBar
-      case 2202: self = .dynamicBaz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .dynamicUnknown: return 0
-      case .dynamicFoo: return 2200
-      case .dynamicBar: return 2201
-      case .dynamicBaz: return 2202
-      }
     }
 
   }
@@ -6994,226 +6580,82 @@ struct EditionUnittest_EnumParseTester: SwiftProtobuf.ExtensibleMessage, @unchec
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum SeqSmall0: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = 0
-    case seqSmall01 // = 1
-    case seqSmall02 // = 2
+  enum SeqSmall0: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = 0
+    case seqSmall01 = 1
+    case seqSmall02 = 2
 
     init() {
       self = .default
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .default
-      case 1: self = .seqSmall01
-      case 2: self = .seqSmall02
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .default: return 0
-      case .seqSmall01: return 1
-      case .seqSmall02: return 2
-      }
-    }
-
   }
 
-  enum SeqSmall1: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case `default` // = 1
-    case seqSmall12 // = 2
-    case seqSmall13 // = 3
+  enum SeqSmall1: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unknown = 0
+    case `default` = 1
+    case seqSmall12 = 2
+    case seqSmall13 = 3
 
     init() {
       self = .unknown
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .default
-      case 2: self = .seqSmall12
-      case 3: self = .seqSmall13
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .default: return 1
-      case .seqSmall12: return 2
-      case .seqSmall13: return 3
-      }
-    }
-
   }
 
-  enum SeqLarge: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = -1
-    case seqLarge0 // = 0
-    case seqLarge1 // = 1
-    case seqLarge2 // = 2
-    case seqLarge3 // = 3
-    case seqLarge4 // = 4
-    case seqLarge5 // = 5
-    case seqLarge6 // = 6
-    case seqLarge7 // = 7
-    case seqLarge8 // = 8
-    case seqLarge9 // = 9
-    case seqLarge10 // = 10
-    case seqLarge11 // = 11
-    case seqLarge12 // = 12
-    case seqLarge13 // = 13
-    case seqLarge14 // = 14
-    case seqLarge15 // = 15
-    case seqLarge16 // = 16
-    case seqLarge17 // = 17
-    case seqLarge18 // = 18
-    case seqLarge19 // = 19
-    case seqLarge20 // = 20
-    case seqLarge21 // = 21
-    case seqLarge22 // = 22
-    case seqLarge23 // = 23
-    case seqLarge24 // = 24
-    case seqLarge25 // = 25
-    case seqLarge26 // = 26
-    case seqLarge27 // = 27
-    case seqLarge28 // = 28
-    case seqLarge29 // = 29
-    case seqLarge30 // = 30
-    case seqLarge31 // = 31
-    case seqLarge32 // = 32
-    case seqLarge33 // = 33
+  enum SeqLarge: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = -1
+    case seqLarge0 = 0
+    case seqLarge1 = 1
+    case seqLarge2 = 2
+    case seqLarge3 = 3
+    case seqLarge4 = 4
+    case seqLarge5 = 5
+    case seqLarge6 = 6
+    case seqLarge7 = 7
+    case seqLarge8 = 8
+    case seqLarge9 = 9
+    case seqLarge10 = 10
+    case seqLarge11 = 11
+    case seqLarge12 = 12
+    case seqLarge13 = 13
+    case seqLarge14 = 14
+    case seqLarge15 = 15
+    case seqLarge16 = 16
+    case seqLarge17 = 17
+    case seqLarge18 = 18
+    case seqLarge19 = 19
+    case seqLarge20 = 20
+    case seqLarge21 = 21
+    case seqLarge22 = 22
+    case seqLarge23 = 23
+    case seqLarge24 = 24
+    case seqLarge25 = 25
+    case seqLarge26 = 26
+    case seqLarge27 = 27
+    case seqLarge28 = 28
+    case seqLarge29 = 29
+    case seqLarge30 = 30
+    case seqLarge31 = 31
+    case seqLarge32 = 32
+    case seqLarge33 = 33
 
     init() {
       self = .default
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .default
-      case 0: self = .seqLarge0
-      case 1: self = .seqLarge1
-      case 2: self = .seqLarge2
-      case 3: self = .seqLarge3
-      case 4: self = .seqLarge4
-      case 5: self = .seqLarge5
-      case 6: self = .seqLarge6
-      case 7: self = .seqLarge7
-      case 8: self = .seqLarge8
-      case 9: self = .seqLarge9
-      case 10: self = .seqLarge10
-      case 11: self = .seqLarge11
-      case 12: self = .seqLarge12
-      case 13: self = .seqLarge13
-      case 14: self = .seqLarge14
-      case 15: self = .seqLarge15
-      case 16: self = .seqLarge16
-      case 17: self = .seqLarge17
-      case 18: self = .seqLarge18
-      case 19: self = .seqLarge19
-      case 20: self = .seqLarge20
-      case 21: self = .seqLarge21
-      case 22: self = .seqLarge22
-      case 23: self = .seqLarge23
-      case 24: self = .seqLarge24
-      case 25: self = .seqLarge25
-      case 26: self = .seqLarge26
-      case 27: self = .seqLarge27
-      case 28: self = .seqLarge28
-      case 29: self = .seqLarge29
-      case 30: self = .seqLarge30
-      case 31: self = .seqLarge31
-      case 32: self = .seqLarge32
-      case 33: self = .seqLarge33
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .default: return -1
-      case .seqLarge0: return 0
-      case .seqLarge1: return 1
-      case .seqLarge2: return 2
-      case .seqLarge3: return 3
-      case .seqLarge4: return 4
-      case .seqLarge5: return 5
-      case .seqLarge6: return 6
-      case .seqLarge7: return 7
-      case .seqLarge8: return 8
-      case .seqLarge9: return 9
-      case .seqLarge10: return 10
-      case .seqLarge11: return 11
-      case .seqLarge12: return 12
-      case .seqLarge13: return 13
-      case .seqLarge14: return 14
-      case .seqLarge15: return 15
-      case .seqLarge16: return 16
-      case .seqLarge17: return 17
-      case .seqLarge18: return 18
-      case .seqLarge19: return 19
-      case .seqLarge20: return 20
-      case .seqLarge21: return 21
-      case .seqLarge22: return 22
-      case .seqLarge23: return 23
-      case .seqLarge24: return 24
-      case .seqLarge25: return 25
-      case .seqLarge26: return 26
-      case .seqLarge27: return 27
-      case .seqLarge28: return 28
-      case .seqLarge29: return 29
-      case .seqLarge30: return 30
-      case .seqLarge31: return 31
-      case .seqLarge32: return 32
-      case .seqLarge33: return 33
-      }
-    }
-
   }
 
-  enum Arbitrary: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = -123123
-    case arbitrary1 // = -123
-    case arbitrary2 // = 213
-    case arbitrary3 // = 213213
-    case min // = -2147483648
-    case max // = 2147483647
+  enum Arbitrary: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = -123123
+    case arbitrary1 = -123
+    case arbitrary2 = 213
+    case arbitrary3 = 213213
+    case min = -2147483648
+    case max = 2147483647
 
     init() {
       self = .default
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -2147483648: self = .min
-      case -123123: self = .default
-      case -123: self = .arbitrary1
-      case 213: self = .arbitrary2
-      case 213213: self = .arbitrary3
-      case 2147483647: self = .max
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .min: return -2147483648
-      case .default: return -123123
-      case .arbitrary1: return -123
-      case .arbitrary2: return 213
-      case .arbitrary3: return 213213
-      case .max: return 2147483647
-      }
     }
 
   }
@@ -7687,34 +7129,14 @@ struct EditionUnittest_TestPackedEnumSmallRange: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -7729,210 +7151,76 @@ struct EditionUnittest_EnumsForBenchmark: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Flat: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a0 // = 0
-    case a1 // = 1
-    case a2 // = 2
-    case a3 // = 3
-    case a4 // = 4
-    case a5 // = 5
-    case a6 // = 6
-    case a7 // = 7
-    case a8 // = 8
-    case a9 // = 9
-    case a10 // = 10
-    case a11 // = 11
-    case a12 // = 12
-    case a13 // = 13
-    case a14 // = 14
-    case a15 // = 15
+  enum Flat: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a0 = 0
+    case a1 = 1
+    case a2 = 2
+    case a3 = 3
+    case a4 = 4
+    case a5 = 5
+    case a6 = 6
+    case a7 = 7
+    case a8 = 8
+    case a9 = 9
+    case a10 = 10
+    case a11 = 11
+    case a12 = 12
+    case a13 = 13
+    case a14 = 14
+    case a15 = 15
 
     init() {
       self = .a0
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a0
-      case 1: self = .a1
-      case 2: self = .a2
-      case 3: self = .a3
-      case 4: self = .a4
-      case 5: self = .a5
-      case 6: self = .a6
-      case 7: self = .a7
-      case 8: self = .a8
-      case 9: self = .a9
-      case 10: self = .a10
-      case 11: self = .a11
-      case 12: self = .a12
-      case 13: self = .a13
-      case 14: self = .a14
-      case 15: self = .a15
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a0: return 0
-      case .a1: return 1
-      case .a2: return 2
-      case .a3: return 3
-      case .a4: return 4
-      case .a5: return 5
-      case .a6: return 6
-      case .a7: return 7
-      case .a8: return 8
-      case .a9: return 9
-      case .a10: return 10
-      case .a11: return 11
-      case .a12: return 12
-      case .a13: return 13
-      case .a14: return 14
-      case .a15: return 15
-      }
-    }
-
   }
 
   /// Has a few holes, bitmap can be used.
-  enum AlmostFlat: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case b0 // = 0
-    case b1 // = 1
-    case b2 // = 2
-    case b3 // = 3
-    case b5 // = 5
-    case b6 // = 6
-    case b7 // = 7
-    case b8 // = 8
-    case b9 // = 9
-    case b11 // = 11
-    case b12 // = 12
-    case b13 // = 13
-    case b14 // = 14
-    case b15 // = 15
-    case b17 // = 17
-    case b19 // = 19
+  enum AlmostFlat: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case b0 = 0
+    case b1 = 1
+    case b2 = 2
+    case b3 = 3
+    case b5 = 5
+    case b6 = 6
+    case b7 = 7
+    case b8 = 8
+    case b9 = 9
+    case b11 = 11
+    case b12 = 12
+    case b13 = 13
+    case b14 = 14
+    case b15 = 15
+    case b17 = 17
+    case b19 = 19
 
     init() {
       self = .b0
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .b0
-      case 1: self = .b1
-      case 2: self = .b2
-      case 3: self = .b3
-      case 5: self = .b5
-      case 6: self = .b6
-      case 7: self = .b7
-      case 8: self = .b8
-      case 9: self = .b9
-      case 11: self = .b11
-      case 12: self = .b12
-      case 13: self = .b13
-      case 14: self = .b14
-      case 15: self = .b15
-      case 17: self = .b17
-      case 19: self = .b19
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .b0: return 0
-      case .b1: return 1
-      case .b2: return 2
-      case .b3: return 3
-      case .b5: return 5
-      case .b6: return 6
-      case .b7: return 7
-      case .b8: return 8
-      case .b9: return 9
-      case .b11: return 11
-      case .b12: return 12
-      case .b13: return 13
-      case .b14: return 14
-      case .b15: return 15
-      case .b17: return 17
-      case .b19: return 19
-      }
-    }
-
   }
 
-  enum Sparse: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case c0 // = 0
-    case c536 // = 536
-    case c8387 // = 8387
-    case c9673 // = 9673
-    case c10285 // = 10285
-    case c13318 // = 13318
-    case c15963 // = 15963
-    case c16439 // = 16439
-    case c18197 // = 18197
-    case c19430 // = 19430
-    case c20361 // = 20361
-    case c20706 // = 20706
-    case c21050 // = 21050
-    case c21906 // = 21906
-    case c27265 // = 27265
-    case c30109 // = 30109
-    case c31670 // = 31670
+  enum Sparse: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case c0 = 0
+    case c536 = 536
+    case c8387 = 8387
+    case c9673 = 9673
+    case c10285 = 10285
+    case c13318 = 13318
+    case c15963 = 15963
+    case c16439 = 16439
+    case c18197 = 18197
+    case c19430 = 19430
+    case c20361 = 20361
+    case c20706 = 20706
+    case c21050 = 21050
+    case c21906 = 21906
+    case c27265 = 27265
+    case c30109 = 30109
+    case c31670 = 31670
 
     init() {
       self = .c0
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .c0
-      case 536: self = .c536
-      case 8387: self = .c8387
-      case 9673: self = .c9673
-      case 10285: self = .c10285
-      case 13318: self = .c13318
-      case 15963: self = .c15963
-      case 16439: self = .c16439
-      case 18197: self = .c18197
-      case 19430: self = .c19430
-      case 20361: self = .c20361
-      case 20706: self = .c20706
-      case 21050: self = .c21050
-      case 21906: self = .c21906
-      case 27265: self = .c27265
-      case 30109: self = .c30109
-      case 31670: self = .c31670
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .c0: return 0
-      case .c536: return 536
-      case .c8387: return 8387
-      case .c9673: return 9673
-      case .c10285: return 10285
-      case .c13318: return 13318
-      case .c15963: return 15963
-      case .c16439: return 16439
-      case .c18197: return 18197
-      case .c19430: return 19430
-      case .c20361: return 20361
-      case .c20706: return 20706
-      case .c21050: return 21050
-      case .c21906: return 21906
-      case .c27265: return 27265
-      case .c30109: return 30109
-      case .c31670: return 31670
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_lite_unittest.pb.swift
@@ -28,92 +28,36 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case proto2MapEnumFooLite // = 0
-  case proto2MapEnumBarLite // = 1
-  case proto2MapEnumBazLite // = 2
+enum ProtobufUnittest_Proto2MapEnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case proto2MapEnumFooLite = 0
+  case proto2MapEnumBarLite = 1
+  case proto2MapEnumBazLite = 2
 
   init() {
     self = .proto2MapEnumFooLite
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .proto2MapEnumFooLite
-    case 1: self = .proto2MapEnumBarLite
-    case 2: self = .proto2MapEnumBazLite
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .proto2MapEnumFooLite: return 0
-    case .proto2MapEnumBarLite: return 1
-    case .proto2MapEnumBazLite: return 2
-    }
-  }
-
 }
 
-enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case eProto2MapEnumFooLite // = 0
-  case eProto2MapEnumBarLite // = 1
-  case eProto2MapEnumBazLite // = 2
-  case eProto2MapEnumExtraLite // = 3
+enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case eProto2MapEnumFooLite = 0
+  case eProto2MapEnumBarLite = 1
+  case eProto2MapEnumBazLite = 2
+  case eProto2MapEnumExtraLite = 3
 
   init() {
     self = .eProto2MapEnumFooLite
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .eProto2MapEnumFooLite
-    case 1: self = .eProto2MapEnumBarLite
-    case 2: self = .eProto2MapEnumBazLite
-    case 3: self = .eProto2MapEnumExtraLite
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .eProto2MapEnumFooLite: return 0
-    case .eProto2MapEnumBarLite: return 1
-    case .eProto2MapEnumBazLite: return 2
-    case .eProto2MapEnumExtraLite: return 3
-    }
-  }
-
 }
 
-enum ProtobufUnittest_MapEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case mapEnumFooLite // = 0
-  case mapEnumBarLite // = 1
-  case mapEnumBazLite // = 2
+enum ProtobufUnittest_MapEnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case mapEnumFooLite = 0
+  case mapEnumBarLite = 1
+  case mapEnumBazLite = 2
 
   init() {
     self = .mapEnumFooLite
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .mapEnumFooLite
-    case 1: self = .mapEnumBarLite
-    case 2: self = .mapEnumBazLite
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .mapEnumFooLite: return 0
-    case .mapEnumBarLite: return 1
-    case .mapEnumBazLite: return 2
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/map_proto2_unittest.pb.swift
@@ -28,63 +28,25 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum ProtobufUnittest_Proto2MapEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
-  }
-
 }
 
-enum ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case eProto2MapEnumFoo // = 0
-  case eProto2MapEnumBar // = 1
-  case eProto2MapEnumBaz // = 2
-  case eProto2MapEnumExtra // = 3
+enum ProtobufUnittest_Proto2MapEnumPlusExtra: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case eProto2MapEnumFoo = 0
+  case eProto2MapEnumBar = 1
+  case eProto2MapEnumBaz = 2
+  case eProto2MapEnumExtra = 3
 
   init() {
     self = .eProto2MapEnumFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .eProto2MapEnumFoo
-    case 1: self = .eProto2MapEnumBar
-    case 2: self = .eProto2MapEnumBaz
-    case 3: self = .eProto2MapEnumExtra
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .eProto2MapEnumFoo: return 0
-    case .eProto2MapEnumBar: return 1
-    case .eProto2MapEnumBaz: return 2
-    case .eProto2MapEnumExtra: return 3
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/test_messages_proto2.pb.swift
+++ b/Reference/upstream/google/protobuf/test_messages_proto2.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Proto2_TestAllRequiredTypesProto2: SwiftProtobuf.Ext
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/unittest.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest.pb.swift
@@ -36,64 +36,28 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 4
-  case foreignBar // = 5
-  case foreignBaz // = 6
+enum ProtobufUnittest_ForeignEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 4
+  case foreignBar = 5
+  case foreignBaz = 6
 
   /// (1 << 32) to generate a 64b bitmask would be incorrect.
-  case foreignBax // = 32
+  case foreignBax = 32
 
   /// Large enough to escape the Boxed Integer cache.
-  case foreignLarge // = 123456
+  case foreignLarge = 123456
 
   init() {
     self = .foreignFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 4: self = .foreignFoo
-    case 5: self = .foreignBar
-    case 6: self = .foreignBaz
-    case 32: self = .foreignBax
-    case 123456: self = .foreignLarge
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 4
-    case .foreignBar: return 5
-    case .foreignBaz: return 6
-    case .foreignBax: return 32
-    case .foreignLarge: return 123456
-    }
-  }
-
 }
 
-enum ProtobufUnittest_TestReservedEnumFields: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case unknown // = 0
+enum ProtobufUnittest_TestReservedEnumFields: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case unknown = 0
 
   init() {
     self = .unknown
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    }
   }
 
 }
@@ -148,11 +112,10 @@ enum ProtobufUnittest_ForeignOpenEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
 }
 
 /// Test an enum that has multiple values with the same number.
-enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo1 // = 1
-  case bar1 // = 2
-  case baz // = 3
+enum ProtobufUnittest_TestEnumWithDupValue: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo1 = 1
+  case bar1 = 2
+  case baz = 3
   static let foo2 = foo1
   static let bar2 = bar1
 
@@ -160,386 +123,129 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterab
     self = .foo1
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .foo1
-    case 2: self = .bar1
-    case 3: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo1: return 1
-    case .bar1: return 2
-    case .baz: return 3
-    }
-  }
-
 }
 
 /// Test an enum with large, unordered values.
-enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case sparseA // = 123
-  case sparseB // = 62374
-  case sparseC // = 12589234
-  case sparseD // = -15
-  case sparseE // = -53452
-  case sparseF // = 0
-  case sparseG // = 2
+enum ProtobufUnittest_TestSparseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case sparseA = 123
+  case sparseB = 62374
+  case sparseC = 12589234
+  case sparseD = -15
+  case sparseE = -53452
+  case sparseF = 0
+  case sparseG = 2
 
   init() {
     self = .sparseA
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case -53452: self = .sparseE
-    case -15: self = .sparseD
-    case 0: self = .sparseF
-    case 2: self = .sparseG
-    case 123: self = .sparseA
-    case 62374: self = .sparseB
-    case 12589234: self = .sparseC
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .sparseE: return -53452
-    case .sparseD: return -15
-    case .sparseF: return 0
-    case .sparseG: return 2
-    case .sparseA: return 123
-    case .sparseB: return 62374
-    case .sparseC: return 12589234
-    }
-  }
-
 }
 
-enum ProtobufUnittest_VeryLargeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case enumLabelDefault // = 0
-  case enumLabel1 // = 1
-  case enumLabel2 // = 2
-  case enumLabel3 // = 3
-  case enumLabel4 // = 4
-  case enumLabel5 // = 5
-  case enumLabel6 // = 6
-  case enumLabel7 // = 7
-  case enumLabel8 // = 8
-  case enumLabel9 // = 9
-  case enumLabel10 // = 10
-  case enumLabel11 // = 11
-  case enumLabel12 // = 12
-  case enumLabel13 // = 13
-  case enumLabel14 // = 14
-  case enumLabel15 // = 15
-  case enumLabel16 // = 16
-  case enumLabel17 // = 17
-  case enumLabel18 // = 18
-  case enumLabel19 // = 19
-  case enumLabel20 // = 20
-  case enumLabel21 // = 21
-  case enumLabel22 // = 22
-  case enumLabel23 // = 23
-  case enumLabel24 // = 24
-  case enumLabel25 // = 25
-  case enumLabel26 // = 26
-  case enumLabel27 // = 27
-  case enumLabel28 // = 28
-  case enumLabel29 // = 29
-  case enumLabel30 // = 30
-  case enumLabel31 // = 31
-  case enumLabel32 // = 32
-  case enumLabel33 // = 33
-  case enumLabel34 // = 34
-  case enumLabel35 // = 35
-  case enumLabel36 // = 36
-  case enumLabel37 // = 37
-  case enumLabel38 // = 38
-  case enumLabel39 // = 39
-  case enumLabel40 // = 40
-  case enumLabel41 // = 41
-  case enumLabel42 // = 42
-  case enumLabel43 // = 43
-  case enumLabel44 // = 44
-  case enumLabel45 // = 45
-  case enumLabel46 // = 46
-  case enumLabel47 // = 47
-  case enumLabel48 // = 48
-  case enumLabel49 // = 49
-  case enumLabel50 // = 50
-  case enumLabel51 // = 51
-  case enumLabel52 // = 52
-  case enumLabel53 // = 53
-  case enumLabel54 // = 54
-  case enumLabel55 // = 55
-  case enumLabel56 // = 56
-  case enumLabel57 // = 57
-  case enumLabel58 // = 58
-  case enumLabel59 // = 59
-  case enumLabel60 // = 60
-  case enumLabel61 // = 61
-  case enumLabel62 // = 62
-  case enumLabel63 // = 63
-  case enumLabel64 // = 64
-  case enumLabel65 // = 65
-  case enumLabel66 // = 66
-  case enumLabel67 // = 67
-  case enumLabel68 // = 68
-  case enumLabel69 // = 69
-  case enumLabel70 // = 70
-  case enumLabel71 // = 71
-  case enumLabel72 // = 72
-  case enumLabel73 // = 73
-  case enumLabel74 // = 74
-  case enumLabel75 // = 75
-  case enumLabel76 // = 76
-  case enumLabel77 // = 77
-  case enumLabel78 // = 78
-  case enumLabel79 // = 79
-  case enumLabel80 // = 80
-  case enumLabel81 // = 81
-  case enumLabel82 // = 82
-  case enumLabel83 // = 83
-  case enumLabel84 // = 84
-  case enumLabel85 // = 85
-  case enumLabel86 // = 86
-  case enumLabel87 // = 87
-  case enumLabel88 // = 88
-  case enumLabel89 // = 89
-  case enumLabel90 // = 90
-  case enumLabel91 // = 91
-  case enumLabel92 // = 92
-  case enumLabel93 // = 93
-  case enumLabel94 // = 94
-  case enumLabel95 // = 95
-  case enumLabel96 // = 96
-  case enumLabel97 // = 97
-  case enumLabel98 // = 98
-  case enumLabel99 // = 99
-  case enumLabel100 // = 100
+enum ProtobufUnittest_VeryLargeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case enumLabelDefault = 0
+  case enumLabel1 = 1
+  case enumLabel2 = 2
+  case enumLabel3 = 3
+  case enumLabel4 = 4
+  case enumLabel5 = 5
+  case enumLabel6 = 6
+  case enumLabel7 = 7
+  case enumLabel8 = 8
+  case enumLabel9 = 9
+  case enumLabel10 = 10
+  case enumLabel11 = 11
+  case enumLabel12 = 12
+  case enumLabel13 = 13
+  case enumLabel14 = 14
+  case enumLabel15 = 15
+  case enumLabel16 = 16
+  case enumLabel17 = 17
+  case enumLabel18 = 18
+  case enumLabel19 = 19
+  case enumLabel20 = 20
+  case enumLabel21 = 21
+  case enumLabel22 = 22
+  case enumLabel23 = 23
+  case enumLabel24 = 24
+  case enumLabel25 = 25
+  case enumLabel26 = 26
+  case enumLabel27 = 27
+  case enumLabel28 = 28
+  case enumLabel29 = 29
+  case enumLabel30 = 30
+  case enumLabel31 = 31
+  case enumLabel32 = 32
+  case enumLabel33 = 33
+  case enumLabel34 = 34
+  case enumLabel35 = 35
+  case enumLabel36 = 36
+  case enumLabel37 = 37
+  case enumLabel38 = 38
+  case enumLabel39 = 39
+  case enumLabel40 = 40
+  case enumLabel41 = 41
+  case enumLabel42 = 42
+  case enumLabel43 = 43
+  case enumLabel44 = 44
+  case enumLabel45 = 45
+  case enumLabel46 = 46
+  case enumLabel47 = 47
+  case enumLabel48 = 48
+  case enumLabel49 = 49
+  case enumLabel50 = 50
+  case enumLabel51 = 51
+  case enumLabel52 = 52
+  case enumLabel53 = 53
+  case enumLabel54 = 54
+  case enumLabel55 = 55
+  case enumLabel56 = 56
+  case enumLabel57 = 57
+  case enumLabel58 = 58
+  case enumLabel59 = 59
+  case enumLabel60 = 60
+  case enumLabel61 = 61
+  case enumLabel62 = 62
+  case enumLabel63 = 63
+  case enumLabel64 = 64
+  case enumLabel65 = 65
+  case enumLabel66 = 66
+  case enumLabel67 = 67
+  case enumLabel68 = 68
+  case enumLabel69 = 69
+  case enumLabel70 = 70
+  case enumLabel71 = 71
+  case enumLabel72 = 72
+  case enumLabel73 = 73
+  case enumLabel74 = 74
+  case enumLabel75 = 75
+  case enumLabel76 = 76
+  case enumLabel77 = 77
+  case enumLabel78 = 78
+  case enumLabel79 = 79
+  case enumLabel80 = 80
+  case enumLabel81 = 81
+  case enumLabel82 = 82
+  case enumLabel83 = 83
+  case enumLabel84 = 84
+  case enumLabel85 = 85
+  case enumLabel86 = 86
+  case enumLabel87 = 87
+  case enumLabel88 = 88
+  case enumLabel89 = 89
+  case enumLabel90 = 90
+  case enumLabel91 = 91
+  case enumLabel92 = 92
+  case enumLabel93 = 93
+  case enumLabel94 = 94
+  case enumLabel95 = 95
+  case enumLabel96 = 96
+  case enumLabel97 = 97
+  case enumLabel98 = 98
+  case enumLabel99 = 99
+  case enumLabel100 = 100
 
   init() {
     self = .enumLabelDefault
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .enumLabelDefault
-    case 1: self = .enumLabel1
-    case 2: self = .enumLabel2
-    case 3: self = .enumLabel3
-    case 4: self = .enumLabel4
-    case 5: self = .enumLabel5
-    case 6: self = .enumLabel6
-    case 7: self = .enumLabel7
-    case 8: self = .enumLabel8
-    case 9: self = .enumLabel9
-    case 10: self = .enumLabel10
-    case 11: self = .enumLabel11
-    case 12: self = .enumLabel12
-    case 13: self = .enumLabel13
-    case 14: self = .enumLabel14
-    case 15: self = .enumLabel15
-    case 16: self = .enumLabel16
-    case 17: self = .enumLabel17
-    case 18: self = .enumLabel18
-    case 19: self = .enumLabel19
-    case 20: self = .enumLabel20
-    case 21: self = .enumLabel21
-    case 22: self = .enumLabel22
-    case 23: self = .enumLabel23
-    case 24: self = .enumLabel24
-    case 25: self = .enumLabel25
-    case 26: self = .enumLabel26
-    case 27: self = .enumLabel27
-    case 28: self = .enumLabel28
-    case 29: self = .enumLabel29
-    case 30: self = .enumLabel30
-    case 31: self = .enumLabel31
-    case 32: self = .enumLabel32
-    case 33: self = .enumLabel33
-    case 34: self = .enumLabel34
-    case 35: self = .enumLabel35
-    case 36: self = .enumLabel36
-    case 37: self = .enumLabel37
-    case 38: self = .enumLabel38
-    case 39: self = .enumLabel39
-    case 40: self = .enumLabel40
-    case 41: self = .enumLabel41
-    case 42: self = .enumLabel42
-    case 43: self = .enumLabel43
-    case 44: self = .enumLabel44
-    case 45: self = .enumLabel45
-    case 46: self = .enumLabel46
-    case 47: self = .enumLabel47
-    case 48: self = .enumLabel48
-    case 49: self = .enumLabel49
-    case 50: self = .enumLabel50
-    case 51: self = .enumLabel51
-    case 52: self = .enumLabel52
-    case 53: self = .enumLabel53
-    case 54: self = .enumLabel54
-    case 55: self = .enumLabel55
-    case 56: self = .enumLabel56
-    case 57: self = .enumLabel57
-    case 58: self = .enumLabel58
-    case 59: self = .enumLabel59
-    case 60: self = .enumLabel60
-    case 61: self = .enumLabel61
-    case 62: self = .enumLabel62
-    case 63: self = .enumLabel63
-    case 64: self = .enumLabel64
-    case 65: self = .enumLabel65
-    case 66: self = .enumLabel66
-    case 67: self = .enumLabel67
-    case 68: self = .enumLabel68
-    case 69: self = .enumLabel69
-    case 70: self = .enumLabel70
-    case 71: self = .enumLabel71
-    case 72: self = .enumLabel72
-    case 73: self = .enumLabel73
-    case 74: self = .enumLabel74
-    case 75: self = .enumLabel75
-    case 76: self = .enumLabel76
-    case 77: self = .enumLabel77
-    case 78: self = .enumLabel78
-    case 79: self = .enumLabel79
-    case 80: self = .enumLabel80
-    case 81: self = .enumLabel81
-    case 82: self = .enumLabel82
-    case 83: self = .enumLabel83
-    case 84: self = .enumLabel84
-    case 85: self = .enumLabel85
-    case 86: self = .enumLabel86
-    case 87: self = .enumLabel87
-    case 88: self = .enumLabel88
-    case 89: self = .enumLabel89
-    case 90: self = .enumLabel90
-    case 91: self = .enumLabel91
-    case 92: self = .enumLabel92
-    case 93: self = .enumLabel93
-    case 94: self = .enumLabel94
-    case 95: self = .enumLabel95
-    case 96: self = .enumLabel96
-    case 97: self = .enumLabel97
-    case 98: self = .enumLabel98
-    case 99: self = .enumLabel99
-    case 100: self = .enumLabel100
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .enumLabelDefault: return 0
-    case .enumLabel1: return 1
-    case .enumLabel2: return 2
-    case .enumLabel3: return 3
-    case .enumLabel4: return 4
-    case .enumLabel5: return 5
-    case .enumLabel6: return 6
-    case .enumLabel7: return 7
-    case .enumLabel8: return 8
-    case .enumLabel9: return 9
-    case .enumLabel10: return 10
-    case .enumLabel11: return 11
-    case .enumLabel12: return 12
-    case .enumLabel13: return 13
-    case .enumLabel14: return 14
-    case .enumLabel15: return 15
-    case .enumLabel16: return 16
-    case .enumLabel17: return 17
-    case .enumLabel18: return 18
-    case .enumLabel19: return 19
-    case .enumLabel20: return 20
-    case .enumLabel21: return 21
-    case .enumLabel22: return 22
-    case .enumLabel23: return 23
-    case .enumLabel24: return 24
-    case .enumLabel25: return 25
-    case .enumLabel26: return 26
-    case .enumLabel27: return 27
-    case .enumLabel28: return 28
-    case .enumLabel29: return 29
-    case .enumLabel30: return 30
-    case .enumLabel31: return 31
-    case .enumLabel32: return 32
-    case .enumLabel33: return 33
-    case .enumLabel34: return 34
-    case .enumLabel35: return 35
-    case .enumLabel36: return 36
-    case .enumLabel37: return 37
-    case .enumLabel38: return 38
-    case .enumLabel39: return 39
-    case .enumLabel40: return 40
-    case .enumLabel41: return 41
-    case .enumLabel42: return 42
-    case .enumLabel43: return 43
-    case .enumLabel44: return 44
-    case .enumLabel45: return 45
-    case .enumLabel46: return 46
-    case .enumLabel47: return 47
-    case .enumLabel48: return 48
-    case .enumLabel49: return 49
-    case .enumLabel50: return 50
-    case .enumLabel51: return 51
-    case .enumLabel52: return 52
-    case .enumLabel53: return 53
-    case .enumLabel54: return 54
-    case .enumLabel55: return 55
-    case .enumLabel56: return 56
-    case .enumLabel57: return 57
-    case .enumLabel58: return 58
-    case .enumLabel59: return 59
-    case .enumLabel60: return 60
-    case .enumLabel61: return 61
-    case .enumLabel62: return 62
-    case .enumLabel63: return 63
-    case .enumLabel64: return 64
-    case .enumLabel65: return 65
-    case .enumLabel66: return 66
-    case .enumLabel67: return 67
-    case .enumLabel68: return 68
-    case .enumLabel69: return 69
-    case .enumLabel70: return 70
-    case .enumLabel71: return 71
-    case .enumLabel72: return 72
-    case .enumLabel73: return 73
-    case .enumLabel74: return 74
-    case .enumLabel75: return 75
-    case .enumLabel76: return 76
-    case .enumLabel77: return 77
-    case .enumLabel78: return 78
-    case .enumLabel79: return 79
-    case .enumLabel80: return 80
-    case .enumLabel81: return 81
-    case .enumLabel82: return 82
-    case .enumLabel83: return 83
-    case .enumLabel84: return 84
-    case .enumLabel85: return 85
-    case .enumLabel86: return 86
-    case .enumLabel87: return 87
-    case .enumLabel88: return 88
-    case .enumLabel89: return 89
-    case .enumLabel90: return 90
-    case .enumLabel91: return 91
-    case .enumLabel92: return 92
-    case .enumLabel93: return 93
-    case .enumLabel94: return 94
-    case .enumLabel95: return 95
-    case .enumLabel96: return 96
-    case .enumLabel97: return 97
-    case .enumLabel98: return 98
-    case .enumLabel99: return 99
-    case .enumLabel100: return 100
-    }
   }
 
 }
@@ -1188,36 +894,16 @@ struct ProtobufUnittest_TestAllTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -1945,36 +1631,16 @@ struct ProtobufUnittest_TestRequiredEnumNoMask: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 2
-    case bar // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 2
+    case bar = 100
 
     /// Intentionally negative.
-    case baz // = -1
+    case baz = -1
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .baz
-      case 0: self = .unspecified
-      case 2: self = .foo
-      case 100: self = .bar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .baz: return -1
-      case .unspecified: return 0
-      case .foo: return 2
-      case .bar: return 100
-      }
     }
 
   }
@@ -2030,34 +1696,14 @@ struct ProtobufUnittest_TestRequiredEnumMulti: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 100
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 100: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 100
-      }
     }
 
   }
@@ -2143,34 +1789,14 @@ struct ProtobufUnittest_TestRequiredNoMaskMulti: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 100
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 100
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 100: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 100
-      }
     }
 
   }
@@ -4670,31 +4296,13 @@ struct ProtobufUnittest_TestOneof2: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -5022,31 +4630,13 @@ struct ProtobufUnittest_TestDynamicExtensions: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum DynamicEnumType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case dynamicFoo // = 2200
-    case dynamicBar // = 2201
-    case dynamicBaz // = 2202
+  enum DynamicEnumType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case dynamicFoo = 2200
+    case dynamicBar = 2201
+    case dynamicBaz = 2202
 
     init() {
       self = .dynamicFoo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 2200: self = .dynamicFoo
-      case 2201: self = .dynamicBar
-      case 2202: self = .dynamicBaz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .dynamicFoo: return 2200
-      case .dynamicBar: return 2201
-      case .dynamicBaz: return 2202
-      }
     }
 
   }
@@ -7165,223 +6755,81 @@ struct ProtobufUnittest_EnumParseTester: SwiftProtobuf.ExtensibleMessage, @unche
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum SeqSmall0: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = 0
-    case seqSmall01 // = 1
-    case seqSmall02 // = 2
+  enum SeqSmall0: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = 0
+    case seqSmall01 = 1
+    case seqSmall02 = 2
 
     init() {
       self = .default
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .default
-      case 1: self = .seqSmall01
-      case 2: self = .seqSmall02
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .default: return 0
-      case .seqSmall01: return 1
-      case .seqSmall02: return 2
-      }
     }
 
   }
 
-  enum SeqSmall1: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = 1
-    case seqSmall12 // = 2
-    case seqSmall13 // = 3
+  enum SeqSmall1: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = 1
+    case seqSmall12 = 2
+    case seqSmall13 = 3
 
     init() {
       self = .default
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .default
-      case 2: self = .seqSmall12
-      case 3: self = .seqSmall13
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .default: return 1
-      case .seqSmall12: return 2
-      case .seqSmall13: return 3
-      }
     }
 
   }
 
-  enum SeqLarge: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = -1
-    case seqLarge0 // = 0
-    case seqLarge1 // = 1
-    case seqLarge2 // = 2
-    case seqLarge3 // = 3
-    case seqLarge4 // = 4
-    case seqLarge5 // = 5
-    case seqLarge6 // = 6
-    case seqLarge7 // = 7
-    case seqLarge8 // = 8
-    case seqLarge9 // = 9
-    case seqLarge10 // = 10
-    case seqLarge11 // = 11
-    case seqLarge12 // = 12
-    case seqLarge13 // = 13
-    case seqLarge14 // = 14
-    case seqLarge15 // = 15
-    case seqLarge16 // = 16
-    case seqLarge17 // = 17
-    case seqLarge18 // = 18
-    case seqLarge19 // = 19
-    case seqLarge20 // = 20
-    case seqLarge21 // = 21
-    case seqLarge22 // = 22
-    case seqLarge23 // = 23
-    case seqLarge24 // = 24
-    case seqLarge25 // = 25
-    case seqLarge26 // = 26
-    case seqLarge27 // = 27
-    case seqLarge28 // = 28
-    case seqLarge29 // = 29
-    case seqLarge30 // = 30
-    case seqLarge31 // = 31
-    case seqLarge32 // = 32
-    case seqLarge33 // = 33
+  enum SeqLarge: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = -1
+    case seqLarge0 = 0
+    case seqLarge1 = 1
+    case seqLarge2 = 2
+    case seqLarge3 = 3
+    case seqLarge4 = 4
+    case seqLarge5 = 5
+    case seqLarge6 = 6
+    case seqLarge7 = 7
+    case seqLarge8 = 8
+    case seqLarge9 = 9
+    case seqLarge10 = 10
+    case seqLarge11 = 11
+    case seqLarge12 = 12
+    case seqLarge13 = 13
+    case seqLarge14 = 14
+    case seqLarge15 = 15
+    case seqLarge16 = 16
+    case seqLarge17 = 17
+    case seqLarge18 = 18
+    case seqLarge19 = 19
+    case seqLarge20 = 20
+    case seqLarge21 = 21
+    case seqLarge22 = 22
+    case seqLarge23 = 23
+    case seqLarge24 = 24
+    case seqLarge25 = 25
+    case seqLarge26 = 26
+    case seqLarge27 = 27
+    case seqLarge28 = 28
+    case seqLarge29 = 29
+    case seqLarge30 = 30
+    case seqLarge31 = 31
+    case seqLarge32 = 32
+    case seqLarge33 = 33
 
     init() {
       self = .default
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .default
-      case 0: self = .seqLarge0
-      case 1: self = .seqLarge1
-      case 2: self = .seqLarge2
-      case 3: self = .seqLarge3
-      case 4: self = .seqLarge4
-      case 5: self = .seqLarge5
-      case 6: self = .seqLarge6
-      case 7: self = .seqLarge7
-      case 8: self = .seqLarge8
-      case 9: self = .seqLarge9
-      case 10: self = .seqLarge10
-      case 11: self = .seqLarge11
-      case 12: self = .seqLarge12
-      case 13: self = .seqLarge13
-      case 14: self = .seqLarge14
-      case 15: self = .seqLarge15
-      case 16: self = .seqLarge16
-      case 17: self = .seqLarge17
-      case 18: self = .seqLarge18
-      case 19: self = .seqLarge19
-      case 20: self = .seqLarge20
-      case 21: self = .seqLarge21
-      case 22: self = .seqLarge22
-      case 23: self = .seqLarge23
-      case 24: self = .seqLarge24
-      case 25: self = .seqLarge25
-      case 26: self = .seqLarge26
-      case 27: self = .seqLarge27
-      case 28: self = .seqLarge28
-      case 29: self = .seqLarge29
-      case 30: self = .seqLarge30
-      case 31: self = .seqLarge31
-      case 32: self = .seqLarge32
-      case 33: self = .seqLarge33
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .default: return -1
-      case .seqLarge0: return 0
-      case .seqLarge1: return 1
-      case .seqLarge2: return 2
-      case .seqLarge3: return 3
-      case .seqLarge4: return 4
-      case .seqLarge5: return 5
-      case .seqLarge6: return 6
-      case .seqLarge7: return 7
-      case .seqLarge8: return 8
-      case .seqLarge9: return 9
-      case .seqLarge10: return 10
-      case .seqLarge11: return 11
-      case .seqLarge12: return 12
-      case .seqLarge13: return 13
-      case .seqLarge14: return 14
-      case .seqLarge15: return 15
-      case .seqLarge16: return 16
-      case .seqLarge17: return 17
-      case .seqLarge18: return 18
-      case .seqLarge19: return 19
-      case .seqLarge20: return 20
-      case .seqLarge21: return 21
-      case .seqLarge22: return 22
-      case .seqLarge23: return 23
-      case .seqLarge24: return 24
-      case .seqLarge25: return 25
-      case .seqLarge26: return 26
-      case .seqLarge27: return 27
-      case .seqLarge28: return 28
-      case .seqLarge29: return 29
-      case .seqLarge30: return 30
-      case .seqLarge31: return 31
-      case .seqLarge32: return 32
-      case .seqLarge33: return 33
-      }
     }
 
   }
 
-  enum Arbitrary: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `default` // = -123123
-    case arbitrary1 // = -123
-    case arbitrary2 // = 213
-    case arbitrary3 // = 213213
-    case min // = -2147483648
-    case max // = 2147483647
+  enum Arbitrary: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `default` = -123123
+    case arbitrary1 = -123
+    case arbitrary2 = 213
+    case arbitrary3 = 213213
+    case min = -2147483648
+    case max = 2147483647
 
     init() {
       self = .default
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -2147483648: self = .min
-      case -123123: self = .default
-      case -123: self = .arbitrary1
-      case 213: self = .arbitrary2
-      case 213213: self = .arbitrary3
-      case 2147483647: self = .max
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .min: return -2147483648
-      case .default: return -123123
-      case .arbitrary1: return -123
-      case .arbitrary2: return 213
-      case .arbitrary3: return 213213
-      case .max: return 2147483647
-      }
     }
 
   }
@@ -7887,34 +7335,14 @@ struct ProtobufUnittest_TestPackedEnumSmallRange: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unspecified = 0
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     init() {
       self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -7929,207 +7357,75 @@ struct ProtobufUnittest_EnumsForBenchmark: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Flat: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a0 // = 0
-    case a1 // = 1
-    case a2 // = 2
-    case a3 // = 3
-    case a4 // = 4
-    case a5 // = 5
-    case a6 // = 6
-    case a7 // = 7
-    case a8 // = 8
-    case a9 // = 9
-    case a10 // = 10
-    case a11 // = 11
-    case a12 // = 12
-    case a13 // = 13
-    case a14 // = 14
-    case a15 // = 15
+  enum Flat: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a0 = 0
+    case a1 = 1
+    case a2 = 2
+    case a3 = 3
+    case a4 = 4
+    case a5 = 5
+    case a6 = 6
+    case a7 = 7
+    case a8 = 8
+    case a9 = 9
+    case a10 = 10
+    case a11 = 11
+    case a12 = 12
+    case a13 = 13
+    case a14 = 14
+    case a15 = 15
 
     init() {
       self = .a0
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a0
-      case 1: self = .a1
-      case 2: self = .a2
-      case 3: self = .a3
-      case 4: self = .a4
-      case 5: self = .a5
-      case 6: self = .a6
-      case 7: self = .a7
-      case 8: self = .a8
-      case 9: self = .a9
-      case 10: self = .a10
-      case 11: self = .a11
-      case 12: self = .a12
-      case 13: self = .a13
-      case 14: self = .a14
-      case 15: self = .a15
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a0: return 0
-      case .a1: return 1
-      case .a2: return 2
-      case .a3: return 3
-      case .a4: return 4
-      case .a5: return 5
-      case .a6: return 6
-      case .a7: return 7
-      case .a8: return 8
-      case .a9: return 9
-      case .a10: return 10
-      case .a11: return 11
-      case .a12: return 12
-      case .a13: return 13
-      case .a14: return 14
-      case .a15: return 15
-      }
-    }
-
   }
 
   /// Has a few holes, bitmap can be used.
-  enum AlmostFlat: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case b0 // = 0
-    case b1 // = 1
-    case b2 // = 2
-    case b3 // = 3
-    case b5 // = 5
-    case b6 // = 6
-    case b7 // = 7
-    case b8 // = 8
-    case b9 // = 9
-    case b11 // = 11
-    case b12 // = 12
-    case b13 // = 13
-    case b14 // = 14
-    case b15 // = 15
-    case b17 // = 17
-    case b19 // = 19
+  enum AlmostFlat: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case b0 = 0
+    case b1 = 1
+    case b2 = 2
+    case b3 = 3
+    case b5 = 5
+    case b6 = 6
+    case b7 = 7
+    case b8 = 8
+    case b9 = 9
+    case b11 = 11
+    case b12 = 12
+    case b13 = 13
+    case b14 = 14
+    case b15 = 15
+    case b17 = 17
+    case b19 = 19
 
     init() {
       self = .b0
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .b0
-      case 1: self = .b1
-      case 2: self = .b2
-      case 3: self = .b3
-      case 5: self = .b5
-      case 6: self = .b6
-      case 7: self = .b7
-      case 8: self = .b8
-      case 9: self = .b9
-      case 11: self = .b11
-      case 12: self = .b12
-      case 13: self = .b13
-      case 14: self = .b14
-      case 15: self = .b15
-      case 17: self = .b17
-      case 19: self = .b19
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .b0: return 0
-      case .b1: return 1
-      case .b2: return 2
-      case .b3: return 3
-      case .b5: return 5
-      case .b6: return 6
-      case .b7: return 7
-      case .b8: return 8
-      case .b9: return 9
-      case .b11: return 11
-      case .b12: return 12
-      case .b13: return 13
-      case .b14: return 14
-      case .b15: return 15
-      case .b17: return 17
-      case .b19: return 19
-      }
-    }
-
   }
 
-  enum Sparse: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case c536 // = 536
-    case c8387 // = 8387
-    case c9673 // = 9673
-    case c10285 // = 10285
-    case c13318 // = 13318
-    case c15963 // = 15963
-    case c16439 // = 16439
-    case c18197 // = 18197
-    case c19430 // = 19430
-    case c20361 // = 20361
-    case c20706 // = 20706
-    case c21050 // = 21050
-    case c21906 // = 21906
-    case c27265 // = 27265
-    case c30109 // = 30109
-    case c31670 // = 31670
+  enum Sparse: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case c536 = 536
+    case c8387 = 8387
+    case c9673 = 9673
+    case c10285 = 10285
+    case c13318 = 13318
+    case c15963 = 15963
+    case c16439 = 16439
+    case c18197 = 18197
+    case c19430 = 19430
+    case c20361 = 20361
+    case c20706 = 20706
+    case c21050 = 21050
+    case c21906 = 21906
+    case c27265 = 27265
+    case c30109 = 30109
+    case c31670 = 31670
 
     init() {
       self = .c536
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 536: self = .c536
-      case 8387: self = .c8387
-      case 9673: self = .c9673
-      case 10285: self = .c10285
-      case 13318: self = .c13318
-      case 15963: self = .c15963
-      case 16439: self = .c16439
-      case 18197: self = .c18197
-      case 19430: self = .c19430
-      case 20361: self = .c20361
-      case 20706: self = .c20706
-      case 21050: self = .c21050
-      case 21906: self = .c21906
-      case 27265: self = .c27265
-      case 30109: self = .c30109
-      case 31670: self = .c31670
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .c536: return 536
-      case .c8387: return 8387
-      case .c9673: return 9673
-      case .c10285: return 10285
-      case .c13318: return 13318
-      case .c15963: return 15963
-      case .c16439: return 16439
-      case .c18197: return 18197
-      case .c19430: return 19430
-      case .c20361: return 20361
-      case .c20706: return 20706
-      case .c21050: return 21050
-      case .c21906: return 21906
-      case .c27265: return 27265
-      case .c30109: return 30109
-      case .c31670: return 31670
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_custom_options.pb.swift
@@ -34,51 +34,21 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case val1 // = 1
-  case val2 // = 2
+enum ProtobufUnittest_MethodOpt1: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case val1 = 1
+  case val2 = 2
 
   init() {
     self = .val1
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .val1
-    case 2: self = .val2
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .val1: return 1
-    case .val2: return 2
-    }
-  }
-
 }
 
-enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case value // = 1
+enum ProtobufUnittest_AggregateEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case value = 1
 
   init() {
     self = .value
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .value
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .value: return 1
-    }
   }
 
 }
@@ -118,28 +88,12 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: Sendable {
 
   }
 
-  enum AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case val1 // = 1
-    case val2 // = 2
+  enum AnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case val1 = 1
+    case val2 = 2
 
     init() {
       self = .val1
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .val1
-      case 2: self = .val2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .val1: return 1
-      case .val2: return 2
-      }
     }
 
   }
@@ -198,28 +152,12 @@ struct ProtobufUnittest_DummyMessageContainingEnum: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnumType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case testOptionEnumType1 // = 22
-    case testOptionEnumType2 // = -23
+  enum TestEnumType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case testOptionEnumType1 = 22
+    case testOptionEnumType2 = -23
 
     init() {
       self = .testOptionEnumType1
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -23: self = .testOptionEnumType2
-      case 22: self = .testOptionEnumType1
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .testOptionEnumType2: return -23
-      case .testOptionEnumType1: return 22
-      }
     }
 
   }
@@ -653,25 +591,11 @@ struct ProtobufUnittest_NestedOptionType: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case value // = 1
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case value = 1
 
     init() {
       self = .value
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .value
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .value: return 1
-      }
     }
 
   }
@@ -718,25 +642,11 @@ struct ProtobufUnittest_OldOptionType: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case oldValue // = 0
+  enum TestEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case oldValue = 0
 
     init() {
       self = .oldValue
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .oldValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .oldValue: return 0
-      }
     }
 
   }
@@ -763,28 +673,12 @@ struct ProtobufUnittest_NewOptionType: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case oldValue // = 0
-    case newValue // = 1
+  enum TestEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case oldValue = 0
+    case newValue = 1
 
     init() {
       self = .oldValue
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .oldValue
-      case 1: self = .newValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .oldValue: return 0
-      case .newValue: return 1
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/unittest_import.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import.pb.swift
@@ -33,61 +33,25 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case importFoo // = 7
-  case importBar // = 8
-  case importBaz // = 9
+enum ProtobufUnittestImport_ImportEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case importFoo = 7
+  case importBar = 8
+  case importBaz = 9
 
   init() {
     self = .importFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 7: self = .importFoo
-    case 8: self = .importBar
-    case 9: self = .importBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .importFoo: return 7
-    case .importBar: return 8
-    case .importBaz: return 9
-    }
-  }
-
 }
 
 /// To use an enum in a map, it must has the first value as 0.
-enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case unknown // = 0
-  case foo // = 1
-  case bar // = 2
+enum ProtobufUnittestImport_ImportEnumForMap: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case unknown = 0
+  case foo = 1
+  case bar = 2
 
   init() {
     self = .unknown
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    case 1: self = .foo
-    case 2: self = .bar
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    case .foo: return 1
-    case .bar: return 2
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_import_lite.pb.swift
@@ -31,31 +31,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case importLiteFoo // = 7
-  case importLiteBar // = 8
-  case importLiteBaz // = 9
+enum ProtobufUnittestImport_ImportEnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case importLiteFoo = 7
+  case importLiteBar = 8
+  case importLiteBaz = 9
 
   init() {
     self = .importLiteFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 7: self = .importLiteFoo
-    case 8: self = .importLiteBar
-    case 9: self = .importLiteBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .importLiteFoo: return 7
-    case .importLiteBar: return 8
-    case .importLiteBaz: return 9
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/unittest_lazy_dependencies_enum.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lazy_dependencies_enum.pb.swift
@@ -33,28 +33,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_LazyImports_LazyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case lazyEnum0 // = 0
-  case lazyEnum1 // = 1
+enum ProtobufUnittest_LazyImports_LazyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case lazyEnum0 = 0
+  case lazyEnum1 = 1
 
   init() {
     self = .lazyEnum0
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .lazyEnum0
-    case 1: self = .lazyEnum1
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .lazyEnum0: return 0
-    case .lazyEnum1: return 1
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_lite.pb.swift
@@ -32,80 +32,32 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignLiteFoo // = 4
-  case foreignLiteBaz // = 6
-  case foreignLiteBar // = 5
+enum ProtobufUnittest_ForeignEnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignLiteFoo = 4
+  case foreignLiteBaz = 6
+  case foreignLiteBar = 5
 
   init() {
     self = .foreignLiteFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 4: self = .foreignLiteFoo
-    case 5: self = .foreignLiteBar
-    case 6: self = .foreignLiteBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignLiteFoo: return 4
-    case .foreignLiteBar: return 5
-    case .foreignLiteBaz: return 6
-    }
-  }
-
 }
 
-enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case v1First // = 1
+enum ProtobufUnittest_V1EnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case v1First = 1
 
   init() {
     self = .v1First
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .v1First
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .v1First: return 1
-    }
-  }
-
 }
 
-enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case v2First // = 1
-  case v2Second // = 2
+enum ProtobufUnittest_V2EnumLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case v2First = 1
+  case v2Second = 2
 
   init() {
     self = .v2First
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .v2First
-    case 2: self = .v2Second
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .v2First: return 1
-    case .v2Second: return 2
-    }
   }
 
 }
@@ -754,31 +706,13 @@ struct ProtobufUnittest_TestAllTypesLite: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -1657,33 +1591,15 @@ struct ProtobufUnittest_DupEnum: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnumWithDupValueLite: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo1 // = 1
-    case bar1 // = 2
-    case baz // = 3
+  enum TestEnumWithDupValueLite: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo1 = 1
+    case bar1 = 2
+    case baz = 3
     static let foo2 = foo1
     static let bar2 = bar1
 
     init() {
       self = .foo1
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo1
-      case 2: self = .bar1
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo1: return 1
-      case .bar1: return 2
-      case .baz: return 3
-      }
     }
 
   }

--- a/Reference/upstream/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_no_generic_services.pb.swift
@@ -29,25 +29,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 1
+enum ProtobufUnittest_NoGenericServicesTest_TestEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 1
 
   init() {
     self = .foo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .foo
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 1
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -27,31 +27,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum Proto2PreserveUnknownEnumUnittest_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
   }
 
 }

--- a/Reference/upstream/google/protobuf/unittest_retention.pb.swift
+++ b/Reference/upstream/google/protobuf/unittest_retention.pb.swift
@@ -27,25 +27,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufUnittest_TopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case topLevelUnknown // = 0
+enum ProtobufUnittest_TopLevelEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case topLevelUnknown = 0
 
   init() {
     self = .topLevelUnknown
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .topLevelUnknown
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .topLevelUnknown: return 0
-    }
   }
 
 }
@@ -135,25 +121,11 @@ struct ProtobufUnittest_TopLevelMessage: SwiftProtobuf.ExtensibleMessage, Sendab
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case nestedUnknown // = 0
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case nestedUnknown = 0
 
     init() {
       self = .nestedUnknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .nestedUnknown
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .nestedUnknown: return 0
-      }
     }
 
   }

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Proto2_TestAllTypesProto2: SwiftProtobuf.ExtensibleM
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Proto2_TestAllRequiredTypesProto2: SwiftProtobuf.Ext
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Sources/Conformance/test_messages_proto2_editions.pb.swift
+++ b/Sources/Conformance/test_messages_proto2_editions.pb.swift
@@ -34,31 +34,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 0
-  case foreignBar // = 1
-  case foreignBaz // = 2
+enum ProtobufTestMessages_Editions_Proto2_ForeignEnumProto2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 0
+  case foreignBar = 1
+  case foreignBaz = 2
 
   init() {
     self = .foreignFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foreignFoo
-    case 1: self = .foreignBar
-    case 2: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 0
-    case .foreignBar: return 1
-    case .foreignBaz: return 2
-    }
   }
 
 }
@@ -1033,36 +1015,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2: SwiftProtobuf.Ex
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }
@@ -1374,28 +1336,12 @@ struct ProtobufTestMessages_Editions_Proto2_EnumOnlyProto2: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum BoolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case kFalse // = 0
-    case kTrue // = 1
+  enum BoolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case kFalse = 0
+    case kTrue = 1
 
     init() {
       self = .kFalse
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .kFalse
-      case 1: self = .kTrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .kFalse: return 0
-      case .kTrue: return 1
-      }
     }
 
   }
@@ -1817,36 +1763,16 @@ struct ProtobufTestMessages_Editions_Proto2_TestAllRequiredTypesProto2: SwiftPro
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      }
     }
 
   }

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -60,79 +60,43 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: ProtobufAPIVersionCheck 
 }
 
 /// The full set of known editions.
-public enum Google_Protobuf_Edition: Enum, Swift.CaseIterable {
-  public typealias RawValue = Int
+public enum Google_Protobuf_Edition: Int, Enum, Swift.CaseIterable {
 
   /// A placeholder for an unknown edition value.
-  case unknown // = 0
+  case unknown = 0
 
   /// A placeholder edition for specifying default behaviors *before* a feature
   /// was first introduced.  This is effectively an "infinite past".
-  case legacy // = 900
+  case legacy = 900
 
   /// Legacy syntax "editions".  These pre-date editions, but behave much like
   /// distinct editions.  These can't be used to specify the edition of proto
   /// files, but feature definitions must supply proto2/proto3 defaults for
   /// backwards compatibility.
-  case proto2 // = 998
-  case proto3 // = 999
+  case proto2 = 998
+  case proto3 = 999
 
   /// Editions that have been released.  The specific values are arbitrary and
   /// should not be depended on, but they will always be time-ordered for easy
   /// comparison.
-  case edition2023 // = 1000
-  case edition2024 // = 1001
+  case edition2023 = 1000
+  case edition2024 = 1001
 
   /// Placeholder editions for testing feature resolution.  These should not be
   /// used or relied on outside of tests.
-  case edition1TestOnly // = 1
-  case edition2TestOnly // = 2
-  case edition99997TestOnly // = 99997
-  case edition99998TestOnly // = 99998
-  case edition99999TestOnly // = 99999
+  case edition1TestOnly = 1
+  case edition2TestOnly = 2
+  case edition99997TestOnly = 99997
+  case edition99998TestOnly = 99998
+  case edition99999TestOnly = 99999
 
   /// Placeholder for specifying unbounded edition support.  This should only
   /// ever be used by plugins that can expect to never require any changes to
   /// support a new edition.
-  case max // = 2147483647
+  case max = 2147483647
 
   public init() {
     self = .unknown
-  }
-
-  public init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .unknown
-    case 1: self = .edition1TestOnly
-    case 2: self = .edition2TestOnly
-    case 900: self = .legacy
-    case 998: self = .proto2
-    case 999: self = .proto3
-    case 1000: self = .edition2023
-    case 1001: self = .edition2024
-    case 99997: self = .edition99997TestOnly
-    case 99998: self = .edition99998TestOnly
-    case 99999: self = .edition99999TestOnly
-    case 2147483647: self = .max
-    default: return nil
-    }
-  }
-
-  public var rawValue: Int {
-    switch self {
-    case .unknown: return 0
-    case .edition1TestOnly: return 1
-    case .edition2TestOnly: return 2
-    case .legacy: return 900
-    case .proto2: return 998
-    case .proto3: return 999
-    case .edition2023: return 1000
-    case .edition2024: return 1001
-    case .edition99997TestOnly: return 99997
-    case .edition99998TestOnly: return 99998
-    case .edition99999TestOnly: return 99999
-    case .max: return 2147483647
-    }
   }
 
 }
@@ -451,30 +415,14 @@ public struct Google_Protobuf_ExtensionRangeOptions: ExtensibleMessage, Sendable
   public var unknownFields = UnknownStorage()
 
   /// The verification state of the extension range.
-  public enum VerificationState: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum VerificationState: Int, Enum, Swift.CaseIterable {
 
     /// All the extensions of the range must be declared.
-    case declaration // = 0
-    case unverified // = 1
+    case declaration = 0
+    case unverified = 1
 
     public init() {
       self = .declaration
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .declaration
-      case 1: self = .unverified
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .declaration: return 0
-      case .unverified: return 1
-      }
     }
 
   }
@@ -705,134 +653,68 @@ public struct Google_Protobuf_FieldDescriptorProto: Sendable {
 
   public var unknownFields = UnknownStorage()
 
-  public enum TypeEnum: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum TypeEnum: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors.
     /// Order is weird for historical reasons.
-    case double // = 1
-    case float // = 2
+    case double = 1
+    case float = 2
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
     /// negative values are likely.
-    case int64 // = 3
-    case uint64 // = 4
+    case int64 = 3
+    case uint64 = 4
 
     /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
     /// negative values are likely.
-    case int32 // = 5
-    case fixed64 // = 6
-    case fixed32 // = 7
-    case bool // = 8
-    case string // = 9
+    case int32 = 5
+    case fixed64 = 6
+    case fixed32 = 7
+    case bool = 8
+    case string = 9
 
     /// Tag-delimited aggregate.
     /// Group type is deprecated and not supported after google.protobuf. However, Proto3
     /// implementations should still be able to parse the group wire format and
     /// treat group fields as unknown fields.  In Editions, the group wire format
     /// can be enabled via the `message_encoding` feature.
-    case group // = 10
+    case group = 10
 
     /// Length-delimited aggregate.
-    case message // = 11
+    case message = 11
 
     /// New in version 2.
-    case bytes // = 12
-    case uint32 // = 13
-    case `enum` // = 14
-    case sfixed32 // = 15
-    case sfixed64 // = 16
+    case bytes = 12
+    case uint32 = 13
+    case `enum` = 14
+    case sfixed32 = 15
+    case sfixed64 = 16
 
     /// Uses ZigZag encoding.
-    case sint32 // = 17
+    case sint32 = 17
 
     /// Uses ZigZag encoding.
-    case sint64 // = 18
+    case sint64 = 18
 
     public init() {
       self = .double
     }
 
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .double
-      case 2: self = .float
-      case 3: self = .int64
-      case 4: self = .uint64
-      case 5: self = .int32
-      case 6: self = .fixed64
-      case 7: self = .fixed32
-      case 8: self = .bool
-      case 9: self = .string
-      case 10: self = .group
-      case 11: self = .message
-      case 12: self = .bytes
-      case 13: self = .uint32
-      case 14: self = .enum
-      case 15: self = .sfixed32
-      case 16: self = .sfixed64
-      case 17: self = .sint32
-      case 18: self = .sint64
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .double: return 1
-      case .float: return 2
-      case .int64: return 3
-      case .uint64: return 4
-      case .int32: return 5
-      case .fixed64: return 6
-      case .fixed32: return 7
-      case .bool: return 8
-      case .string: return 9
-      case .group: return 10
-      case .message: return 11
-      case .bytes: return 12
-      case .uint32: return 13
-      case .enum: return 14
-      case .sfixed32: return 15
-      case .sfixed64: return 16
-      case .sint32: return 17
-      case .sint64: return 18
-      }
-    }
-
   }
 
-  public enum Label: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum Label: Int, Enum, Swift.CaseIterable {
 
     /// 0 is reserved for errors
-    case `optional` // = 1
-    case repeated // = 3
+    case `optional` = 1
+    case repeated = 3
 
     /// The required label is only allowed in google.protobuf.  In proto3 and Editions
     /// it's explicitly prohibited.  In Editions, the `field_presence` feature
     /// can be used to get this behavior.
-    case `required` // = 2
+    case `required` = 2
 
     public init() {
       self = .optional
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .optional
-      case 2: self = .required
-      case 3: self = .repeated
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .optional: return 1
-      case .required: return 2
-      case .repeated: return 3
-      }
     }
 
   }
@@ -1384,37 +1266,19 @@ public struct Google_Protobuf_FileOptions: ExtensibleMessage, @unchecked Sendabl
   public var unknownFields = UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  public enum OptimizeMode: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum OptimizeMode: Int, Enum, Swift.CaseIterable {
 
     /// Generate complete code for parsing, serialization,
-    case speed // = 1
+    case speed = 1
 
     /// etc.
-    case codeSize // = 2
+    case codeSize = 2
 
     /// Generate code using MessageLite and the lite runtime.
-    case liteRuntime // = 3
+    case liteRuntime = 3
 
     public init() {
       self = .speed
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .speed
-      case 2: self = .codeSize
-      case 3: self = .liteRuntime
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .speed: return 1
-      case .codeSize: return 2
-      case .liteRuntime: return 3
-      }
     }
 
   }
@@ -1745,11 +1609,10 @@ public struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendab
 
   public var unknownFields = UnknownStorage()
 
-  public enum CType: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum CType: Int, Enum, Swift.CaseIterable {
 
     /// Default mode.
-    case string // = 0
+    case string = 0
 
     /// The option [ctype=CORD] may be applied to a non-repeated field of type
     /// "bytes". It indicates that in C++, the data should be stored in a Cord
@@ -1757,93 +1620,40 @@ public struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendab
     /// fragmentation. It may also allow better performance when parsing from a
     /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
     /// alias the original buffer.
-    case cord // = 1
-    case stringPiece // = 2
+    case cord = 1
+    case stringPiece = 2
 
     public init() {
       self = .string
     }
 
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .string
-      case 1: self = .cord
-      case 2: self = .stringPiece
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .string: return 0
-      case .cord: return 1
-      case .stringPiece: return 2
-      }
-    }
-
   }
 
-  public enum JSType: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
+  public enum JSType: Int, Enum, Swift.CaseIterable {
 
     /// Use the default type.
-    case jsNormal // = 0
+    case jsNormal = 0
 
     /// Use JavaScript strings.
-    case jsString // = 1
+    case jsString = 1
 
     /// Use JavaScript numbers.
-    case jsNumber // = 2
+    case jsNumber = 2
 
     public init() {
       self = .jsNormal
     }
 
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .jsNormal
-      case 1: self = .jsString
-      case 2: self = .jsNumber
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .jsNormal: return 0
-      case .jsString: return 1
-      case .jsNumber: return 2
-      }
-    }
-
   }
 
   /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
-  public enum OptionRetention: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case retentionUnknown // = 0
-    case retentionRuntime // = 1
-    case retentionSource // = 2
+  public enum OptionRetention: Int, Enum, Swift.CaseIterable {
+    case retentionUnknown = 0
+    case retentionRuntime = 1
+    case retentionSource = 2
 
     public init() {
       self = .retentionUnknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .retentionUnknown
-      case 1: self = .retentionRuntime
-      case 2: self = .retentionSource
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .retentionUnknown: return 0
-      case .retentionRuntime: return 1
-      case .retentionSource: return 2
-      }
     }
 
   }
@@ -1851,52 +1661,20 @@ public struct Google_Protobuf_FieldOptions: ExtensibleMessage, @unchecked Sendab
   /// This indicates the types of entities that the field may apply to when used
   /// as an option. If it is unset, then the field may be freely used as an
   /// option on any kind of entity.
-  public enum OptionTargetType: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case targetTypeUnknown // = 0
-    case targetTypeFile // = 1
-    case targetTypeExtensionRange // = 2
-    case targetTypeMessage // = 3
-    case targetTypeField // = 4
-    case targetTypeOneof // = 5
-    case targetTypeEnum // = 6
-    case targetTypeEnumEntry // = 7
-    case targetTypeService // = 8
-    case targetTypeMethod // = 9
+  public enum OptionTargetType: Int, Enum, Swift.CaseIterable {
+    case targetTypeUnknown = 0
+    case targetTypeFile = 1
+    case targetTypeExtensionRange = 2
+    case targetTypeMessage = 3
+    case targetTypeField = 4
+    case targetTypeOneof = 5
+    case targetTypeEnum = 6
+    case targetTypeEnumEntry = 7
+    case targetTypeService = 8
+    case targetTypeMethod = 9
 
     public init() {
       self = .targetTypeUnknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .targetTypeUnknown
-      case 1: self = .targetTypeFile
-      case 2: self = .targetTypeExtensionRange
-      case 3: self = .targetTypeMessage
-      case 4: self = .targetTypeField
-      case 5: self = .targetTypeOneof
-      case 6: self = .targetTypeEnum
-      case 7: self = .targetTypeEnumEntry
-      case 8: self = .targetTypeService
-      case 9: self = .targetTypeMethod
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .targetTypeUnknown: return 0
-      case .targetTypeFile: return 1
-      case .targetTypeExtensionRange: return 2
-      case .targetTypeMessage: return 3
-      case .targetTypeField: return 4
-      case .targetTypeOneof: return 5
-      case .targetTypeEnum: return 6
-      case .targetTypeEnumEntry: return 7
-      case .targetTypeService: return 8
-      case .targetTypeMethod: return 9
-      }
     }
 
   }
@@ -2261,35 +2039,17 @@ public struct Google_Protobuf_MethodOptions: ExtensibleMessage, Sendable {
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  public enum IdempotencyLevel: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case idempotencyUnknown // = 0
+  public enum IdempotencyLevel: Int, Enum, Swift.CaseIterable {
+    case idempotencyUnknown = 0
 
     /// implies idempotent
-    case noSideEffects // = 1
+    case noSideEffects = 1
 
     /// idempotent, but may have side effects
-    case idempotent // = 2
+    case idempotent = 2
 
     public init() {
       self = .idempotencyUnknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .idempotencyUnknown
-      case 1: self = .noSideEffects
-      case 2: self = .idempotent
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .idempotencyUnknown: return 0
-      case .noSideEffects: return 1
-      case .idempotent: return 2
-      }
     }
 
   }
@@ -2486,179 +2246,69 @@ public struct Google_Protobuf_FeatureSet: ExtensibleMessage, Sendable {
 
   public var unknownFields = UnknownStorage()
 
-  public enum FieldPresence: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case explicit // = 1
-    case implicit // = 2
-    case legacyRequired // = 3
+  public enum FieldPresence: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case explicit = 1
+    case implicit = 2
+    case legacyRequired = 3
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .explicit
-      case 2: self = .implicit
-      case 3: self = .legacyRequired
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .explicit: return 1
-      case .implicit: return 2
-      case .legacyRequired: return 3
-      }
     }
 
   }
 
-  public enum EnumType: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case `open` // = 1
-    case closed // = 2
+  public enum EnumType: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case `open` = 1
+    case closed = 2
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .open
-      case 2: self = .closed
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .open: return 1
-      case .closed: return 2
-      }
     }
 
   }
 
-  public enum RepeatedFieldEncoding: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case packed // = 1
-    case expanded // = 2
+  public enum RepeatedFieldEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case packed = 1
+    case expanded = 2
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .packed
-      case 2: self = .expanded
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .packed: return 1
-      case .expanded: return 2
-      }
     }
 
   }
 
-  public enum Utf8Validation: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case verify // = 2
-    case none // = 3
+  public enum Utf8Validation: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case verify = 2
+    case none = 3
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 2: self = .verify
-      case 3: self = .none
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .verify: return 2
-      case .none: return 3
-      }
     }
 
   }
 
-  public enum MessageEncoding: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case lengthPrefixed // = 1
-    case delimited // = 2
+  public enum MessageEncoding: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case lengthPrefixed = 1
+    case delimited = 2
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .lengthPrefixed
-      case 2: self = .delimited
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .lengthPrefixed: return 1
-      case .delimited: return 2
-      }
     }
 
   }
 
-  public enum JsonFormat: Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case unknown // = 0
-    case allow // = 1
-    case legacyBestEffort // = 2
+  public enum JsonFormat: Int, Enum, Swift.CaseIterable {
+    case unknown = 0
+    case allow = 1
+    case legacyBestEffort = 2
 
     public init() {
       self = .unknown
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .allow
-      case 2: self = .legacyBestEffort
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .allow: return 1
-      case .legacyBestEffort: return 2
-      }
     }
 
   }
@@ -3002,37 +2652,19 @@ public struct Google_Protobuf_GeneratedCodeInfo: Sendable {
 
     /// Represents the identified object's effect on the element in the original
     /// .proto file.
-    public enum Semantic: Enum, Swift.CaseIterable {
-      public typealias RawValue = Int
+    public enum Semantic: Int, Enum, Swift.CaseIterable {
 
       /// There is no effect or the effect is indescribable.
-      case none // = 0
+      case none = 0
 
       /// The element is set or otherwise mutated.
-      case set // = 1
+      case set = 1
 
       /// An alias to the element is returned.
-      case alias // = 2
+      case alias = 2
 
       public init() {
         self = .none
-      }
-
-      public init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .none
-        case 1: self = .set
-        case 2: self = .alias
-        default: return nil
-        }
-      }
-
-      public var rawValue: Int {
-        switch self {
-        case .none: return 0
-        case .set: return 1
-        case .alias: return 2
-        }
       }
 
     }

--- a/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
@@ -224,31 +224,13 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: Sendable {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Sync with code_generator.h.
-  public enum Feature: SwiftProtobuf.Enum, Swift.CaseIterable {
-    public typealias RawValue = Int
-    case none // = 0
-    case proto3Optional // = 1
-    case supportsEditions // = 2
+  public enum Feature: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case none = 0
+    case proto3Optional = 1
+    case supportsEditions = 2
 
     public init() {
       self = .none
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .none
-      case 1: self = .proto3Optional
-      case 2: self = .supportsEditions
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .none: return 0
-      case .proto3Optional: return 1
-      case .supportsEditions: return 2
-      }
     }
 
   }

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
@@ -36,31 +36,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SDTTopLevelEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case valueZero // = 0
-  case valueOne // = 1
-  case valueTwo // = 2
+enum SDTTopLevelEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case valueZero = 0
+  case valueOne = 1
+  case valueTwo = 2
 
   init() {
     self = .valueZero
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .valueZero
-    case 1: self = .valueOne
-    case 2: self = .valueTwo
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .valueZero: return 0
-    case .valueOne: return 1
-    case .valueTwo: return 2
-    }
   }
 
 }
@@ -135,31 +117,13 @@ struct SDTTopLevelMessage: @unchecked Sendable {
 
   }
 
-  enum SubEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case subValue0 // = 0
-    case subValue1 // = 1
-    case subValue2 // = 2
+  enum SubEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case subValue0 = 0
+    case subValue1 = 1
+    case subValue2 = 2
 
     init() {
       self = .subValue0
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .subValue0
-      case 1: self = .subValue1
-      case 2: self = .subValue2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .subValue0: return 0
-      case .subValue1: return 1
-      case .subValue2: return 2
-      }
     }
 
   }

--- a/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
@@ -84,43 +84,17 @@ struct SwiftFeatureTest_TestFeatures: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumFeature: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unknown // = 0
-    case value1 // = 1
-    case value2 // = 2
-    case value3 // = 3
-    case value4 // = 4
-    case value5 // = 5
-    case value6 // = 6
+  enum EnumFeature: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case unknown = 0
+    case value1 = 1
+    case value2 = 2
+    case value3 = 3
+    case value4 = 4
+    case value5 = 5
+    case value6 = 6
 
     init() {
       self = .unknown
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unknown
-      case 1: self = .value1
-      case 2: self = .value2
-      case 3: self = .value3
-      case 4: self = .value4
-      case 5: self = .value5
-      case 6: self = .value6
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unknown: return 0
-      case .value1: return 1
-      case .value2: return 2
-      case .value3: return 3
-      case .value4: return 4
-      case .value5: return 5
-      case .value6: return 6
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
+++ b/Tests/SwiftProtobufTests/fuzz_testing.pb.swift
@@ -35,34 +35,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Fuzz_AnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case zero // = 0
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_Fuzz_AnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case zero = 0
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .zero
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .zero
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .zero: return 0
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -50,63 +50,25 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Proto2MapEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum SwiftProtoTesting_Proto2MapEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
-  }
-
 }
 
-enum SwiftProtoTesting_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case eProto2MapEnumFoo // = 0
-  case eProto2MapEnumBar // = 1
-  case eProto2MapEnumBaz // = 2
-  case eProto2MapEnumExtra // = 3
+enum SwiftProtoTesting_Proto2MapEnumPlusExtra: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case eProto2MapEnumFoo = 0
+  case eProto2MapEnumBar = 1
+  case eProto2MapEnumBaz = 2
+  case eProto2MapEnumExtra = 3
 
   init() {
     self = .eProto2MapEnumFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .eProto2MapEnumFoo
-    case 1: self = .eProto2MapEnumBar
-    case 2: self = .eProto2MapEnumBaz
-    case 3: self = .eProto2MapEnumExtra
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .eProto2MapEnumFoo: return 0
-    case .eProto2MapEnumBar: return 1
-    case .eProto2MapEnumBaz: return 2
-    case .eProto2MapEnumExtra: return 3
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -59,63 +59,27 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_ForeignEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foreignFoo // = 4
-  case foreignBar // = 5
-  case foreignBaz // = 6
+enum SwiftProtoTesting_ForeignEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foreignFoo = 4
+  case foreignBar = 5
+  case foreignBaz = 6
 
   init() {
     self = .foreignFoo
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 4: self = .foreignFoo
-    case 5: self = .foreignBar
-    case 6: self = .foreignBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foreignFoo: return 4
-    case .foreignBar: return 5
-    case .foreignBaz: return 6
-    }
-  }
-
 }
 
 /// Test an enum that has multiple values with the same number.
-enum SwiftProtoTesting_TestEnumWithDupValue: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo1 // = 1
-  case bar1 // = 2
-  case baz // = 3
+enum SwiftProtoTesting_TestEnumWithDupValue: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo1 = 1
+  case bar1 = 2
+  case baz = 3
   static let foo2 = foo1
   static let bar2 = bar1
 
   init() {
     self = .foo1
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .foo1
-    case 2: self = .bar1
-    case 3: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo1: return 1
-    case .bar1: return 2
-    case .baz: return 3
-    }
   }
 
 }
@@ -728,36 +692,16 @@ struct SwiftProtoTesting_TestAllTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -56,31 +56,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Import_ImportEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case importFoo // = 7
-  case importBar // = 8
-  case importBaz // = 9
+enum SwiftProtoTesting_Import_ImportEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case importFoo = 7
+  case importBar = 8
+  case importBaz = 9
 
   init() {
     self = .importFoo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 7: self = .importFoo
-    case 8: self = .importBar
-    case 9: self = .importBaz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .importFoo: return 7
-    case .importBar: return 8
-    case .importBaz: return 9
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -50,31 +50,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case foo // = 0
-  case bar // = 1
-  case baz // = 2
+enum SwiftProtoTesting_UnknownEnum_Proto2_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case foo = 0
+  case bar = 1
+  case baz = 2
 
   init() {
     self = .foo
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .foo
-    case 1: self = .bar
-    case 2: self = .baz
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .foo: return 0
-    case .bar: return 1
-    case .baz: return 2
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -529,36 +529,16 @@ struct SwiftProtoTesting_TestAllRequiredTypes: @unchecked Sendable {
 
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
-    case bar // = 2
-    case baz // = 3
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
+    case bar = 2
+    case baz = 3
 
     /// Intentionally negative.
-    case neg // = -1
+    case neg = -1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case -1: self = .neg
-      case 1: self = .foo
-      case 2: self = .bar
-      case 3: self = .baz
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .neg: return -1
-      case .foo: return 1
-      case .bar: return 2
-      case .baz: return 3
-      }
     }
 
   }
@@ -675,25 +655,11 @@ struct SwiftProtoTesting_TestSomeRequiredTypes: @unchecked Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 1
+  enum NestedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 1
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 1
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_deprecated.pb.swift
@@ -37,37 +37,19 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// An enum value marked as deprecated.
-enum SwiftProtoTesting_Deprecated_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
+enum SwiftProtoTesting_Deprecated_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
 
   /// Enum comment
   ///
   /// NOTE: This enum value was marked as deprecated in the .proto file
-  case two // = 2
+  case two = 2
 
   /// NOTE: This enum value was marked as deprecated in the .proto file
-  case three // = 3
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }
@@ -75,31 +57,13 @@ enum SwiftProtoTesting_Deprecated_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable
 /// Whole enum marked as deprecated.
 ///
 /// NOTE: This enum was marked as deprecated in the .proto file.
-enum SwiftProtoTesting_Deprecated_MyEnum2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_Deprecated_MyEnum2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_deprecated_file.pb.swift
@@ -37,31 +37,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// NOTE: The whole .proto file that defined this enum was marked as deprecated.
-enum SwiftProtoTesting_DeprecatedFile_MyEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case one // = 1
-  case two // = 2
-  case three // = 3
+enum SwiftProtoTesting_DeprecatedFile_MyEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case one = 1
+  case two = 2
+  case three = 3
 
   init() {
     self = .one
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 1: self = .one
-    case 2: self = .two
-    case 3: self = .three
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .one: return 1
-    case .two: return 2
-    case .three: return 3
-    }
   }
 
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -70,25 +70,11 @@ struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-      typealias RawValue = Int
-      case foo // = 0
+    enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+      case foo = 0
 
       init() {
         self = .foo
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .foo
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .foo: return 0
-        }
       }
 
     }
@@ -114,25 +100,11 @@ struct SwiftProtoTesting_Extend_EnumOptionalDefault: Sendable {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-      typealias RawValue = Int
-      case foo // = 0
+    enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+      case foo = 0
 
       init() {
         self = .foo
-      }
-
-      init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .foo
-        default: return nil
-        }
-      }
-
-      var rawValue: Int {
-        switch self {
-        case .foo: return 0
-        }
       }
 
     }

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
@@ -65,106 +65,42 @@ struct SwiftProtoTesting_Enum2_SwiftEnumTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumTest1: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case firstValue // = 1
-    case secondValue // = 2
+  enum EnumTest1: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case firstValue = 1
+    case secondValue = 2
 
     init() {
       self = .firstValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .firstValue
-      case 2: self = .secondValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .firstValue: return 1
-      case .secondValue: return 2
-      }
-    }
-
   }
 
-  enum EnumTest2: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case firstValue // = 1
-    case secondValue // = 2
+  enum EnumTest2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case firstValue = 1
+    case secondValue = 2
 
     init() {
       self = .firstValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .firstValue
-      case 2: self = .secondValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .firstValue: return 1
-      case .secondValue: return 2
-      }
-    }
-
   }
 
-  enum EnumTestNoStem: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case enumTestNoStem1 // = 1
-    case enumTestNoStem2 // = 2
+  enum EnumTestNoStem: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case enumTestNoStem1 = 1
+    case enumTestNoStem2 = 2
 
     init() {
       self = .enumTestNoStem1
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .enumTestNoStem1
-      case 2: self = .enumTestNoStem2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .enumTestNoStem1: return 1
-      case .enumTestNoStem2: return 2
-      }
-    }
-
   }
 
-  enum EnumTestReservedWord: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case `var` // = 1
-    case notReserved // = 2
+  enum EnumTestReservedWord: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case `var` = 1
+    case notReserved = 2
 
     init() {
       self = .var
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .var
-      case 2: self = .notReserved
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .var: return 1
-      case .notReserved: return 2
-      }
     }
 
   }
@@ -181,35 +117,17 @@ struct SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumWithAlias: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo1 // = 1
+  enum EnumWithAlias: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo1 = 1
     static let foo2 = foo1
 
     /// out of value order to test allCases
-    case baz1 // = 3
-    case bar1 // = 2
+    case baz1 = 3
+    case bar1 = 2
     static let bar2 = bar1
 
     init() {
       self = .foo1
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .foo1
-      case 2: self = .bar1
-      case 3: self = .baz1
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo1: return 1
-      case .bar1: return 2
-      case .baz1: return 3
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -38,655 +38,226 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-enum SwiftProtoTesting_Names_EnumFieldNames: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case a // = 0
-  case string // = 1
-  case int // = 2
-  case double // = 3
-  case float // = 4
-  case uint // = 5
-  case hashValue_ // = 6
-  case description_ // = 7
-  case debugDescription_ // = 8
-  case swift // = 9
-  case unrecognized // = 10
-  case `class` // = 11
-  case `deinit` // = 12
-  case `enum` // = 13
-  case `extension` // = 14
-  case `func` // = 15
-  case `import` // = 16
-  case init_ // = 17
-  case `inout` // = 18
-  case `internal` // = 19
-  case `let` // = 20
-  case `operator` // = 21
-  case `private` // = 22
-  case `protocol` // = 23
-  case `public` // = 24
-  case `static` // = 25
-  case `struct` // = 26
-  case `subscript` // = 27
-  case `typealias` // = 28
-  case `var` // = 29
-  case `break` // = 30
-  case `case` // = 31
-  case `continue` // = 32
-  case `default` // = 33
-  case `defer` // = 34
-  case `do` // = 35
-  case `else` // = 36
-  case `fallthrough` // = 37
-  case `for` // = 38
-  case `guard` // = 39
-  case `if` // = 40
-  case `in` // = 41
-  case `repeat` // = 42
-  case `return` // = 43
-  case `switch` // = 44
-  case `where` // = 45
-  case `while` // = 46
-  case `as` // = 47
-  case `catch` // = 48
-  case dynamicType_ // = 49
-  case `false` // = 50
-  case `is` // = 51
-  case `nil` // = 52
-  case `rethrows` // = 53
-  case `super` // = 54
-  case self_ // = 55
-  case `throw` // = 57
-  case `throws` // = 58
-  case `true` // = 59
-  case `try` // = 60
-  case _Column__ // = 61
-  case _File__ // = 62
-  case _Function__ // = 63
-  case _Line__ // = 64
-  case ___ // = 65
-  case `associativity` // = 66
-  case convenience // = 67
-  case dynamic // = 68
-  case didSet // = 69
-  case final // = 70
-  case get // = 71
-  case infix // = 72
-  case indirect // = 73
-  case lazy // = 74
-  case left // = 75
-  case mutating // = 76
-  case none // = 77
-  case nonmutating // = 78
-  case `optional` // = 79
-  case override // = 80
-  case postfix // = 81
-  case precedence // = 82
-  case prefix // = 83
-  case `required` // = 85
-  case right // = 86
-  case set // = 87
-  case type // = 88
-  case unowned // = 89
-  case weak // = 90
-  case willSet // = 91
+enum SwiftProtoTesting_Names_EnumFieldNames: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case a = 0
+  case string = 1
+  case int = 2
+  case double = 3
+  case float = 4
+  case uint = 5
+  case hashValue_ = 6
+  case description_ = 7
+  case debugDescription_ = 8
+  case swift = 9
+  case unrecognized = 10
+  case `class` = 11
+  case `deinit` = 12
+  case `enum` = 13
+  case `extension` = 14
+  case `func` = 15
+  case `import` = 16
+  case init_ = 17
+  case `inout` = 18
+  case `internal` = 19
+  case `let` = 20
+  case `operator` = 21
+  case `private` = 22
+  case `protocol` = 23
+  case `public` = 24
+  case `static` = 25
+  case `struct` = 26
+  case `subscript` = 27
+  case `typealias` = 28
+  case `var` = 29
+  case `break` = 30
+  case `case` = 31
+  case `continue` = 32
+  case `default` = 33
+  case `defer` = 34
+  case `do` = 35
+  case `else` = 36
+  case `fallthrough` = 37
+  case `for` = 38
+  case `guard` = 39
+  case `if` = 40
+  case `in` = 41
+  case `repeat` = 42
+  case `return` = 43
+  case `switch` = 44
+  case `where` = 45
+  case `while` = 46
+  case `as` = 47
+  case `catch` = 48
+  case dynamicType_ = 49
+  case `false` = 50
+  case `is` = 51
+  case `nil` = 52
+  case `rethrows` = 53
+  case `super` = 54
+  case self_ = 55
+  case `throw` = 57
+  case `throws` = 58
+  case `true` = 59
+  case `try` = 60
+  case _Column__ = 61
+  case _File__ = 62
+  case _Function__ = 63
+  case _Line__ = 64
+  case ___ = 65
+  case `associativity` = 66
+  case convenience = 67
+  case dynamic = 68
+  case didSet = 69
+  case final = 70
+  case get = 71
+  case infix = 72
+  case indirect = 73
+  case lazy = 74
+  case left = 75
+  case mutating = 76
+  case none = 77
+  case nonmutating = 78
+  case `optional` = 79
+  case override = 80
+  case postfix = 81
+  case precedence = 82
+  case prefix = 83
+  case `required` = 85
+  case right = 86
+  case set = 87
+  case type = 88
+  case unowned = 89
+  case weak = 90
+  case willSet = 91
 
   ///    id = 92;
-  case cmd // = 93
-  case out // = 96
-  case bycopy // = 98
-  case byref // = 99
-  case oneway // = 100
-  case and // = 102
-  case andEq // = 103
-  case alignas // = 104
-  case alignof // = 105
-  case asm // = 106
-  case auto // = 107
-  case bitand // = 108
-  case bitor // = 109
-  case bool // = 110
-  case char // = 114
-  case char16T // = 115
-  case char32T // = 116
-  case compl // = 118
-  case const // = 119
-  case constexpr // = 120
-  case constCast // = 121
-  case decltype // = 123
-  case delete // = 125
-  case dynamicCast // = 127
-  case explicit // = 130
-  case export // = 131
-  case extern // = 132
-  case friend // = 136
-  case goto // = 137
-  case inline // = 139
-  case long // = 141
-  case mutable // = 142
-  case namespace // = 143
-  case new // = 144
-  case noexcept // = 145
-  case not // = 146
-  case notEq // = 147
-  case nullptr // = 148
-  case or // = 150
-  case orEq // = 151
-  case protected // = 153
-  case register // = 155
-  case reinterpretCast // = 156
-  case short // = 158
-  case signed // = 159
-  case sizeof // = 160
-  case staticAssert // = 162
-  case staticCast // = 163
-  case template // = 166
-  case this // = 167
-  case threadLocal // = 168
-  case typedef // = 172
-  case typeid // = 173
-  case typename // = 174
-  case union // = 175
-  case unsigned // = 176
-  case using // = 177
-  case virtual // = 178
-  case void // = 179
-  case volatile // = 180
-  case wcharT // = 181
-  case xor // = 183
-  case xorEq // = 184
-  case restrict // = 185
-  case category // = 186
-  case ivar // = 187
-  case method // = 188
-  case finalize // = 192
-  case hash // = 193
-  case dealloc // = 194
-  case superclass // = 197
-  case retain // = 198
-  case release // = 199
-  case autorelease // = 200
-  case retainCount // = 201
-  case zone // = 202
-  case isProxy // = 203
-  case copy // = 204
-  case mutableCopy // = 205
-  case classForCoder // = 206
-  case clear // = 207
-  case data // = 208
-  case delimitedData // = 209
-  case descriptor // = 210
-  case extensionRegistry // = 211
-  case extensionsCurrentlySet // = 212
-  case isInitialized // = 213
-  case serializedSize // = 214
-  case sortedExtensionsInUse // = 215
-  case unknownFields // = 216
-  case fixed // = 217
-  case fract // = 218
-  case size // = 219
-  case logicalAddress // = 220
-  case physicalAddress // = 221
-  case byteCount // = 222
-  case byteOffset // = 223
-  case duration // = 224
-  case absoluteTime // = 225
-  case optionBits // = 226
-  case itemCount // = 227
-  case pbversion // = 228
-  case scriptCode // = 229
-  case langCode // = 230
-  case regionCode // = 231
-  case ostype // = 232
-  case processSerialNumber // = 233
-  case point // = 234
-  case rect // = 235
-  case fixedPoint // = 236
-  case fixedRect // = 237
-  case style // = 238
-  case styleParameter // = 239
-  case styleField // = 240
-  case timeScale // = 241
-  case timeBase // = 242
-  case timeRecord // = 243
-  case extensions // = 244
+  case cmd = 93
+  case out = 96
+  case bycopy = 98
+  case byref = 99
+  case oneway = 100
+  case and = 102
+  case andEq = 103
+  case alignas = 104
+  case alignof = 105
+  case asm = 106
+  case auto = 107
+  case bitand = 108
+  case bitor = 109
+  case bool = 110
+  case char = 114
+  case char16T = 115
+  case char32T = 116
+  case compl = 118
+  case const = 119
+  case constexpr = 120
+  case constCast = 121
+  case decltype = 123
+  case delete = 125
+  case dynamicCast = 127
+  case explicit = 130
+  case export = 131
+  case extern = 132
+  case friend = 136
+  case goto = 137
+  case inline = 139
+  case long = 141
+  case mutable = 142
+  case namespace = 143
+  case new = 144
+  case noexcept = 145
+  case not = 146
+  case notEq = 147
+  case nullptr = 148
+  case or = 150
+  case orEq = 151
+  case protected = 153
+  case register = 155
+  case reinterpretCast = 156
+  case short = 158
+  case signed = 159
+  case sizeof = 160
+  case staticAssert = 162
+  case staticCast = 163
+  case template = 166
+  case this = 167
+  case threadLocal = 168
+  case typedef = 172
+  case typeid = 173
+  case typename = 174
+  case union = 175
+  case unsigned = 176
+  case using = 177
+  case virtual = 178
+  case void = 179
+  case volatile = 180
+  case wcharT = 181
+  case xor = 183
+  case xorEq = 184
+  case restrict = 185
+  case category = 186
+  case ivar = 187
+  case method = 188
+  case finalize = 192
+  case hash = 193
+  case dealloc = 194
+  case superclass = 197
+  case retain = 198
+  case release = 199
+  case autorelease = 200
+  case retainCount = 201
+  case zone = 202
+  case isProxy = 203
+  case copy = 204
+  case mutableCopy = 205
+  case classForCoder = 206
+  case clear = 207
+  case data = 208
+  case delimitedData = 209
+  case descriptor = 210
+  case extensionRegistry = 211
+  case extensionsCurrentlySet = 212
+  case isInitialized = 213
+  case serializedSize = 214
+  case sortedExtensionsInUse = 215
+  case unknownFields = 216
+  case fixed = 217
+  case fract = 218
+  case size = 219
+  case logicalAddress = 220
+  case physicalAddress = 221
+  case byteCount = 222
+  case byteOffset = 223
+  case duration = 224
+  case absoluteTime = 225
+  case optionBits = 226
+  case itemCount = 227
+  case pbversion = 228
+  case scriptCode = 229
+  case langCode = 230
+  case regionCode = 231
+  case ostype = 232
+  case processSerialNumber = 233
+  case point = 234
+  case rect = 235
+  case fixedPoint = 236
+  case fixedRect = 237
+  case style = 238
+  case styleParameter = 239
+  case styleField = 240
+  case timeScale = 241
+  case timeBase = 242
+  case timeRecord = 243
+  case extensions = 244
 
   init() {
     self = .a
   }
 
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .a
-    case 1: self = .string
-    case 2: self = .int
-    case 3: self = .double
-    case 4: self = .float
-    case 5: self = .uint
-    case 6: self = .hashValue_
-    case 7: self = .description_
-    case 8: self = .debugDescription_
-    case 9: self = .swift
-    case 10: self = .unrecognized
-    case 11: self = .class
-    case 12: self = .deinit
-    case 13: self = .enum
-    case 14: self = .extension
-    case 15: self = .func
-    case 16: self = .import
-    case 17: self = .init_
-    case 18: self = .inout
-    case 19: self = .internal
-    case 20: self = .let
-    case 21: self = .operator
-    case 22: self = .private
-    case 23: self = .protocol
-    case 24: self = .public
-    case 25: self = .static
-    case 26: self = .struct
-    case 27: self = .subscript
-    case 28: self = .typealias
-    case 29: self = .var
-    case 30: self = .break
-    case 31: self = .case
-    case 32: self = .continue
-    case 33: self = .default
-    case 34: self = .defer
-    case 35: self = .do
-    case 36: self = .else
-    case 37: self = .fallthrough
-    case 38: self = .for
-    case 39: self = .guard
-    case 40: self = .if
-    case 41: self = .in
-    case 42: self = .repeat
-    case 43: self = .return
-    case 44: self = .switch
-    case 45: self = .where
-    case 46: self = .while
-    case 47: self = .as
-    case 48: self = .catch
-    case 49: self = .dynamicType_
-    case 50: self = .false
-    case 51: self = .is
-    case 52: self = .nil
-    case 53: self = .rethrows
-    case 54: self = .super
-    case 55: self = .self_
-    case 57: self = .throw
-    case 58: self = .throws
-    case 59: self = .true
-    case 60: self = .try
-    case 61: self = ._Column__
-    case 62: self = ._File__
-    case 63: self = ._Function__
-    case 64: self = ._Line__
-    case 65: self = .___
-    case 66: self = .associativity
-    case 67: self = .convenience
-    case 68: self = .dynamic
-    case 69: self = .didSet
-    case 70: self = .final
-    case 71: self = .get
-    case 72: self = .infix
-    case 73: self = .indirect
-    case 74: self = .lazy
-    case 75: self = .left
-    case 76: self = .mutating
-    case 77: self = .none
-    case 78: self = .nonmutating
-    case 79: self = .optional
-    case 80: self = .override
-    case 81: self = .postfix
-    case 82: self = .precedence
-    case 83: self = .prefix
-    case 85: self = .required
-    case 86: self = .right
-    case 87: self = .set
-    case 88: self = .type
-    case 89: self = .unowned
-    case 90: self = .weak
-    case 91: self = .willSet
-    case 93: self = .cmd
-    case 96: self = .out
-    case 98: self = .bycopy
-    case 99: self = .byref
-    case 100: self = .oneway
-    case 102: self = .and
-    case 103: self = .andEq
-    case 104: self = .alignas
-    case 105: self = .alignof
-    case 106: self = .asm
-    case 107: self = .auto
-    case 108: self = .bitand
-    case 109: self = .bitor
-    case 110: self = .bool
-    case 114: self = .char
-    case 115: self = .char16T
-    case 116: self = .char32T
-    case 118: self = .compl
-    case 119: self = .const
-    case 120: self = .constexpr
-    case 121: self = .constCast
-    case 123: self = .decltype
-    case 125: self = .delete
-    case 127: self = .dynamicCast
-    case 130: self = .explicit
-    case 131: self = .export
-    case 132: self = .extern
-    case 136: self = .friend
-    case 137: self = .goto
-    case 139: self = .inline
-    case 141: self = .long
-    case 142: self = .mutable
-    case 143: self = .namespace
-    case 144: self = .new
-    case 145: self = .noexcept
-    case 146: self = .not
-    case 147: self = .notEq
-    case 148: self = .nullptr
-    case 150: self = .or
-    case 151: self = .orEq
-    case 153: self = .protected
-    case 155: self = .register
-    case 156: self = .reinterpretCast
-    case 158: self = .short
-    case 159: self = .signed
-    case 160: self = .sizeof
-    case 162: self = .staticAssert
-    case 163: self = .staticCast
-    case 166: self = .template
-    case 167: self = .this
-    case 168: self = .threadLocal
-    case 172: self = .typedef
-    case 173: self = .typeid
-    case 174: self = .typename
-    case 175: self = .union
-    case 176: self = .unsigned
-    case 177: self = .using
-    case 178: self = .virtual
-    case 179: self = .void
-    case 180: self = .volatile
-    case 181: self = .wcharT
-    case 183: self = .xor
-    case 184: self = .xorEq
-    case 185: self = .restrict
-    case 186: self = .category
-    case 187: self = .ivar
-    case 188: self = .method
-    case 192: self = .finalize
-    case 193: self = .hash
-    case 194: self = .dealloc
-    case 197: self = .superclass
-    case 198: self = .retain
-    case 199: self = .release
-    case 200: self = .autorelease
-    case 201: self = .retainCount
-    case 202: self = .zone
-    case 203: self = .isProxy
-    case 204: self = .copy
-    case 205: self = .mutableCopy
-    case 206: self = .classForCoder
-    case 207: self = .clear
-    case 208: self = .data
-    case 209: self = .delimitedData
-    case 210: self = .descriptor
-    case 211: self = .extensionRegistry
-    case 212: self = .extensionsCurrentlySet
-    case 213: self = .isInitialized
-    case 214: self = .serializedSize
-    case 215: self = .sortedExtensionsInUse
-    case 216: self = .unknownFields
-    case 217: self = .fixed
-    case 218: self = .fract
-    case 219: self = .size
-    case 220: self = .logicalAddress
-    case 221: self = .physicalAddress
-    case 222: self = .byteCount
-    case 223: self = .byteOffset
-    case 224: self = .duration
-    case 225: self = .absoluteTime
-    case 226: self = .optionBits
-    case 227: self = .itemCount
-    case 228: self = .pbversion
-    case 229: self = .scriptCode
-    case 230: self = .langCode
-    case 231: self = .regionCode
-    case 232: self = .ostype
-    case 233: self = .processSerialNumber
-    case 234: self = .point
-    case 235: self = .rect
-    case 236: self = .fixedPoint
-    case 237: self = .fixedRect
-    case 238: self = .style
-    case 239: self = .styleParameter
-    case 240: self = .styleField
-    case 241: self = .timeScale
-    case 242: self = .timeBase
-    case 243: self = .timeRecord
-    case 244: self = .extensions
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .a: return 0
-    case .string: return 1
-    case .int: return 2
-    case .double: return 3
-    case .float: return 4
-    case .uint: return 5
-    case .hashValue_: return 6
-    case .description_: return 7
-    case .debugDescription_: return 8
-    case .swift: return 9
-    case .unrecognized: return 10
-    case .class: return 11
-    case .deinit: return 12
-    case .enum: return 13
-    case .extension: return 14
-    case .func: return 15
-    case .import: return 16
-    case .init_: return 17
-    case .inout: return 18
-    case .internal: return 19
-    case .let: return 20
-    case .operator: return 21
-    case .private: return 22
-    case .protocol: return 23
-    case .public: return 24
-    case .static: return 25
-    case .struct: return 26
-    case .subscript: return 27
-    case .typealias: return 28
-    case .var: return 29
-    case .break: return 30
-    case .case: return 31
-    case .continue: return 32
-    case .default: return 33
-    case .defer: return 34
-    case .do: return 35
-    case .else: return 36
-    case .fallthrough: return 37
-    case .for: return 38
-    case .guard: return 39
-    case .if: return 40
-    case .in: return 41
-    case .repeat: return 42
-    case .return: return 43
-    case .switch: return 44
-    case .where: return 45
-    case .while: return 46
-    case .as: return 47
-    case .catch: return 48
-    case .dynamicType_: return 49
-    case .false: return 50
-    case .is: return 51
-    case .nil: return 52
-    case .rethrows: return 53
-    case .super: return 54
-    case .self_: return 55
-    case .throw: return 57
-    case .throws: return 58
-    case .true: return 59
-    case .try: return 60
-    case ._Column__: return 61
-    case ._File__: return 62
-    case ._Function__: return 63
-    case ._Line__: return 64
-    case .___: return 65
-    case .associativity: return 66
-    case .convenience: return 67
-    case .dynamic: return 68
-    case .didSet: return 69
-    case .final: return 70
-    case .get: return 71
-    case .infix: return 72
-    case .indirect: return 73
-    case .lazy: return 74
-    case .left: return 75
-    case .mutating: return 76
-    case .none: return 77
-    case .nonmutating: return 78
-    case .optional: return 79
-    case .override: return 80
-    case .postfix: return 81
-    case .precedence: return 82
-    case .prefix: return 83
-    case .required: return 85
-    case .right: return 86
-    case .set: return 87
-    case .type: return 88
-    case .unowned: return 89
-    case .weak: return 90
-    case .willSet: return 91
-    case .cmd: return 93
-    case .out: return 96
-    case .bycopy: return 98
-    case .byref: return 99
-    case .oneway: return 100
-    case .and: return 102
-    case .andEq: return 103
-    case .alignas: return 104
-    case .alignof: return 105
-    case .asm: return 106
-    case .auto: return 107
-    case .bitand: return 108
-    case .bitor: return 109
-    case .bool: return 110
-    case .char: return 114
-    case .char16T: return 115
-    case .char32T: return 116
-    case .compl: return 118
-    case .const: return 119
-    case .constexpr: return 120
-    case .constCast: return 121
-    case .decltype: return 123
-    case .delete: return 125
-    case .dynamicCast: return 127
-    case .explicit: return 130
-    case .export: return 131
-    case .extern: return 132
-    case .friend: return 136
-    case .goto: return 137
-    case .inline: return 139
-    case .long: return 141
-    case .mutable: return 142
-    case .namespace: return 143
-    case .new: return 144
-    case .noexcept: return 145
-    case .not: return 146
-    case .notEq: return 147
-    case .nullptr: return 148
-    case .or: return 150
-    case .orEq: return 151
-    case .protected: return 153
-    case .register: return 155
-    case .reinterpretCast: return 156
-    case .short: return 158
-    case .signed: return 159
-    case .sizeof: return 160
-    case .staticAssert: return 162
-    case .staticCast: return 163
-    case .template: return 166
-    case .this: return 167
-    case .threadLocal: return 168
-    case .typedef: return 172
-    case .typeid: return 173
-    case .typename: return 174
-    case .union: return 175
-    case .unsigned: return 176
-    case .using: return 177
-    case .virtual: return 178
-    case .void: return 179
-    case .volatile: return 180
-    case .wcharT: return 181
-    case .xor: return 183
-    case .xorEq: return 184
-    case .restrict: return 185
-    case .category: return 186
-    case .ivar: return 187
-    case .method: return 188
-    case .finalize: return 192
-    case .hash: return 193
-    case .dealloc: return 194
-    case .superclass: return 197
-    case .retain: return 198
-    case .release: return 199
-    case .autorelease: return 200
-    case .retainCount: return 201
-    case .zone: return 202
-    case .isProxy: return 203
-    case .copy: return 204
-    case .mutableCopy: return 205
-    case .classForCoder: return 206
-    case .clear: return 207
-    case .data: return 208
-    case .delimitedData: return 209
-    case .descriptor: return 210
-    case .extensionRegistry: return 211
-    case .extensionsCurrentlySet: return 212
-    case .isInitialized: return 213
-    case .serializedSize: return 214
-    case .sortedExtensionsInUse: return 215
-    case .unknownFields: return 216
-    case .fixed: return 217
-    case .fract: return 218
-    case .size: return 219
-    case .logicalAddress: return 220
-    case .physicalAddress: return 221
-    case .byteCount: return 222
-    case .byteOffset: return 223
-    case .duration: return 224
-    case .absoluteTime: return 225
-    case .optionBits: return 226
-    case .itemCount: return 227
-    case .pbversion: return 228
-    case .scriptCode: return 229
-    case .langCode: return 230
-    case .regionCode: return 231
-    case .ostype: return 232
-    case .processSerialNumber: return 233
-    case .point: return 234
-    case .rect: return 235
-    case .fixedPoint: return 236
-    case .fixedRect: return 237
-    case .style: return 238
-    case .styleParameter: return 239
-    case .styleField: return 240
-    case .timeScale: return 241
-    case .timeBase: return 242
-    case .timeRecord: return 243
-    case .extensions: return 244
-    }
-  }
-
 }
 
-enum SwiftProtoTesting_Names_EnumFieldNames2: SwiftProtobuf.Enum, Swift.CaseIterable {
-  typealias RawValue = Int
-  case aa // = 0
+enum SwiftProtoTesting_Names_EnumFieldNames2: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+  case aa = 0
 
   /// protoc no longer allows enum naming that would differ only in underscores.
   /// Initial commit:
@@ -695,25 +266,10 @@ enum SwiftProtoTesting_Names_EnumFieldNames2: SwiftProtobuf.Enum, Swift.CaseIter
   ///   https://github.com/protocolbuffers/protobuf/pull/2204
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
-  case ____ // = 1065
+  case ____ = 1065
 
   init() {
     self = .aa
-  }
-
-  init?(rawValue: Int) {
-    switch rawValue {
-    case 0: self = .aa
-    case 1065: self = .____
-    default: return nil
-    }
-  }
-
-  var rawValue: Int {
-    switch self {
-    case .aa: return 0
-    case .____: return 1065
-    }
   }
 
 }
@@ -7251,4855 +6807,1901 @@ struct SwiftProtoTesting_Names_EnumNames: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum StringEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aString // = 0
+  enum StringEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aString = 0
 
     init() {
       self = .aString
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aString
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aString: return 0
-      }
-    }
-
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aProtocol // = 0
+  enum ProtocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aProtocol = 0
 
     init() {
       self = .aProtocol
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aProtocol
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aProtocol: return 0
-      }
-    }
-
   }
 
-  enum IntEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aInt // = 0
+  enum IntEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aInt = 0
 
     init() {
       self = .aInt
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aInt
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aInt: return 0
-      }
-    }
-
   }
 
-  enum DoubleEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aDouble // = 0
+  enum DoubleEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aDouble = 0
 
     init() {
       self = .aDouble
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aDouble
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aDouble: return 0
-      }
-    }
-
   }
 
-  enum FloatEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFloat // = 0
+  enum FloatEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFloat = 0
 
     init() {
       self = .aFloat
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFloat
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFloat: return 0
-      }
-    }
-
   }
 
-  enum UIntEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aUint // = 0
+  enum UIntEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aUint = 0
 
     init() {
       self = .aUint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aUint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aUint: return 0
-      }
-    }
-
   }
 
-  enum hashValueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ahashValue // = 0
+  enum hashValueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ahashValue = 0
 
     init() {
       self = .ahashValue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ahashValue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ahashValue: return 0
-      }
-    }
-
   }
 
-  enum descriptionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adescription // = 0
+  enum descriptionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adescription = 0
 
     init() {
       self = .adescription
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adescription
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adescription: return 0
-      }
-    }
-
   }
 
-  enum debugDescriptionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adebugDescription // = 0
+  enum debugDescriptionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adebugDescription = 0
 
     init() {
       self = .adebugDescription
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adebugDescription
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adebugDescription: return 0
-      }
-    }
-
   }
 
-  enum SwiftEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aSwift // = 0
+  enum SwiftEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aSwift = 0
 
     init() {
       self = .aSwift
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aSwift
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aSwift: return 0
-      }
-    }
-
   }
 
-  enum UNRECOGNIZED: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aUnrecognized // = 0
+  enum UNRECOGNIZED: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aUnrecognized = 0
 
     init() {
       self = .aUnrecognized
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aUnrecognized
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aUnrecognized: return 0
-      }
-    }
-
   }
 
-  enum classEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclass // = 0
+  enum classEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclass = 0
 
     init() {
       self = .aclass
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclass
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclass: return 0
-      }
-    }
-
   }
 
-  enum deinitEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adeinit // = 0
+  enum deinitEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adeinit = 0
 
     init() {
       self = .adeinit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adeinit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adeinit: return 0
-      }
-    }
-
   }
 
-  enum enumEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aenum // = 0
+  enum enumEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aenum = 0
 
     init() {
       self = .aenum
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aenum
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aenum: return 0
-      }
-    }
-
   }
 
-  enum extensionEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextension // = 0
+  enum extensionEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextension = 0
 
     init() {
       self = .aextension
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextension
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextension: return 0
-      }
-    }
-
   }
 
-  enum funcEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afunc // = 0
+  enum funcEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afunc = 0
 
     init() {
       self = .afunc
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afunc
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afunc: return 0
-      }
-    }
-
   }
 
-  enum importEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aimport // = 0
+  enum importEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aimport = 0
 
     init() {
       self = .aimport
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aimport
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aimport: return 0
-      }
-    }
-
   }
 
-  enum initEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainit // = 0
+  enum initEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainit = 0
 
     init() {
       self = .ainit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainit: return 0
-      }
-    }
-
   }
 
-  enum inoutEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainout // = 0
+  enum inoutEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainout = 0
 
     init() {
       self = .ainout
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainout
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainout: return 0
-      }
-    }
-
   }
 
-  enum internalEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainternal // = 0
+  enum internalEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainternal = 0
 
     init() {
       self = .ainternal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainternal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainternal: return 0
-      }
-    }
-
   }
 
-  enum letEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case alet // = 0
+  enum letEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case alet = 0
 
     init() {
       self = .alet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .alet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .alet: return 0
-      }
-    }
-
   }
 
-  enum operatorEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoperator // = 0
+  enum operatorEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoperator = 0
 
     init() {
       self = .aoperator
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoperator
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoperator: return 0
-      }
-    }
-
   }
 
-  enum privateEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprivate // = 0
+  enum privateEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprivate = 0
 
     init() {
       self = .aprivate
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprivate
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprivate: return 0
-      }
-    }
-
   }
 
-  enum protocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprotocol // = 0
+  enum protocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprotocol = 0
 
     init() {
       self = .aprotocol
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprotocol
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprotocol: return 0
-      }
-    }
-
   }
 
-  enum publicEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case apublic // = 0
+  enum publicEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case apublic = 0
 
     init() {
       self = .apublic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .apublic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .apublic: return 0
-      }
-    }
-
   }
 
-  enum staticEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astatic // = 0
+  enum staticEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astatic = 0
 
     init() {
       self = .astatic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astatic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astatic: return 0
-      }
-    }
-
   }
 
-  enum structEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astruct // = 0
+  enum structEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astruct = 0
 
     init() {
       self = .astruct
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astruct
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astruct: return 0
-      }
-    }
-
   }
 
-  enum subscriptEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asubscript // = 0
+  enum subscriptEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asubscript = 0
 
     init() {
       self = .asubscript
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asubscript
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asubscript: return 0
-      }
-    }
-
   }
 
-  enum typealiasEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypealias // = 0
+  enum typealiasEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypealias = 0
 
     init() {
       self = .atypealias
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypealias
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypealias: return 0
-      }
-    }
-
   }
 
-  enum varEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avar // = 0
+  enum varEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avar = 0
 
     init() {
       self = .avar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avar: return 0
-      }
-    }
-
   }
 
-  enum breakEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abreak // = 0
+  enum breakEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abreak = 0
 
     init() {
       self = .abreak
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abreak
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abreak: return 0
-      }
-    }
-
   }
 
-  enum caseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acase // = 0
+  enum caseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acase = 0
 
     init() {
       self = .acase
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acase
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acase: return 0
-      }
-    }
-
   }
 
-  enum continueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acontinue // = 0
+  enum continueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acontinue = 0
 
     init() {
       self = .acontinue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acontinue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acontinue: return 0
-      }
-    }
-
   }
 
-  enum defaultEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adefault // = 0
+  enum defaultEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adefault = 0
 
     init() {
       self = .adefault
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adefault
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adefault: return 0
-      }
-    }
-
   }
 
-  enum deferEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adefer // = 0
+  enum deferEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adefer = 0
 
     init() {
       self = .adefer
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adefer
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adefer: return 0
-      }
-    }
-
   }
 
-  enum doEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ado // = 0
+  enum doEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ado = 0
 
     init() {
       self = .ado
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ado
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ado: return 0
-      }
-    }
-
   }
 
-  enum elseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aelse // = 0
+  enum elseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aelse = 0
 
     init() {
       self = .aelse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aelse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aelse: return 0
-      }
-    }
-
   }
 
-  enum fallthroughEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afallthrough // = 0
+  enum fallthroughEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afallthrough = 0
 
     init() {
       self = .afallthrough
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afallthrough
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afallthrough: return 0
-      }
-    }
-
   }
 
-  enum forEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afor // = 0
+  enum forEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afor = 0
 
     init() {
       self = .afor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afor: return 0
-      }
-    }
-
   }
 
-  enum guardEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aguard // = 0
+  enum guardEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aguard = 0
 
     init() {
       self = .aguard
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aguard
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aguard: return 0
-      }
-    }
-
   }
 
-  enum ifEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aif // = 0
+  enum ifEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aif = 0
 
     init() {
       self = .aif
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aif
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aif: return 0
-      }
-    }
-
   }
 
-  enum inEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ain // = 0
+  enum inEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ain = 0
 
     init() {
       self = .ain
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ain
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ain: return 0
-      }
-    }
-
   }
 
-  enum repeatEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arepeat // = 0
+  enum repeatEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arepeat = 0
 
     init() {
       self = .arepeat
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arepeat
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arepeat: return 0
-      }
-    }
-
   }
 
-  enum returnEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case areturn // = 0
+  enum returnEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case areturn = 0
 
     init() {
       self = .areturn
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .areturn
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .areturn: return 0
-      }
-    }
-
   }
 
-  enum switchEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aswitch // = 0
+  enum switchEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aswitch = 0
 
     init() {
       self = .aswitch
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aswitch
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aswitch: return 0
-      }
-    }
-
   }
 
-  enum whereEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awhere // = 0
+  enum whereEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awhere = 0
 
     init() {
       self = .awhere
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awhere
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awhere: return 0
-      }
-    }
-
   }
 
-  enum whileEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awhile // = 0
+  enum whileEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awhile = 0
 
     init() {
       self = .awhile
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awhile
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awhile: return 0
-      }
-    }
-
   }
 
-  enum asEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aas // = 0
+  enum asEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aas = 0
 
     init() {
       self = .aas
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aas
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aas: return 0
-      }
-    }
-
   }
 
-  enum catchEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acatch // = 0
+  enum catchEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acatch = 0
 
     init() {
       self = .acatch
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acatch
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acatch: return 0
-      }
-    }
-
   }
 
-  enum dynamicTypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamicType // = 0
+  enum dynamicTypeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamicType = 0
 
     init() {
       self = .adynamicType
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamicType
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamicType: return 0
-      }
-    }
-
   }
 
-  enum falseEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afalse // = 0
+  enum falseEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afalse = 0
 
     init() {
       self = .afalse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afalse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afalse: return 0
-      }
-    }
-
   }
 
-  enum isEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ais // = 0
+  enum isEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ais = 0
 
     init() {
       self = .ais
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ais
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ais: return 0
-      }
-    }
-
   }
 
-  enum nilEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anil // = 0
+  enum nilEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anil = 0
 
     init() {
       self = .anil
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anil
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anil: return 0
-      }
-    }
-
   }
 
-  enum rethrowsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arethrows // = 0
+  enum rethrowsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arethrows = 0
 
     init() {
       self = .arethrows
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arethrows
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arethrows: return 0
-      }
-    }
-
   }
 
-  enum superEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asuper // = 0
+  enum superEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asuper = 0
 
     init() {
       self = .asuper
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asuper
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asuper: return 0
-      }
-    }
-
   }
 
-  enum selfEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aself // = 0
+  enum selfEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aself = 0
 
     init() {
       self = .aself
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aself
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aself: return 0
-      }
-    }
-
   }
 
-  enum throwEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athrow // = 0
+  enum throwEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athrow = 0
 
     init() {
       self = .athrow
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athrow
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athrow: return 0
-      }
-    }
-
   }
 
-  enum throwsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athrows // = 0
+  enum throwsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athrows = 0
 
     init() {
       self = .athrows
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athrows
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athrows: return 0
-      }
-    }
-
   }
 
-  enum trueEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atrue // = 0
+  enum trueEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atrue = 0
 
     init() {
       self = .atrue
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atrue
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atrue: return 0
-      }
-    }
-
   }
 
-  enum tryEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atry // = 0
+  enum tryEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atry = 0
 
     init() {
       self = .atry
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atry
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atry: return 0
-      }
-    }
-
   }
 
-  enum __COLUMN__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Column__ // = 0
+  enum __COLUMN__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Column__ = 0
 
     init() {
       self = .a_Column__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Column__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Column__: return 0
-      }
-    }
-
   }
 
-  enum __FILE__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_File__ // = 0
+  enum __FILE__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_File__ = 0
 
     init() {
       self = .a_File__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_File__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_File__: return 0
-      }
-    }
-
   }
 
-  enum __FUNCTION__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Function__ // = 0
+  enum __FUNCTION__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Function__ = 0
 
     init() {
       self = .a_Function__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Function__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Function__: return 0
-      }
-    }
-
   }
 
-  enum __LINE__Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_Line__ // = 0
+  enum __LINE__Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_Line__ = 0
 
     init() {
       self = .a_Line__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_Line__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_Line__: return 0
-      }
-    }
-
   }
 
-  enum _Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a_ // = 0
+  enum _Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a_ = 0
 
     init() {
       self = .a_
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a_
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a_: return 0
-      }
-    }
-
   }
 
-  enum __Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a__ // = 0
+  enum __Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a__ = 0
 
     init() {
       self = .a__
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .a__
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a__: return 0
-      }
-    }
-
   }
 
-  enum associativity: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aassociativity // = 0
+  enum associativity: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aassociativity = 0
 
     init() {
       self = .aassociativity
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aassociativity
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aassociativity: return 0
-      }
-    }
-
   }
 
-  enum convenience: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconvenience // = 0
+  enum convenience: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconvenience = 0
 
     init() {
       self = .aconvenience
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconvenience
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconvenience: return 0
-      }
-    }
-
   }
 
-  enum dynamic: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamic // = 0
+  enum dynamic: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamic = 0
 
     init() {
       self = .adynamic
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamic
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamic: return 0
-      }
-    }
-
   }
 
-  enum didSet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adidSet // = 0
+  enum didSet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adidSet = 0
 
     init() {
       self = .adidSet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adidSet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adidSet: return 0
-      }
-    }
-
   }
 
-  enum final: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afinal // = 0
+  enum final: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afinal = 0
 
     init() {
       self = .afinal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afinal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afinal: return 0
-      }
-    }
-
   }
 
-  enum get: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aget // = 0
+  enum get: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aget = 0
 
     init() {
       self = .aget
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aget
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aget: return 0
-      }
-    }
-
   }
 
-  enum infix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainfix // = 0
+  enum infix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainfix = 0
 
     init() {
       self = .ainfix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainfix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainfix: return 0
-      }
-    }
-
   }
 
-  enum indirect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aindirect // = 0
+  enum indirect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aindirect = 0
 
     init() {
       self = .aindirect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aindirect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aindirect: return 0
-      }
-    }
-
   }
 
-  enum lazy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case alazy // = 0
+  enum lazy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case alazy = 0
 
     init() {
       self = .alazy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .alazy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .alazy: return 0
-      }
-    }
-
   }
 
-  enum left: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aleft // = 0
+  enum left: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aleft = 0
 
     init() {
       self = .aleft
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aleft
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aleft: return 0
-      }
-    }
-
   }
 
-  enum mutating: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutating // = 0
+  enum mutating: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutating = 0
 
     init() {
       self = .amutating
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutating
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutating: return 0
-      }
-    }
-
   }
 
-  enum none: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anone // = 0
+  enum none: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anone = 0
 
     init() {
       self = .anone
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anone
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anone: return 0
-      }
-    }
-
   }
 
-  enum nonmutating: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anonmutating // = 0
+  enum nonmutating: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anonmutating = 0
 
     init() {
       self = .anonmutating
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anonmutating
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anonmutating: return 0
-      }
-    }
-
   }
 
-  enum optional: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoptional // = 0
+  enum optional: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoptional = 0
 
     init() {
       self = .aoptional
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoptional
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoptional: return 0
-      }
-    }
-
   }
 
-  enum override: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoverride // = 0
+  enum override: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoverride = 0
 
     init() {
       self = .aoverride
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoverride
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoverride: return 0
-      }
-    }
-
   }
 
-  enum postfix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case apostfix // = 0
+  enum postfix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case apostfix = 0
 
     init() {
       self = .apostfix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .apostfix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .apostfix: return 0
-      }
-    }
-
   }
 
-  enum precedence: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprecedence // = 0
+  enum precedence: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprecedence = 0
 
     init() {
       self = .aprecedence
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprecedence
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprecedence: return 0
-      }
-    }
-
   }
 
-  enum prefix: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprefix // = 0
+  enum prefix: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprefix = 0
 
     init() {
       self = .aprefix
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprefix
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprefix: return 0
-      }
-    }
-
   }
 
-  enum required: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arequired // = 0
+  enum required: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arequired = 0
 
     init() {
       self = .arequired
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arequired
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arequired: return 0
-      }
-    }
-
   }
 
-  enum right: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aright // = 0
+  enum right: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aright = 0
 
     init() {
       self = .aright
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aright
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aright: return 0
-      }
-    }
-
   }
 
-  enum set: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aset // = 0
+  enum set: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aset = 0
 
     init() {
       self = .aset
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aset
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aset: return 0
-      }
-    }
-
   }
 
-  enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aType // = 0
+  enum TypeEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aType = 0
 
     init() {
       self = .aType
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aType
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aType: return 0
-      }
-    }
-
   }
 
-  enum unowned: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunowned // = 0
+  enum unowned: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunowned = 0
 
     init() {
       self = .aunowned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunowned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunowned: return 0
-      }
-    }
-
   }
 
-  enum weak: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aweak // = 0
+  enum weak: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aweak = 0
 
     init() {
       self = .aweak
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aweak
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aweak: return 0
-      }
-    }
-
   }
 
-  enum willSet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awillSet // = 0
+  enum willSet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awillSet = 0
 
     init() {
       self = .awillSet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awillSet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awillSet: return 0
-      }
-    }
-
   }
 
-  enum id: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aid // = 0
+  enum id: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aid = 0
 
     init() {
       self = .aid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aid: return 0
-      }
-    }
-
   }
 
-  enum _cmd: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aCmd // = 0
+  enum _cmd: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aCmd = 0
 
     init() {
       self = .aCmd
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aCmd
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aCmd: return 0
-      }
-    }
-
   }
 
-  enum out: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aout // = 0
+  enum out: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aout = 0
 
     init() {
       self = .aout
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aout
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aout: return 0
-      }
-    }
-
   }
 
-  enum bycopy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abycopy // = 0
+  enum bycopy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abycopy = 0
 
     init() {
       self = .abycopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abycopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abycopy: return 0
-      }
-    }
-
   }
 
-  enum byref: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abyref // = 0
+  enum byref: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abyref = 0
 
     init() {
       self = .abyref
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abyref
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abyref: return 0
-      }
-    }
-
   }
 
-  enum oneway: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aoneway // = 0
+  enum oneway: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aoneway = 0
 
     init() {
       self = .aoneway
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aoneway
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aoneway: return 0
-      }
-    }
-
   }
 
-  enum and: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aand // = 0
+  enum and: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aand = 0
 
     init() {
       self = .aand
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aand
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aand: return 0
-      }
-    }
-
   }
 
-  enum and_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aandEq // = 0
+  enum and_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aandEq = 0
 
     init() {
       self = .aandEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aandEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aandEq: return 0
-      }
-    }
-
   }
 
-  enum alignas: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aalignas // = 0
+  enum alignas: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aalignas = 0
 
     init() {
       self = .aalignas
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aalignas
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aalignas: return 0
-      }
-    }
-
   }
 
-  enum alignof: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aalignof // = 0
+  enum alignof: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aalignof = 0
 
     init() {
       self = .aalignof
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aalignof
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aalignof: return 0
-      }
-    }
-
   }
 
-  enum asm: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aasm // = 0
+  enum asm: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aasm = 0
 
     init() {
       self = .aasm
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aasm
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aasm: return 0
-      }
-    }
-
   }
 
-  enum auto: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aauto // = 0
+  enum auto: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aauto = 0
 
     init() {
       self = .aauto
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aauto
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aauto: return 0
-      }
-    }
-
   }
 
-  enum bitand: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abitand // = 0
+  enum bitand: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abitand = 0
 
     init() {
       self = .abitand
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abitand
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abitand: return 0
-      }
-    }
-
   }
 
-  enum bitor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abitor // = 0
+  enum bitor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abitor = 0
 
     init() {
       self = .abitor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abitor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abitor: return 0
-      }
-    }
-
   }
 
-  enum bool: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case abool // = 0
+  enum bool: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case abool = 0
 
     init() {
       self = .abool
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .abool
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .abool: return 0
-      }
-    }
-
   }
 
-  enum char: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar // = 0
+  enum char: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar = 0
 
     init() {
       self = .achar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar: return 0
-      }
-    }
-
   }
 
-  enum char16_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar16T // = 0
+  enum char16_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar16T = 0
 
     init() {
       self = .achar16T
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar16T
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar16T: return 0
-      }
-    }
-
   }
 
-  enum char32_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case achar32T // = 0
+  enum char32_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case achar32T = 0
 
     init() {
       self = .achar32T
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .achar32T
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .achar32T: return 0
-      }
-    }
-
   }
 
-  enum compl: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acompl // = 0
+  enum compl: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acompl = 0
 
     init() {
       self = .acompl
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acompl
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acompl: return 0
-      }
-    }
-
   }
 
-  enum const: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconst // = 0
+  enum const: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconst = 0
 
     init() {
       self = .aconst
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconst
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconst: return 0
-      }
-    }
-
   }
 
-  enum constexpr: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconstexpr // = 0
+  enum constexpr: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconstexpr = 0
 
     init() {
       self = .aconstexpr
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconstexpr
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconstexpr: return 0
-      }
-    }
-
   }
 
-  enum const_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aconstCast // = 0
+  enum const_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aconstCast = 0
 
     init() {
       self = .aconstCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aconstCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aconstCast: return 0
-      }
-    }
-
   }
 
-  enum decltype: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adecltype // = 0
+  enum decltype: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adecltype = 0
 
     init() {
       self = .adecltype
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adecltype
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adecltype: return 0
-      }
-    }
-
   }
 
-  enum delete: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adelete // = 0
+  enum delete: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adelete = 0
 
     init() {
       self = .adelete
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adelete
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adelete: return 0
-      }
-    }
-
   }
 
-  enum dynamic_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adynamicCast // = 0
+  enum dynamic_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adynamicCast = 0
 
     init() {
       self = .adynamicCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adynamicCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adynamicCast: return 0
-      }
-    }
-
   }
 
-  enum explicit: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aexplicit // = 0
+  enum explicit: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aexplicit = 0
 
     init() {
       self = .aexplicit
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aexplicit
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aexplicit: return 0
-      }
-    }
-
   }
 
-  enum export: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aexport // = 0
+  enum export: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aexport = 0
 
     init() {
       self = .aexport
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aexport
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aexport: return 0
-      }
-    }
-
   }
 
-  enum extern: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextern // = 0
+  enum extern: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextern = 0
 
     init() {
       self = .aextern
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextern
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextern: return 0
-      }
-    }
-
   }
 
-  enum friend: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afriend // = 0
+  enum friend: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afriend = 0
 
     init() {
       self = .afriend
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afriend
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afriend: return 0
-      }
-    }
-
   }
 
-  enum goto: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case agoto // = 0
+  enum goto: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case agoto = 0
 
     init() {
       self = .agoto
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .agoto
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .agoto: return 0
-      }
-    }
-
   }
 
-  enum inline: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ainline // = 0
+  enum inline: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ainline = 0
 
     init() {
       self = .ainline
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ainline
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ainline: return 0
-      }
-    }
-
   }
 
-  enum long: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case along // = 0
+  enum long: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case along = 0
 
     init() {
       self = .along
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .along
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .along: return 0
-      }
-    }
-
   }
 
-  enum mutable: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutable // = 0
+  enum mutable: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutable = 0
 
     init() {
       self = .amutable
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutable
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutable: return 0
-      }
-    }
-
   }
 
-  enum namespace: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anamespace // = 0
+  enum namespace: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anamespace = 0
 
     init() {
       self = .anamespace
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anamespace
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anamespace: return 0
-      }
-    }
-
   }
 
-  enum new: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anew // = 0
+  enum new: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anew = 0
 
     init() {
       self = .anew
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anew
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anew: return 0
-      }
-    }
-
   }
 
-  enum noexcept: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anoexcept // = 0
+  enum noexcept: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anoexcept = 0
 
     init() {
       self = .anoexcept
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anoexcept
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anoexcept: return 0
-      }
-    }
-
   }
 
-  enum not: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anot // = 0
+  enum not: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anot = 0
 
     init() {
       self = .anot
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anot
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anot: return 0
-      }
-    }
-
   }
 
-  enum not_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anotEq // = 0
+  enum not_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anotEq = 0
 
     init() {
       self = .anotEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anotEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anotEq: return 0
-      }
-    }
-
   }
 
-  enum nullptr: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case anullptr // = 0
+  enum nullptr: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case anullptr = 0
 
     init() {
       self = .anullptr
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .anullptr
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .anullptr: return 0
-      }
-    }
-
   }
 
-  enum or: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aor // = 0
+  enum or: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aor = 0
 
     init() {
       self = .aor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aor: return 0
-      }
-    }
-
   }
 
-  enum or_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aorEq // = 0
+  enum or_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aorEq = 0
 
     init() {
       self = .aorEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aorEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aorEq: return 0
-      }
-    }
-
   }
 
-  enum protected: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aprotected // = 0
+  enum protected: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aprotected = 0
 
     init() {
       self = .aprotected
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aprotected
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aprotected: return 0
-      }
-    }
-
   }
 
-  enum register: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aregister // = 0
+  enum register: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aregister = 0
 
     init() {
       self = .aregister
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aregister
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aregister: return 0
-      }
-    }
-
   }
 
-  enum reinterpret_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case areinterpretCast // = 0
+  enum reinterpret_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case areinterpretCast = 0
 
     init() {
       self = .areinterpretCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .areinterpretCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .areinterpretCast: return 0
-      }
-    }
-
   }
 
-  enum short: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ashort // = 0
+  enum short: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ashort = 0
 
     init() {
       self = .ashort
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ashort
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ashort: return 0
-      }
-    }
-
   }
 
-  enum signed: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asigned // = 0
+  enum signed: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asigned = 0
 
     init() {
       self = .asigned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asigned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asigned: return 0
-      }
-    }
-
   }
 
-  enum sizeof: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asizeof // = 0
+  enum sizeof: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asizeof = 0
 
     init() {
       self = .asizeof
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asizeof
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asizeof: return 0
-      }
-    }
-
   }
 
-  enum static_assert: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astaticAssert // = 0
+  enum static_assert: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astaticAssert = 0
 
     init() {
       self = .astaticAssert
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astaticAssert
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astaticAssert: return 0
-      }
-    }
-
   }
 
-  enum static_cast: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case astaticCast // = 0
+  enum static_cast: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case astaticCast = 0
 
     init() {
       self = .astaticCast
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .astaticCast
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .astaticCast: return 0
-      }
-    }
-
   }
 
-  enum template: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atemplate // = 0
+  enum template: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atemplate = 0
 
     init() {
       self = .atemplate
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atemplate
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atemplate: return 0
-      }
-    }
-
   }
 
-  enum this: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athis // = 0
+  enum this: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athis = 0
 
     init() {
       self = .athis
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athis
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athis: return 0
-      }
-    }
-
   }
 
-  enum thread_local: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case athreadLocal // = 0
+  enum thread_local: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case athreadLocal = 0
 
     init() {
       self = .athreadLocal
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .athreadLocal
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .athreadLocal: return 0
-      }
-    }
-
   }
 
-  enum typedef: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypedef // = 0
+  enum typedef: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypedef = 0
 
     init() {
       self = .atypedef
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypedef
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypedef: return 0
-      }
-    }
-
   }
 
-  enum typeid: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypeid // = 0
+  enum typeid: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypeid = 0
 
     init() {
       self = .atypeid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypeid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypeid: return 0
-      }
-    }
-
   }
 
-  enum typename: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case atypename // = 0
+  enum typename: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case atypename = 0
 
     init() {
       self = .atypename
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .atypename
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .atypename: return 0
-      }
-    }
-
   }
 
-  enum union: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunion // = 0
+  enum union: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunion = 0
 
     init() {
       self = .aunion
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunion
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunion: return 0
-      }
-    }
-
   }
 
-  enum unsigned: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunsigned // = 0
+  enum unsigned: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunsigned = 0
 
     init() {
       self = .aunsigned
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunsigned
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunsigned: return 0
-      }
-    }
-
   }
 
-  enum using: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ausing // = 0
+  enum using: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ausing = 0
 
     init() {
       self = .ausing
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ausing
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ausing: return 0
-      }
-    }
-
   }
 
-  enum virtual: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avirtual // = 0
+  enum virtual: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avirtual = 0
 
     init() {
       self = .avirtual
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avirtual
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avirtual: return 0
-      }
-    }
-
   }
 
-  enum void: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avoid // = 0
+  enum void: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avoid = 0
 
     init() {
       self = .avoid
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avoid
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avoid: return 0
-      }
-    }
-
   }
 
-  enum volatile: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case avolatile // = 0
+  enum volatile: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case avolatile = 0
 
     init() {
       self = .avolatile
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .avolatile
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .avolatile: return 0
-      }
-    }
-
   }
 
-  enum wchar_t: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case awcharT // = 0
+  enum wchar_t: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case awcharT = 0
 
     init() {
       self = .awcharT
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .awcharT
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .awcharT: return 0
-      }
-    }
-
   }
 
-  enum xor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case axor // = 0
+  enum xor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case axor = 0
 
     init() {
       self = .axor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .axor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .axor: return 0
-      }
-    }
-
   }
 
-  enum xor_eq: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case axorEq // = 0
+  enum xor_eq: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case axorEq = 0
 
     init() {
       self = .axorEq
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .axorEq
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .axorEq: return 0
-      }
-    }
-
   }
 
-  enum restrict: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arestrict // = 0
+  enum restrict: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arestrict = 0
 
     init() {
       self = .arestrict
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arestrict
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arestrict: return 0
-      }
-    }
-
   }
 
-  enum Category: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aCategory // = 0
+  enum Category: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aCategory = 0
 
     init() {
       self = .aCategory
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aCategory
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aCategory: return 0
-      }
-    }
-
   }
 
-  enum Ivar: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aIvar // = 0
+  enum Ivar: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aIvar = 0
 
     init() {
       self = .aIvar
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aIvar
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aIvar: return 0
-      }
-    }
-
   }
 
-  enum Method: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aMethod // = 0
+  enum Method: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aMethod = 0
 
     init() {
       self = .aMethod
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aMethod
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aMethod: return 0
-      }
-    }
-
   }
 
-  enum finalize: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case afinalize // = 0
+  enum finalize: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case afinalize = 0
 
     init() {
       self = .afinalize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .afinalize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .afinalize: return 0
-      }
-    }
-
   }
 
-  enum hash: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case ahash // = 0
+  enum hash: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case ahash = 0
 
     init() {
       self = .ahash
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .ahash
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .ahash: return 0
-      }
-    }
-
   }
 
-  enum dealloc: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adealloc // = 0
+  enum dealloc: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adealloc = 0
 
     init() {
       self = .adealloc
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adealloc
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adealloc: return 0
-      }
-    }
-
   }
 
-  enum superclass: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asuperclass // = 0
+  enum superclass: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asuperclass = 0
 
     init() {
       self = .asuperclass
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asuperclass
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asuperclass: return 0
-      }
-    }
-
   }
 
-  enum retain: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aretain // = 0
+  enum retain: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aretain = 0
 
     init() {
       self = .aretain
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aretain
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aretain: return 0
-      }
-    }
-
   }
 
-  enum release: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case arelease // = 0
+  enum release: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case arelease = 0
 
     init() {
       self = .arelease
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .arelease
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .arelease: return 0
-      }
-    }
-
   }
 
-  enum autorelease: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aautorelease // = 0
+  enum autorelease: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aautorelease = 0
 
     init() {
       self = .aautorelease
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aautorelease
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aautorelease: return 0
-      }
-    }
-
   }
 
-  enum retainCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aretainCount // = 0
+  enum retainCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aretainCount = 0
 
     init() {
       self = .aretainCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aretainCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aretainCount: return 0
-      }
-    }
-
   }
 
-  enum zone: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case azone // = 0
+  enum zone: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case azone = 0
 
     init() {
       self = .azone
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .azone
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .azone: return 0
-      }
-    }
-
   }
 
-  enum isProxy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aisProxy // = 0
+  enum isProxy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aisProxy = 0
 
     init() {
       self = .aisProxy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aisProxy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aisProxy: return 0
-      }
-    }
-
   }
 
-  enum copy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case acopy // = 0
+  enum copy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case acopy = 0
 
     init() {
       self = .acopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .acopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .acopy: return 0
-      }
-    }
-
   }
 
-  enum mutableCopy: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case amutableCopy // = 0
+  enum mutableCopy: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case amutableCopy = 0
 
     init() {
       self = .amutableCopy
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .amutableCopy
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .amutableCopy: return 0
-      }
-    }
-
   }
 
-  enum classForCoder: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclassForCoder // = 0
+  enum classForCoder: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclassForCoder = 0
 
     init() {
       self = .aclassForCoder
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclassForCoder
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclassForCoder: return 0
-      }
-    }
-
   }
 
-  enum clear: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aclear // = 0
+  enum clear: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aclear = 0
 
     init() {
       self = .aclear
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aclear
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aclear: return 0
-      }
-    }
-
   }
 
-  enum data: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adata // = 0
+  enum data: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adata = 0
 
     init() {
       self = .adata
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adata
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adata: return 0
-      }
-    }
-
   }
 
-  enum delimitedData: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adelimitedData // = 0
+  enum delimitedData: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adelimitedData = 0
 
     init() {
       self = .adelimitedData
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adelimitedData
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adelimitedData: return 0
-      }
-    }
-
   }
 
-  enum descriptor: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case adescriptor // = 0
+  enum descriptor: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case adescriptor = 0
 
     init() {
       self = .adescriptor
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .adescriptor
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .adescriptor: return 0
-      }
-    }
-
   }
 
-  enum extensionRegistry: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextensionRegistry // = 0
+  enum extensionRegistry: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextensionRegistry = 0
 
     init() {
       self = .aextensionRegistry
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextensionRegistry
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextensionRegistry: return 0
-      }
-    }
-
   }
 
-  enum extensionsCurrentlySet: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aextensionsCurrentlySet // = 0
+  enum extensionsCurrentlySet: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aextensionsCurrentlySet = 0
 
     init() {
       self = .aextensionsCurrentlySet
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aextensionsCurrentlySet
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aextensionsCurrentlySet: return 0
-      }
-    }
-
   }
 
-  enum isInitializedEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aisInitialized // = 0
+  enum isInitializedEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aisInitialized = 0
 
     init() {
       self = .aisInitialized
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aisInitialized
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aisInitialized: return 0
-      }
-    }
-
   }
 
-  enum serializedSize: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aserializedSize // = 0
+  enum serializedSize: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aserializedSize = 0
 
     init() {
       self = .aserializedSize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aserializedSize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aserializedSize: return 0
-      }
-    }
-
   }
 
-  enum sortedExtensionsInUse: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case asortedExtensionsInUse // = 0
+  enum sortedExtensionsInUse: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case asortedExtensionsInUse = 0
 
     init() {
       self = .asortedExtensionsInUse
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .asortedExtensionsInUse
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .asortedExtensionsInUse: return 0
-      }
-    }
-
   }
 
-  enum unknownFieldsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aunknownFields // = 0
+  enum unknownFieldsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aunknownFields = 0
 
     init() {
       self = .aunknownFields
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aunknownFields
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aunknownFields: return 0
-      }
-    }
-
   }
 
-  enum Fixed: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixed // = 0
+  enum Fixed: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixed = 0
 
     init() {
       self = .aFixed
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixed
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixed: return 0
-      }
-    }
-
   }
 
-  enum Fract: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFract // = 0
+  enum Fract: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFract = 0
 
     init() {
       self = .aFract
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFract
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFract: return 0
-      }
-    }
-
   }
 
-  enum Size: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aSize // = 0
+  enum Size: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aSize = 0
 
     init() {
       self = .aSize
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aSize
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aSize: return 0
-      }
-    }
-
   }
 
-  enum LogicalAddress: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aLogicalAddress // = 0
+  enum LogicalAddress: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aLogicalAddress = 0
 
     init() {
       self = .aLogicalAddress
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aLogicalAddress
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aLogicalAddress: return 0
-      }
-    }
-
   }
 
-  enum PhysicalAddress: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPhysicalAddress // = 0
+  enum PhysicalAddress: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPhysicalAddress = 0
 
     init() {
       self = .aPhysicalAddress
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPhysicalAddress
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPhysicalAddress: return 0
-      }
-    }
-
   }
 
-  enum ByteCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aByteCount // = 0
+  enum ByteCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aByteCount = 0
 
     init() {
       self = .aByteCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aByteCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aByteCount: return 0
-      }
-    }
-
   }
 
-  enum ByteOffset: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aByteOffset // = 0
+  enum ByteOffset: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aByteOffset = 0
 
     init() {
       self = .aByteOffset
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aByteOffset
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aByteOffset: return 0
-      }
-    }
-
   }
 
-  enum Duration: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aDuration // = 0
+  enum Duration: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aDuration = 0
 
     init() {
       self = .aDuration
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aDuration
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aDuration: return 0
-      }
-    }
-
   }
 
-  enum AbsoluteTime: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aAbsoluteTime // = 0
+  enum AbsoluteTime: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aAbsoluteTime = 0
 
     init() {
       self = .aAbsoluteTime
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aAbsoluteTime
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aAbsoluteTime: return 0
-      }
-    }
-
   }
 
-  enum OptionBits: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aOptionBits // = 0
+  enum OptionBits: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aOptionBits = 0
 
     init() {
       self = .aOptionBits
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aOptionBits
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aOptionBits: return 0
-      }
-    }
-
   }
 
-  enum ItemCount: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aItemCount // = 0
+  enum ItemCount: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aItemCount = 0
 
     init() {
       self = .aItemCount
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aItemCount
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aItemCount: return 0
-      }
-    }
-
   }
 
-  enum PBVersion: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPbversion // = 0
+  enum PBVersion: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPbversion = 0
 
     init() {
       self = .aPbversion
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPbversion
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPbversion: return 0
-      }
-    }
-
   }
 
-  enum ScriptCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aScriptCode // = 0
+  enum ScriptCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aScriptCode = 0
 
     init() {
       self = .aScriptCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aScriptCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aScriptCode: return 0
-      }
-    }
-
   }
 
-  enum LangCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aLangCode // = 0
+  enum LangCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aLangCode = 0
 
     init() {
       self = .aLangCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aLangCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aLangCode: return 0
-      }
-    }
-
   }
 
-  enum RegionCode: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aRegionCode // = 0
+  enum RegionCode: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aRegionCode = 0
 
     init() {
       self = .aRegionCode
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aRegionCode
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aRegionCode: return 0
-      }
-    }
-
   }
 
-  enum OSType: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aOstype // = 0
+  enum OSType: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aOstype = 0
 
     init() {
       self = .aOstype
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aOstype
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aOstype: return 0
-      }
-    }
-
   }
 
-  enum ProcessSerialNumber: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aProcessSerialNumber // = 0
+  enum ProcessSerialNumber: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aProcessSerialNumber = 0
 
     init() {
       self = .aProcessSerialNumber
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aProcessSerialNumber
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aProcessSerialNumber: return 0
-      }
-    }
-
   }
 
-  enum Point: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aPoint // = 0
+  enum Point: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aPoint = 0
 
     init() {
       self = .aPoint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aPoint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aPoint: return 0
-      }
-    }
-
   }
 
-  enum Rect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aRect // = 0
+  enum Rect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aRect = 0
 
     init() {
       self = .aRect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aRect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aRect: return 0
-      }
-    }
-
   }
 
-  enum FixedPoint: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixedPoint // = 0
+  enum FixedPoint: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixedPoint = 0
 
     init() {
       self = .aFixedPoint
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixedPoint
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixedPoint: return 0
-      }
-    }
-
   }
 
-  enum FixedRect: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aFixedRect // = 0
+  enum FixedRect: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aFixedRect = 0
 
     init() {
       self = .aFixedRect
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aFixedRect
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aFixedRect: return 0
-      }
-    }
-
   }
 
-  enum Style: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyle // = 0
+  enum Style: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyle = 0
 
     init() {
       self = .aStyle
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyle
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyle: return 0
-      }
-    }
-
   }
 
-  enum StyleParameter: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyleParameter // = 0
+  enum StyleParameter: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyleParameter = 0
 
     init() {
       self = .aStyleParameter
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyleParameter
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyleParameter: return 0
-      }
-    }
-
   }
 
-  enum StyleField: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aStyleField // = 0
+  enum StyleField: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aStyleField = 0
 
     init() {
       self = .aStyleField
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aStyleField
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aStyleField: return 0
-      }
-    }
-
   }
 
-  enum TimeScale: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeScale // = 0
+  enum TimeScale: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeScale = 0
 
     init() {
       self = .aTimeScale
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeScale
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeScale: return 0
-      }
-    }
-
   }
 
-  enum TimeBase: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeBase // = 0
+  enum TimeBase: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeBase = 0
 
     init() {
       self = .aTimeBase
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeBase
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeBase: return 0
-      }
-    }
-
   }
 
-  enum TimeRecord: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aTimeRecord // = 0
+  enum TimeRecord: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aTimeRecord = 0
 
     init() {
       self = .aTimeRecord
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aTimeRecord
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aTimeRecord: return 0
-      }
-    }
-
   }
 
-  enum Extension: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aExtension // = 0
+  enum Extension: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aExtension = 0
 
     init() {
       self = .aExtension
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aExtension
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aExtension: return 0
-      }
-    }
-
   }
 
-  enum ExtensionsEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case aExtensions // = 0
+  enum ExtensionsEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case aExtensions = 0
 
     init() {
       self = .aExtensions
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .aExtensions
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .aExtensions: return 0
-      }
     }
 
   }
@@ -12769,42 +9371,22 @@ struct SwiftProtoTesting_Names_ValidIdentifiers: Sendable {
 
   }
 
-  enum TestEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
+  enum TestEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
 
     /// Won't prefix strip
-    case testEnum0 // = 0
+    case testEnum0 = 0
 
     /// Will prefix strip
-    case first // = 1
+    case first = 1
 
     /// Leading underscore & number, keeps that.
-    case _2 // = 2
+    case _2 = 2
 
     /// Leading underscore & number, keeps that.
-    case _3Value // = 3
+    case _3Value = 3
 
     init() {
       self = .testEnum0
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .testEnum0
-      case 1: self = .first
-      case 2: self = ._2
-      case 3: self = ._3Value
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .testEnum0: return 0
-      case .first: return 1
-      case ._2: return 2
-      case ._3Value: return 3
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -118,63 +118,25 @@ struct SwiftProtoTesting_SwiftReservedTest: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case double // = 1
-    case json // = 2
-    case `class` // = 3
-    case ___ // = 4
-    case self_ // = 5
-    case type // = 6
+  enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case double = 1
+    case json = 2
+    case `class` = 3
+    case ___ = 4
+    case self_ = 5
+    case type = 6
 
     init() {
       self = .double
     }
 
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .double
-      case 2: self = .json
-      case 3: self = .class
-      case 4: self = .___
-      case 5: self = .self_
-      case 6: self = .type
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .double: return 1
-      case .json: return 2
-      case .class: return 3
-      case .___: return 4
-      case .self_: return 5
-      case .type: return 6
-      }
-    }
-
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case a // = 1
+  enum ProtocolEnum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case a = 1
 
     init() {
       self = .a
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .a
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .a: return 1
-      }
     }
 
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -576,34 +576,14 @@ struct SwiftProtoTesting_Message2: @unchecked Sendable {
 
   }
 
-  enum Enum: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case foo // = 0
-    case bar // = 1
-    case baz // = 2
-    case extra2 // = 20
+  enum Enum: Int, SwiftProtobuf.Enum, Swift.CaseIterable {
+    case foo = 0
+    case bar = 1
+    case baz = 2
+    case extra2 = 20
 
     init() {
       self = .foo
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .foo
-      case 1: self = .bar
-      case 2: self = .baz
-      case 20: self = .extra2
-      default: return nil
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .foo: return 0
-      case .bar: return 1
-      case .baz: return 2
-      case .extra2: return 20
-      }
     }
 
   }


### PR DESCRIPTION
For closed enums there no special `UNRECOGNIZED` case, so a plain Swift `Int` enum with explicit values can be used directly.

This results in the generated `init?(rawValue:)` and `var rawValue` functions not being needed, since the compiler will create them automatically.