### PR TITLE
Like the plugin, use `.rawValue`

### DIFF
--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -55,7 +55,7 @@ class GeneratorOptions {
         var snippet: String {
             switch self {
             case let .accessLevel(visibility):
-                return "\(visibility) import"
+                return "\(visibility.rawValue) import"
             case .plain:
                 return "import"
             case .implementationOnly:


### PR DESCRIPTION
This ends up relying on reflection, so just use `.rawValue` to get the String out instead. The plugin already did it this way.