### PR TITLE
New protocol and generator options for asynchronous mutating traversal of messages

### DIFF
--- a/PluginExamples/Package.swift
+++ b/PluginExamples/Package.swift
@@ -47,6 +47,15 @@ let package = Package(
                 .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
             ]
         ),
+        .target(
+            name: "AsyncTraverse",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
         .testTarget(
             name: "ExampleTests",
             dependencies: [
@@ -54,6 +63,7 @@ let package = Package(
                 .target(name: "Nested"),
                 .target(name: "Import"),
                 .target(name: "AccessLevelOnImport"),
+                .target(name: "AsyncTraverse"),
             ]
         ),
     ],

--- a/PluginExamples/Package@swift-5.8.swift
+++ b/PluginExamples/Package@swift-5.8.swift
@@ -14,6 +14,7 @@ let package = Package(
                 .target(name: "Simple"),
                 .target(name: "Nested"),
                 .target(name: "Import"),
+                .target(name: "AsyncTraverse"),
             ]
         ),
         .target(
@@ -36,6 +37,15 @@ let package = Package(
         ),
         .target(
             name: "Import",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
+        .target(
+            name: "AsyncTraverse",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
             ],

--- a/PluginExamples/Package@swift-5.9.swift
+++ b/PluginExamples/Package@swift-5.9.swift
@@ -47,6 +47,15 @@ let package = Package(
                 .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
             ]
         ),
+        .target(
+            name: "AsyncTraverse",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
         .testTarget(
             name: "ExampleTests",
             dependencies: [
@@ -54,6 +63,7 @@ let package = Package(
                 .target(name: "Nested"),
                 .target(name: "Import"),
                 .target(name: "AccessLevelOnImport"),
+                .target(name: "AsyncTraverse"),
             ]
         ),
     ]

--- a/PluginExamples/Sources/AsyncTraverse/AsyncTraverse.proto
+++ b/PluginExamples/Sources/AsyncTraverse/AsyncTraverse.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+message AsyncTraverseMessage {
+    bytes data = 1;
+    Nested nested = 2;
+    repeated bytes repeated_data = 3;
+    repeated Nested repeated_nested = 4;
+}
+
+message Nested {
+    bytes data = 1;
+    NestedNested nestedNested = 2;
+}
+
+message NestedNested {
+    bytes data = 1;
+}

--- a/PluginExamples/Sources/AsyncTraverse/empty.swift
+++ b/PluginExamples/Sources/AsyncTraverse/empty.swift
@@ -1,0 +1,3 @@
+/// DO NOT DELETE.
+///
+/// We need to keep this file otherwise the plugin is not running.

--- a/PluginExamples/Sources/AsyncTraverse/swift-protobuf-config.json
+++ b/PluginExamples/Sources/AsyncTraverse/swift-protobuf-config.json
@@ -1,0 +1,11 @@
+{
+    "invocations": [
+        {
+            "protoFiles": [
+                "AsyncTraverse.proto",
+            ],
+            "visibility": "public",
+            "asyncTraverse": true,
+        }
+    ]
+}

--- a/PluginExamples/Sources/ExampleTests/AsyncTraverse.swift
+++ b/PluginExamples/Sources/ExampleTests/AsyncTraverse.swift
@@ -1,0 +1,54 @@
+import AsyncTraverse
+import SwiftProtobuf
+import XCTest
+
+final class AsyncTraverseTests: XCTestCase {
+    func testAsyncTraverse() async throws {
+        var message = AsyncTraverseMessage.with {
+            $0.data = .init([UInt8(0)])
+            $0.nested = .with {
+                $0.data = .init([UInt8(1)])
+                $0.nestedNested = .with {
+                    $0.data = .init([UInt8(2)])
+                }
+            }
+            $0.repeatedData = [.init([UInt8(3)]), .init([UInt8(4)])]
+            $0.repeatedNested = [
+                .with {
+                    $0.data = .init([UInt8(5)])
+                    $0.nestedNested = .with {
+                        $0.data = .init([UInt8(6)])
+                    }
+                }
+            ]
+        }
+        var visitor = MyVisitor()
+        try await message.traverse(visitor: &visitor)
+        XCTAssertEqual(message.data, .init([UInt8(1)]))
+        XCTAssertEqual(message.nested.data, .init([UInt8(2)]))
+        XCTAssertEqual(message.nested.nestedNested.data, .init([UInt8(3)]))
+        XCTAssertEqual(message.repeatedData, [.init([UInt8(4)]), .init([UInt8(5)])])
+        XCTAssertEqual(message.repeatedNested[0].data, .init([UInt8(6)]))
+        XCTAssertEqual(message.repeatedNested[0].nestedNested.data, .init([UInt8(7)]))
+    }
+}
+
+struct MyVisitor: AsyncVisitor {
+    mutating func visitSingularMessageField(value: inout some Message, fieldNumber: Int) async throws {
+        try await value.traverse(visitor: &self)
+    }
+
+    mutating func visitRepeatedMessageField<M>(value: inout [M], fieldNumber: Int) async throws
+    where M: SwiftProtobuf.Message {
+        for index in value.indices {
+            try await value[index].traverse(visitor: &self)
+        }
+    }
+
+    mutating func visitSingularBytesField(value: inout Data, fieldNumber: Int) async throws {
+        value = Data([value.first! + UInt8(1)])
+    }
+    mutating func visitRepeatedBytesField(value: inout [Data], fieldNumber: Int) async throws {
+        value = value.map { Data([$0.first! + UInt8(1)]) }
+    }
+}

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -87,6 +87,8 @@ struct SwiftProtobufPlugin {
             var implementationOnlyImports: Bool?
             /// Whether import statements should be preceded with visibility.
             var useAccessLevelOnImports: Bool?
+            /// Whether an async traverse method should be generated.
+            var asyncTraverse: Bool?
         }
 
         /// The path to the `protoc` binary.
@@ -195,6 +197,10 @@ struct SwiftProtobufPlugin {
         // Add the useAccessLevelOnImports only imports flag if it was set
         if let useAccessLevelOnImports = invocation.useAccessLevelOnImports {
             protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(useAccessLevelOnImports)")
+        }
+
+        if let asyncTraverse = invocation.asyncTraverse {
+            protocArgs.append("--swift_opt=AsyncTraverse=\(asyncTraverse)")
         }
 
         var inputFiles = [Path]()

--- a/Sources/SwiftProtobuf/AsyncVisitor.swift
+++ b/Sources/SwiftProtobuf/AsyncVisitor.swift
@@ -1,0 +1,511 @@
+// Sources/SwiftProtobuf/Visitor.swift - Basic serialization machinery
+//
+// Copyright (c) 2025 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+/// This is the protocol used by the generated async `traverse()` methods.
+public protocol AsyncVisitor {
+    /// Called for each non-repeated float field
+    ///
+    /// A default implementation is provided that just widens the value
+    /// and calls `visitSingularDoubleField`
+    mutating func visitSingularFloatField(value: inout Float, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated double field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularDoubleField(value: inout Double, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated int32 field
+    ///
+    /// A default implementation is provided that just widens the value
+    /// and calls `visitSingularInt64Field`
+    mutating func visitSingularInt32Field(value: inout Int32, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated int64 field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularInt64Field(value: inout Int64, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated uint32 field
+    ///
+    /// A default implementation is provided that just widens the value
+    /// and calls `visitSingularUInt64Field`
+    mutating func visitSingularUInt32Field(value: inout UInt32, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated uint64 field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularUInt64Field(value: inout UInt64, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated sint32 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularInt32Field`
+    mutating func visitSingularSInt32Field(value: inout Int32, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated sint64 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularInt64Field`
+    mutating func visitSingularSInt64Field(value: inout Int64, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated fixed32 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularUInt32Field`
+    mutating func visitSingularFixed32Field(value: inout UInt32, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated fixed64 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularUInt64Field`
+    mutating func visitSingularFixed64Field(value: inout UInt64, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated sfixed32 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularInt32Field`
+    mutating func visitSingularSFixed32Field(value: inout Int32, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated sfixed64 field
+    ///
+    /// A default implementation is provided that just forwards to
+    /// `visitSingularInt64Field`
+    mutating func visitSingularSFixed64Field(value: inout Int64, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated bool field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularBoolField(value: inout Bool, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated string field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularStringField(value: inout String, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated bytes field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularBytesField(value: inout Data, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated enum field
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularEnumField<E: Enum>(value: inout E, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated nested message field.
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitSingularMessageField<M: Message>(value: inout M, fieldNumber: Int) async throws
+
+    /// Called for each non-repeated proto2 group field.
+    ///
+    /// A default implementation is provided that simply forwards to
+    /// `visitSingularMessageField`. Implementors who need to handle groups
+    /// differently than nested messages can override this and provide distinct
+    /// implementations.
+    mutating func visitSingularGroupField<G: Message>(value: inout G, fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated float field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularFloatField` once for each item in the array.
+    mutating func visitRepeatedFloatField(value: inout [Float], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated double field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularDoubleField` once for each item in the array.
+    mutating func visitRepeatedDoubleField(value: inout [Double], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated int32 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularInt32Field` once for each item in the array.
+    mutating func visitRepeatedInt32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated int64 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularInt64Field` once for each item in the array.
+    mutating func visitRepeatedInt64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated uint32 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularUInt32Field` once for each item in the array.
+    mutating func visitRepeatedUInt32Field(value: inout [UInt32], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated uint64 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularUInt64Field` once for each item in the array.
+    mutating func visitRepeatedUInt64Field(value: inout [UInt64], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated sint32 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularSInt32Field` once for each item in the array.
+    mutating func visitRepeatedSInt32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated sint64 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularSInt64Field` once for each item in the array.
+    mutating func visitRepeatedSInt64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated fixed32 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularFixed32Field` once for each item in the array.
+    mutating func visitRepeatedFixed32Field(value: inout [UInt32], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated fixed64 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularFixed64Field` once for each item in the array.
+    mutating func visitRepeatedFixed64Field(value: inout [UInt64], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated sfixed32 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularSFixed32Field` once for each item in the array.
+    mutating func visitRepeatedSFixed32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated sfixed64 field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularSFixed64Field` once for each item in the array.
+    mutating func visitRepeatedSFixed64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated bool field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularBoolField` once for each item in the array.
+    mutating func visitRepeatedBoolField(value: inout [Bool], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated string field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularStringField` once for each item in the array.
+    mutating func visitRepeatedStringField(value: inout [String], fieldNumber: Int) async throws
+
+    // Called for each non-packed repeated bytes field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularBytesField` once for each item in the array.
+    mutating func visitRepeatedBytesField(value: inout [Data], fieldNumber: Int) async throws
+
+    /// Called for each repeated, unpacked enum field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularEnumField` once for each item in the array.
+    mutating func visitRepeatedEnumField<E: Enum>(value: inout [E], fieldNumber: Int) async throws
+
+    /// Called for each repeated nested message field. The method is called once
+    /// with the complete array of values for the field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularMessageField` once for each item in the array.
+    mutating func visitRepeatedMessageField<M: Message>(
+        value: inout [M],
+        fieldNumber: Int
+    ) async throws
+
+    /// Called for each repeated proto2 group field.
+    ///
+    /// A default implementation is provided that simply calls
+    /// `visitSingularGroupField` once for each item in the array.
+    mutating func visitRepeatedGroupField<G: Message>(value: inout [G], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated float field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedFloatField(value: inout [Float], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated double field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedDoubleField(value: inout [Double], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated int32 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedInt32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated int64 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedInt64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated uint32 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedUInt32Field(value: inout [UInt32], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated uint64 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedUInt64Field(value: inout [UInt64], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated sint32 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedSInt32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated sint64 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedSInt64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated fixed32 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedFixed32Field(value: inout [UInt32], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated fixed64 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedFixed64Field(value: inout [UInt64], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated sfixed32 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedSFixed32Field(value: inout [Int32], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated sfixed64 field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedSFixed64Field(value: inout [Int64], fieldNumber: Int) async throws
+
+    // Called for each packed, repeated bool field.
+    ///
+    /// This is called once with the complete array of values for
+    /// the field.
+    ///
+    /// There is a default implementation that forwards to the non-packed
+    /// function.
+    mutating func visitPackedBoolField(value: inout [Bool], fieldNumber: Int) async throws
+
+    /// Called for each repeated, packed enum field.
+    /// The method is called once with the complete array of values for
+    /// the field.
+    ///
+    /// A default implementation is provided that simply forwards to
+    /// `visitRepeatedEnumField`. Implementors who need to handle packed fields
+    /// differently than unpacked fields can override this and provide distinct
+    /// implementations.
+    mutating func visitPackedEnumField<E: Enum>(value: inout [E], fieldNumber: Int) async throws
+
+    /// Called for each map field with primitive values. The method is
+    /// called once with the complete dictionary of keys/values for the
+    /// field.
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitMapField<KeyType, ValueType: MapValueType>(
+        fieldType: _ProtobufMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws
+
+    /// Called for each map field with enum values. The method is called
+    /// once with the complete dictionary of keys/values for the field.
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitMapField<KeyType, ValueType>(
+        fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufEnumMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws where ValueType.RawValue == Int
+
+    /// Called for each map field with message values. The method is
+    /// called once with the complete dictionary of keys/values for the
+    /// field.
+    ///
+    /// There is no default implementation.  This must be implemented.
+    mutating func visitMapField<KeyType, ValueType>(
+        fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufMessageMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws
+
+    /// Called for each extension range.
+    mutating func visitExtensionFields(fields: inout ExtensionFieldValueSet, start: Int, end: Int) async throws
+
+    /// Called for each extension range.
+    mutating func visitExtensionFieldsAsMessageSet(
+        fields: inout ExtensionFieldValueSet,
+        start: Int,
+        end: Int
+    ) async throws
+
+    /// Called with the raw bytes that represent any unknown fields.
+    mutating func visitUnknown(bytes: inout Data) async throws
+}
+
+extension AsyncVisitor {
+    public mutating func visitSingularFloatField(value: inout Float, fieldNumber: Int) async throws {}
+    public mutating func visitSingularDoubleField(value: inout Double, fieldNumber: Int) async throws {}
+    public mutating func visitSingularInt32Field(value: inout Int32, fieldNumber: Int) async throws {}
+    public mutating func visitSingularInt64Field(value: inout Int64, fieldNumber: Int) async throws {}
+    public mutating func visitSingularUInt32Field(value: inout UInt32, fieldNumber: Int) async throws {}
+    public mutating func visitSingularUInt64Field(value: inout UInt64, fieldNumber: Int) async throws {}
+    public mutating func visitSingularSInt32Field(value: inout Int32, fieldNumber: Int) async throws {}
+    public mutating func visitSingularSInt64Field(value: inout Int64, fieldNumber: Int) async throws {}
+    public mutating func visitSingularFixed32Field(value: inout UInt32, fieldNumber: Int) async throws {}
+    public mutating func visitSingularFixed64Field(value: inout UInt64, fieldNumber: Int) async throws {}
+    public mutating func visitSingularSFixed32Field(value: inout Int32, fieldNumber: Int) async throws {}
+    public mutating func visitSingularSFixed64Field(value: inout Int64, fieldNumber: Int) async throws {}
+    public mutating func visitSingularBoolField(value: inout Bool, fieldNumber: Int) async throws {}
+    public mutating func visitSingularStringField(value: inout String, fieldNumber: Int) async throws {}
+    public mutating func visitSingularBytesField(value: inout Data, fieldNumber: Int) async throws {}
+    public mutating func visitSingularEnumField<E: Enum>(value: inout E, fieldNumber: Int) async throws {}
+    public mutating func visitSingularMessageField<M: Message>(value: inout M, fieldNumber: Int) async throws {}
+    public mutating func visitSingularGroupField<G: Message>(value: inout G, fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedFloatField(value: inout [Float], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedDoubleField(value: inout [Double], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedInt32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedInt64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedUInt32Field(value: inout [UInt32], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedUInt64Field(value: inout [UInt64], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedSInt32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedSInt64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedFixed32Field(value: inout [UInt32], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedFixed64Field(value: inout [UInt64], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedSFixed32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedSFixed64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedBoolField(value: inout [Bool], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedStringField(value: inout [String], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedBytesField(value: inout [Data], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedEnumField<E: Enum>(value: inout [E], fieldNumber: Int) async throws {}
+    public mutating func visitRepeatedMessageField<M: Message>(
+        value: inout [M],
+        fieldNumber: Int
+    ) async throws {}
+    public mutating func visitRepeatedGroupField<G: Message>(value: inout [G], fieldNumber: Int) async throws {}
+    public mutating func visitPackedFloatField(value: inout [Float], fieldNumber: Int) async throws {}
+    public mutating func visitPackedDoubleField(value: inout [Double], fieldNumber: Int) async throws {}
+    public mutating func visitPackedInt32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitPackedInt64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitPackedUInt32Field(value: inout [UInt32], fieldNumber: Int) async throws {}
+    public mutating func visitPackedUInt64Field(value: inout [UInt64], fieldNumber: Int) async throws {}
+    public mutating func visitPackedSInt32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitPackedSInt64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitPackedFixed32Field(value: inout [UInt32], fieldNumber: Int) async throws {}
+    public mutating func visitPackedFixed64Field(value: inout [UInt64], fieldNumber: Int) async throws {}
+    public mutating func visitPackedSFixed32Field(value: inout [Int32], fieldNumber: Int) async throws {}
+    public mutating func visitPackedSFixed64Field(value: inout [Int64], fieldNumber: Int) async throws {}
+    public mutating func visitPackedBoolField(value: inout [Bool], fieldNumber: Int) async throws {}
+    public mutating func visitPackedEnumField<E: Enum>(value: inout [E], fieldNumber: Int) async throws {}
+    public mutating func visitMapField<KeyType, ValueType: MapValueType>(
+        fieldType: _ProtobufMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws {}
+    public mutating func visitMapField<KeyType, ValueType>(
+        fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufEnumMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws where ValueType.RawValue == Int {}
+    public mutating func visitMapField<KeyType, ValueType>(
+        fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type,
+        value: inout _ProtobufMessageMap<KeyType, ValueType>.BaseType,
+        fieldNumber: Int
+    ) async throws {}
+    public mutating func visitExtensionFields(fields: inout ExtensionFieldValueSet, start: Int, end: Int) async throws {
+    }
+    public mutating func visitExtensionFieldsAsMessageSet(
+        fields: inout ExtensionFieldValueSet,
+        start: Int,
+        end: Int
+    ) async throws {}
+    public mutating func visitUnknown(bytes: inout Data) async throws {}
+}

--- a/Sources/SwiftProtobuf/ExtensionFieldValueSet.swift
+++ b/Sources/SwiftProtobuf/ExtensionFieldValueSet.swift
@@ -64,6 +64,15 @@ public struct ExtensionFieldValueSet: Hashable, Sendable {
         }
     }
 
+    public mutating func traverse<V: AsyncVisitor>(visitor: inout V, start: Int, end: Int) async throws {
+        let validIndexes = values.keys.filter { $0 >= start && $0 < end }
+        for i in validIndexes.sorted() {
+            var value = values[i]!
+            try await value.traverse(visitor: &visitor)
+            values[i] = value
+        }
+    }
+
     public subscript(index: Int) -> (any AnyExtensionField)? {
         get { values[index] }
         set { values[index] = newValue }

--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -45,6 +45,46 @@ public protocol FieldType: Sendable {
     static func visitSingular<V: Visitor>(value: BaseType, fieldNumber: Int, with visitor: inout V) throws
     static func visitRepeated<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws
     static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws
+
+    static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws
+    static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws
+    static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws
+}
+
+extension FieldType {
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        throw SwiftProtobufError.AsyncTraverse.unimplemented()
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        throw SwiftProtobufError.AsyncTraverse.unimplemented()
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        throw SwiftProtobufError.AsyncTraverse.unimplemented()
+    }
 }
 
 ///
@@ -98,6 +138,27 @@ public struct ProtobufFloat: FieldType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedFloatField(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularFloatField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedFloatField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedFloatField(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -121,6 +182,27 @@ public struct ProtobufDouble: FieldType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedDoubleField(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularDoubleField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedDoubleField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedDoubleField(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -143,6 +225,27 @@ public struct ProtobufInt32: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedInt32Field(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedInt32Field(value: &value, fieldNumber: fieldNumber)
     }
 }
 
@@ -168,6 +271,27 @@ public struct ProtobufInt64: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedInt64Field(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -190,6 +314,27 @@ public struct ProtobufUInt32: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedUInt32Field(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularUInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedUInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedUInt32Field(value: &value, fieldNumber: fieldNumber)
     }
 }
 
@@ -215,6 +360,27 @@ public struct ProtobufUInt64: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedUInt64Field(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularUInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedUInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedUInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -237,6 +403,27 @@ public struct ProtobufSInt32: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedSInt32Field(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularSInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedSInt32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedSInt32Field(value: &value, fieldNumber: fieldNumber)
     }
 }
 
@@ -262,6 +449,27 @@ public struct ProtobufSInt64: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedSInt64Field(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularSInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedSInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedSInt64Field(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -284,6 +492,27 @@ public struct ProtobufFixed32: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedFixed32Field(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularFixed32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedFixed32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedFixed32Field(value: &value, fieldNumber: fieldNumber)
     }
 }
 
@@ -308,6 +537,27 @@ public struct ProtobufFixed64: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedFixed64Field(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -330,6 +580,27 @@ public struct ProtobufSFixed32: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedSFixed32Field(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularSFixed32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedSFixed32Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedSFixed32Field(value: &value, fieldNumber: fieldNumber)
     }
 }
 
@@ -354,6 +625,27 @@ public struct ProtobufSFixed64: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedSFixed64Field(value: value, fieldNumber: fieldNumber)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularSFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedSFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedSFixed64Field(value: &value, fieldNumber: fieldNumber)
+    }
 }
 
 ///
@@ -376,6 +668,27 @@ public struct ProtobufBool: FieldType, MapKeyType, MapValueType {
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         try visitor.visitPackedBoolField(value: value, fieldNumber: fieldNumber)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularBoolField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedBoolField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitPackedBoolField(value: &value, fieldNumber: fieldNumber)
     }
 
     /// Custom _lessThan since `Bool` isn't `Comparable`.
@@ -408,6 +721,27 @@ public struct ProtobufString: FieldType, MapKeyType, MapValueType {
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
         assert(false)
     }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularStringField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedStringField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        assert(false)
+    }
 }
 
 ///
@@ -429,6 +763,27 @@ public struct ProtobufBytes: FieldType, MapValueType {
         try visitor.visitRepeatedBytesField(value: value, fieldNumber: fieldNumber)
     }
     public static func visitPacked<V: Visitor>(value: [BaseType], fieldNumber: Int, with visitor: inout V) throws {
+        assert(false)
+    }
+    public static func visitSingular<V: AsyncVisitor>(
+        value: inout BaseType,
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitSingularBytesField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitRepeated<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
+        try await visitor.visitRepeatedBytesField(value: &value, fieldNumber: fieldNumber)
+    }
+    public static func visitPacked<V: AsyncVisitor>(
+        value: inout [BaseType],
+        fieldNumber: Int,
+        with visitor: inout V
+    ) async throws {
         assert(false)
     }
 }

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -97,6 +97,12 @@ public protocol Message: Sendable, CustomDebugStringConvertible {
     /// behaviors for specific encodings, but the general idea is quite simple.
     func traverse<V: Visitor>(visitor: inout V) throws
 
+    /// Traverses the fields of the message, calling the appropriate methods
+    /// of the passed ``AsyncVisitor`` object.
+    ///
+    /// - Parameter visitor: The visitor used for traversing.
+    mutating func traverse<V: AsyncVisitor>(visitor: inout V) async throws
+
     // Standard utility properties and methods.
     // Most of these are simple wrappers on top of the visitor machinery.
     // They are implemented in the protocol, not in the generated structs,
@@ -167,6 +173,10 @@ extension Message {
         var message = Self()
         try populator(&message)
         return message
+    }
+
+    public mutating func traverse<V: AsyncVisitor>(visitor: inout V) async throws {
+        throw SwiftProtobufError.AsyncTraverse.unimplemented()
     }
 }
 

--- a/Sources/SwiftProtobuf/SwiftProtobufError.swift
+++ b/Sources/SwiftProtobuf/SwiftProtobufError.swift
@@ -93,6 +93,7 @@ extension SwiftProtobufError {
             case binaryStreamDecodingError
             case jsonDecodingError
             case jsonEncodingError
+            case unimplemented
 
             var description: String {
                 switch self {
@@ -104,6 +105,8 @@ extension SwiftProtobufError {
                     return "JSON decoding error"
                 case .jsonEncodingError:
                     return "JSON encoding error"
+                case .unimplemented:
+                    return "Unimplemented"
                 }
             }
         }
@@ -137,6 +140,11 @@ extension SwiftProtobufError {
         /// Errors arising from JSON encoding of messages.
         public static var jsonEncodingError: Self {
             Self(.jsonEncodingError)
+        }
+
+        /// Errors arising when a method is not implemented.
+        public static var unimplemented: Self {
+            Self(.unimplemented)
         }
     }
 
@@ -311,6 +319,21 @@ extension SwiftProtobufError {
             SwiftProtobufError(
                 code: .jsonEncodingError,
                 message: "google.protobuf.Any 'type_url' was empty, only allowed for empty objects.",
+                location: SourceLocation(function: function, file: file, line: line)
+            )
+        }
+    }
+
+    public enum AsyncTraverse {
+        /// Error thrown when a method required for async traversing is unimpleneted.
+        public static func unimplemented(
+            function: String = #function,
+            file: String = #fileID,
+            line: Int = #line
+        ) -> SwiftProtobufError {
+            SwiftProtobufError(
+                code: .unimplemented,
+                message: "Method needed for async traverse is not implemented.",
                 location: SourceLocation(function: function, file: file, line: line)
             )
         }

--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -40,4 +40,10 @@ public struct UnknownStorage: Equatable, @unchecked Sendable {
             try visitor.visitUnknown(bytes: data)
         }
     }
+
+    public mutating func traverse<V: AsyncVisitor>(visitor: inout V) async throws {
+        if !data.isEmpty {
+            try await visitor.visitUnknown(bytes: &data)
+        }
+    }
 }

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -42,7 +42,7 @@ protocol FieldGenerator {
     var generateTraverseUsesLocals: Bool { get }
 
     /// Generate the support for traversing this field.
-    func generateTraverse(printer: inout CodePrinter)
+    func generateTraverse(printer: inout CodePrinter, isAsync: Bool)
 
     /// Generate support for comparing this field's value.
     /// The generated code should return false in the current scope if the field's don't match.

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -225,7 +225,12 @@ class FileGenerator {
                 e.generateRuntimeSupport(printer: &p)
             }
             for m in messages {
-                m.generateRuntimeSupport(printer: &p, file: self, parent: nil)
+                m.generateRuntimeSupport(
+                    printer: &p,
+                    file: self,
+                    parent: nil,
+                    generateAsyncTraverse: generatorOptions.asyncTraverse
+                )
             }
         }
     }

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -68,6 +68,7 @@ class GeneratorOptions {
     let protoToModuleMappings: ProtoFileToModuleMappings
     let visibility: Visibility
     let importDirective: ImportDirective
+    let asyncTraverse: Bool
     let experimentalStripNonfunctionalCodegen: Bool
 
     /// A string snippet to insert for the visibility
@@ -80,6 +81,7 @@ class GeneratorOptions {
         var swiftProtobufModuleName: String? = nil
         var implementationOnlyImports: Bool = false
         var useAccessLevelOnImports = false
+        var asyncTraverse: Bool = false
         var experimentalStripNonfunctionalCodegen: Bool = false
 
         for pair in parameter.parsedPairs {
@@ -135,6 +137,15 @@ class GeneratorOptions {
                         value: pair.value
                     )
                 }
+            case "AsyncTraverse":
+                if let value = Bool(pair.value) {
+                    asyncTraverse = value
+                } else {
+                    throw GenerationError.invalidParameterValue(
+                        name: pair.key,
+                        value: pair.value
+                    )
+                }
             case "experimental_strip_nonfunctional_codegen":
                 if pair.value.isEmpty {  // Also support option without any value.
                     experimentalStripNonfunctionalCodegen = true
@@ -169,6 +180,7 @@ class GeneratorOptions {
 
         self.outputNaming = outputNaming
         self.visibility = visibility
+        self.asyncTraverse = asyncTraverse
 
         switch visibility {
         case .internal:


### PR DESCRIPTION
## Motivation

Our current `Visitor` protocol and generated `traverse` methods allow synchronous throwing traversal of the message fields. This works great for how our current serializers are working; however, often one wants to implement validators or transformers that mutate the fields of message. Sometimes this mutation is even asynchronous.

## Modification

This PR adds a few things:
- A new `AsyncVisitor` protocol that allows to asynchronously traverse and mutate the fields of a message
- A code generator option to generate the new async traverse method
- Tests that validate that mutating async traversal is working

## Result

We can now implement async visitors that mutate message fields.