### PR TITLE
Deprecate FieldDescriptor.isOptional.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -1092,17 +1092,18 @@ public final class FieldDescriptor {
     /// optional/required/repeated
     public let label: Google_Protobuf_FieldDescriptorProto.Label
 
-    /// Shorthand for `label` == `.required`.
-    ///
-    /// NOTE: This could also be a map as the are also repeated fields.
+    /// Whether or not the field is required. For proto2 required fields and
+    /// Editions `LEGACY_REQUIRED` fields.
     public var isRequired: Bool {
         // Implementation comes from FieldDescriptor::is_required()
         features.fieldPresence == .legacyRequired
     }
-    /// Shorthand for `label` == `.optional`
-    public var isOptional: Bool { label == .optional }
-    /// Shorthand for `label` == `.repeated`
+    /// Whether or not the field is repeated/map field.
     public var isRepeated: Bool { label == .repeated }
+
+    /// Use !isRequired() && !isRepeated() instead.
+    @available(*, deprecated, message: "Use !isRequired() && !isRepeated() instead.")
+    public var isOptional: Bool { label == .optional }
 
     /// Is this field packable.
     public var isPackable: Bool {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -117,9 +117,9 @@ class MessageGenerator {
                     "\(e.containingType.fullName) has the option message_set_wire_format but \(e.fullName) is a non message extension field."
                 return
             }
-            guard e.isOptional else {
+            guard !e.isRequired && !e.isRepeated else {
                 errorString =
-                    "\(e.containingType.fullName) has the option message_set_wire_format but \(e.fullName) is not a \"optional\" extension field."
+                    "\(e.containingType.fullName) has the option message_set_wire_format but \(e.fullName) cannot be required nor repeated extension field."
                 return
             }
         }


### PR DESCRIPTION
This is the start of tracking the upstream changes to move away from Label and the "optional" bit in there. See
https://github.com/protocolbuffers/protobuf/pull/20687 for the start of it.

Update the comments on isRequired and isRepeated also.