### PR TITLE
Some small cleanups.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -23,19 +23,15 @@ import Foundation
 internal struct TextFormatDecoder: Decoder {
     internal var scanner: TextFormatScanner
     private var fieldCount = 0
-    private var terminator: UInt8?
-    private var fieldNameMap: _NameMap?
-    private var messageType: any Message.Type
+    private let terminator: UInt8?
+    private let fieldNameMap: _NameMap
+    private let messageType: any Message.Type
 
     internal var options: TextFormatDecodingOptions {
         scanner.options
     }
 
-    internal var complete: Bool {
-        mutating get {
-            scanner.complete
-        }
-    }
+    internal var complete: Bool { scanner.complete }
 
     internal init(
         messageType: any Message.Type,
@@ -50,6 +46,7 @@ internal struct TextFormatDecoder: Decoder {
         }
         fieldNameMap = nameProviding._protobuf_nameMap
         self.messageType = messageType
+        self.terminator = nil
     }
 
     internal init(messageType: any Message.Type, scanner: TextFormatScanner, terminator: UInt8?) throws {
@@ -71,7 +68,7 @@ internal struct TextFormatDecoder: Decoder {
             scanner.skipOptionalSeparator()
         }
         if let fieldNumber = try scanner.nextFieldNumber(
-            names: fieldNameMap!,
+            names: fieldNameMap,
             messageType: messageType,
             terminator: terminator
         ) {

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -240,19 +240,15 @@ private func decodeString(_ s: String) -> String? {
 /// TextFormatScanner has no public members.
 ///
 internal struct TextFormatScanner {
-    internal var extensions: (any ExtensionMap)?
+    internal let extensions: (any ExtensionMap)?
     private var p: UnsafeRawPointer
-    private var end: UnsafeRawPointer
-    private var doubleParser = DoubleParser()
+    private let end: UnsafeRawPointer
+    private let doubleParser = DoubleParser()
 
     internal let options: TextFormatDecodingOptions
     internal var recursionBudget: Int
 
-    internal var complete: Bool {
-        mutating get {
-            p == end
-        }
-    }
+    internal var complete: Bool { p == end }
 
     internal init(
         utf8Pointer: UnsafeRawPointer,


### PR DESCRIPTION
- Make things that never need to mutate explicit `let`s so intent is clear.
- Simplify `complete`, guess this used to actually mutate, but it doesn't anymore.
- The `_NameMap` is always found or `init` fails, so no need for it to be `Optional` and thus no need to force unwrap it.