### PR TITLE
Move two of the tests off `@testable import`

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor.swift
@@ -1137,7 +1137,7 @@ public final class FieldDescriptor {
 
     /// Returns true if this field was syntactically written with "optional" in the
     /// .proto file. Excludes singular proto3 fields that do not have a label.
-    var _hasOptionalKeyword: Bool {
+    package var _hasOptionalKeyword: Bool {
         // This logic comes from the C++ FieldDescriptor::has_optional_keyword()
         // impl.
         proto3Optional || (file.edition == .proto2 && !isRequired && !isRepeated && oneofIndex == nil)

--- a/Sources/SwiftProtobufPluginLibrary/FeatureResolver.swift
+++ b/Sources/SwiftProtobufPluginLibrary/FeatureResolver.swift
@@ -27,9 +27,9 @@ extension Google_Protobuf_MethodOptions: ProvidesFeatureSets {}
 
 /// Encapsulates the process of Feature resolution, sorta like the upstream
 /// `feature_resolver.cpp`.
-class FeatureResolver {
+package class FeatureResolver {
 
-    enum Error: Swift.Error, Equatable, CustomStringConvertible {
+    package enum Error: Swift.Error, Equatable, CustomStringConvertible {
         case unsupported(
             edition: Google_Protobuf_Edition,
             supported: ClosedRange<Google_Protobuf_Edition>
@@ -37,7 +37,7 @@ class FeatureResolver {
         case noDefault(edition: Google_Protobuf_Edition)
         case invalidExtension(type: String)
 
-        var description: String {
+        package var description: String {
             switch self {
             case .unsupported(let edition, let supported):
                 return "Edition \(edition) is not in the supported range (\(supported))"
@@ -50,9 +50,9 @@ class FeatureResolver {
     }
 
     /// The requested Edition.
-    let edition: Google_Protobuf_Edition
+    package let edition: Google_Protobuf_Edition
     /// The detaults to use for this edition.
-    let defaultFeatureSet: Google_Protobuf_FeatureSet
+    package let defaultFeatureSet: Google_Protobuf_FeatureSet
 
     private let extensionMap: (any ExtensionMap)?
 
@@ -70,7 +70,7 @@ class FeatureResolver {
     /// - Returns: A configured resolver for the given edition/defaults.
     /// - Throws: `FeatureResolver.Error` if there edition requested can't be
     ///           supported by the given defaults.
-    init(
+    package init(
         edition: Google_Protobuf_Edition,
         featureSetDefaults defaults: Google_Protobuf_FeatureSetDefaults,
         featureExtensions extensions: [any AnyMessageExtension] = []
@@ -127,7 +127,7 @@ class FeatureResolver {
     ///
     /// This needs to the full FieldDescriptorProto incase it has to do fallback
     /// inference.
-    func resolve(
+    package func resolve(
         _ proto: Google_Protobuf_FieldDescriptorProto,
         resolvedParent: Google_Protobuf_FeatureSet
     ) -> Google_Protobuf_FeatureSet {
@@ -172,7 +172,7 @@ class FeatureResolver {
     }
 
     /// Helper to do the merging.
-    func resolve(
+    package func resolve(
         features: Google_Protobuf_FeatureSet?,
         resolvedParent: Google_Protobuf_FeatureSet
     ) -> Google_Protobuf_FeatureSet {

--- a/Sources/SwiftProtobufPluginLibrary/NamingUtils.swift
+++ b/Sources/SwiftProtobufPluginLibrary/NamingUtils.swift
@@ -366,7 +366,7 @@ private enum CamelCaser {
 public enum NamingUtils {
 
     // Returns the type prefix to use for a given
-    static func typePrefix(protoPackage: String, fileOptions: Google_Protobuf_FileOptions) -> String {
+    package static func typePrefix(protoPackage: String, fileOptions: Google_Protobuf_FileOptions) -> String {
         // Explicit option (including blank), wins.
         if fileOptions.hasSwiftPrefix {
             return fileOptions.swiftPrefix
@@ -420,16 +420,16 @@ public enum NamingUtils {
     /// NOTE: Since this is acting on proto enum names and enum cases, we know
     /// the values must be _identifier_s which is defined (in Tokenizer::Next() as
     /// `[a-zA-Z_][a-zA-Z0-9_]*`, so this code is based on that limited input.
-    struct PrefixStripper {
+    package struct PrefixStripper {
         private let prefixChars: String.UnicodeScalarView
 
-        init(prefix: String) {
+        package init(prefix: String) {
             self.prefixChars = prefix.lowercased().replacingOccurrences(of: "_", with: "").unicodeScalars
         }
 
         /// Strip the prefix and return the result, or return nil if it can't
         /// be stripped.
-        func strip(from: String) -> String? {
+        package func strip(from: String) -> String? {
             var prefixIndex = prefixChars.startIndex
             let prefixEnd = prefixChars.endIndex
 
@@ -483,19 +483,19 @@ public enum NamingUtils {
         }
     }
 
-    static func sanitize(messageName s: String, forbiddenTypeNames: Set<String>) -> String {
+    package static func sanitize(messageName s: String, forbiddenTypeNames: Set<String>) -> String {
         sanitizeTypeName(s, disambiguator: "Message", forbiddenTypeNames: forbiddenTypeNames)
     }
 
-    static func sanitize(enumName s: String, forbiddenTypeNames: Set<String>) -> String {
+    package static func sanitize(enumName s: String, forbiddenTypeNames: Set<String>) -> String {
         sanitizeTypeName(s, disambiguator: "Enum", forbiddenTypeNames: forbiddenTypeNames)
     }
 
-    static func sanitize(oneofName s: String, forbiddenTypeNames: Set<String>) -> String {
+    package static func sanitize(oneofName s: String, forbiddenTypeNames: Set<String>) -> String {
         sanitizeTypeName(s, disambiguator: "Oneof", forbiddenTypeNames: forbiddenTypeNames)
     }
 
-    static func sanitize(fieldName s: String, basedOn: String) -> String {
+    package static func sanitize(fieldName s: String, basedOn: String) -> String {
         if basedOn.hasPrefix("clear") && isCharacterUppercase(basedOn, index: 5) {
             return s + "_p"
         } else if basedOn.hasPrefix("has") && isCharacterUppercase(basedOn, index: 3) {
@@ -513,11 +513,11 @@ public enum NamingUtils {
         }
     }
 
-    static func sanitize(fieldName s: String) -> String {
+    package static func sanitize(fieldName s: String) -> String {
         sanitize(fieldName: s, basedOn: s)
     }
 
-    static func sanitize(enumCaseName s: String) -> String {
+    package static func sanitize(enumCaseName s: String) -> String {
         if reservedEnumCases.contains(s) {
             return "\(s)_"
         } else if quotableEnumCases.contains(s) {
@@ -529,7 +529,7 @@ public enum NamingUtils {
         }
     }
 
-    static func sanitize(messageScopedExtensionName s: String) -> String {
+    package static func sanitize(messageScopedExtensionName s: String) -> String {
         if reservedMessageScopedExtensionNames.contains(s) {
             return "\(s)_"
         } else if quotableMessageScopedExtensionNames.contains(s) {
@@ -545,7 +545,7 @@ public enum NamingUtils {
     /// the rest of the characters in their existing case.
     ///
     /// Use toUpperCamelCase() to get leading "HTTP", "URL", etc. correct.
-    static func uppercaseFirstCharacter(_ s: String) -> String {
+    package static func uppercaseFirstCharacter(_ s: String) -> String {
         let out = s.unicodeScalars
         if let first = out.first {
             var result = makeUnicodeScalarView(from: first.ascUppercased())
@@ -572,7 +572,7 @@ public enum NamingUtils {
         CamelCaser.transform(s, initialUpperCase: false)
     }
 
-    static func trimBackticks(_ s: String) -> String {
+    package static func trimBackticks(_ s: String) -> String {
         // This only has to deal with the backticks added when computing relative names, so
         // they are always matched and a single set.
         let backtick = "`"

--- a/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
@@ -36,7 +36,7 @@ public struct ProtoFileToModuleMappings {
     /// Proto file name to module name.
     /// This is really `private` to this type, it is just `internal` so the tests can
     /// access it to verify things.
-    let mappings: [String: String]
+    package let mappings: [String: String]
 
     /// A Boolean value that indicates that there were developer provided
     /// mappings.

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -65,7 +65,7 @@ extension FileDescriptor {
     // Aside: This could be moved into the plugin library, but it doesn't seem
     // like anyone else would need the logic. Swift GRPC support probably stick
     // with the support for the module mappings.
-    func computeImports(
+    package func computeImports(
         namer: SwiftProtobufNamer,
         directive: GeneratorOptions.ImportDirective,
         reexportPublicImports: Bool
@@ -250,7 +250,7 @@ extension Descriptor {
     ///
     /// This also uses Range<> since the options that could be on
     /// `extensionRanges` no longer can apply as the things have been merged.
-    var _normalizedExtensionRanges: [Range<Int32>] {
+    package var _normalizedExtensionRanges: [Range<Int32>] {
         self.messageExtensionRanges.map({ $0.start..<$0.end }).sortAndMergeContinuous()
     }
 
@@ -261,7 +261,7 @@ extension Descriptor {
     ///
     /// This also uses Range<> since the options that could be on
     /// `extensionRanges` no longer can apply as the things have been merged.
-    var _ambitiousExtensionRanges: [Range<Int32>] {
+    package var _ambitiousExtensionRanges: [Range<Int32>] {
         var merged = self._normalizedExtensionRanges
         if merged.count > 1 {
             var fieldNumbersReversedIterator =
@@ -466,17 +466,17 @@ extension EnumDescriptor {
 
     /// Helper object that computes the alias relationships of
     /// `EnumValueDescriptor`s for a given `EnumDescriptor`.
-    final class ValueAliasInfo {
+    package final class ValueAliasInfo {
         /// The `EnumValueDescriptor`s that are not aliases of another value. In
         /// the same order as the values on the `EnumDescriptor`.
-        let mainValues: [EnumValueDescriptor]
+        package let mainValues: [EnumValueDescriptor]
 
         /// Find the alias values for the given value.
         ///
         /// - Parameter value: The value descriptor to look up.
         /// - Returns The list of value descriptors that are aliases for this
         ///     value, or `nil` if there are no alias (or if this was an alias).
-        func aliases(_ value: EnumValueDescriptor) -> [EnumValueDescriptor]? {
+        package func aliases(_ value: EnumValueDescriptor) -> [EnumValueDescriptor]? {
             assert(mainValues.first!.enumType === value.enumType)
             return aliasesMap[value.index]
         }
@@ -485,7 +485,7 @@ extension EnumDescriptor {
         ///
         /// - Parameter value: The value descriptor to look up.
         /// - Returns The original/main value if this was an alias otherwise `nil`.
-        func original(of: EnumValueDescriptor) -> EnumValueDescriptor? {
+        package func original(of: EnumValueDescriptor) -> EnumValueDescriptor? {
             assert(mainValues.first!.enumType === of.enumType)
             return aliasOfMap[of.index]
         }
@@ -497,7 +497,7 @@ extension EnumDescriptor {
         private let aliasOfMap: [Int: EnumValueDescriptor]
 
         /// Initialize the mappings for the given `EnumDescriptor`.
-        init(enumDescriptor descriptor: EnumDescriptor) {
+        package init(enumDescriptor descriptor: EnumDescriptor) {
             var mainValues = [EnumValueDescriptor]()
             var aliasesMap = [Int: [EnumValueDescriptor]]()
             var aliasOfMap = [Int: EnumValueDescriptor]()

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -10,7 +10,7 @@
 
 import SwiftProtobufPluginLibrary
 
-class GeneratorOptions {
+package class GeneratorOptions {
     enum OutputNaming {
         case fullPath
         case pathToUnderscores
@@ -30,7 +30,7 @@ class GeneratorOptions {
         }
     }
 
-    enum Visibility: String {
+    package enum Visibility: String {
         case `internal`
         case `public`
         case `package`
@@ -40,7 +40,7 @@ class GeneratorOptions {
         }
     }
 
-    enum ImportDirective: Equatable {
+    package enum ImportDirective: Equatable {
         case accessLevel(Visibility)
         case plain
         case implementationOnly

--- a/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
+++ b/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
@@ -20,7 +20,7 @@ extension SwiftProtobufNamer {
     /// names. Only poorly named proto enum alias values get filtered
     /// away, so the assumption is they aren't really needed from an
     /// api pov.
-    func uniquelyNamedValues(
+    package func uniquelyNamedValues(
         valueAliasInfo aliasInfo: EnumDescriptor.ValueAliasInfo
     ) -> [EnumValueDescriptor] {
         aliasInfo.mainValues.first!.enumType.values.filter {

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -9,9 +9,8 @@
 // -----------------------------------------------------------------------------
 
 import SwiftProtobuf
+import SwiftProtobufPluginLibrary
 import XCTest
-
-@testable import SwiftProtobufPluginLibrary
 
 extension FileDescriptor {
     func extensionField(named: String) -> FieldDescriptor? {

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_FeatureResolver.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_FeatureResolver.swift
@@ -9,9 +9,8 @@
 // -----------------------------------------------------------------------------
 
 import SwiftProtobuf
+import SwiftProtobufPluginLibrary
 import XCTest
-
-@testable import SwiftProtobufPluginLibrary
 
 final class Test_FeatureResolver: XCTestCase {
 

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_NamingUtils.swift
@@ -9,9 +9,8 @@
 // -----------------------------------------------------------------------------
 
 import SwiftProtobuf
+import SwiftProtobufPluginLibrary
 import XCTest
-
-@testable import SwiftProtobufPluginLibrary
 
 final class Test_NamingUtils: XCTestCase {
 

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -9,10 +9,9 @@
 // -----------------------------------------------------------------------------
 
 import SwiftProtobuf
+import SwiftProtobufPluginLibrary
 import SwiftProtobufTestHelpers
 import XCTest
-
-@testable import SwiftProtobufPluginLibrary
 
 // Helpers to make test cases.
 

--- a/Tests/protoc-gen-swiftTests/Test_DescriptorExtensions.swift
+++ b/Tests/protoc-gen-swiftTests/Test_DescriptorExtensions.swift
@@ -11,8 +11,7 @@
 import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 import XCTest
-
-@testable import protoc_gen_swift
+import protoc_gen_swift
 
 private typealias FileDescriptorProto = Google_Protobuf_FileDescriptorProto
 

--- a/Tests/protoc-gen-swiftTests/Test_SwiftProtobufNamerExtensions.swift
+++ b/Tests/protoc-gen-swiftTests/Test_SwiftProtobufNamerExtensions.swift
@@ -12,8 +12,7 @@ import SwiftProtobuf
 import SwiftProtobufPluginLibrary
 import SwiftProtobufTestHelpers
 import XCTest
-
-@testable import protoc_gen_swift
+import protoc_gen_swift
 
 final class Test_SwiftProtobufNamer: XCTestCase {
 


### PR DESCRIPTION
Now that Swift 5.9 is the baseline, make some things `package` visible and move off the `@testable` import.

Opened #1784 to track doing this with for the main runtime as they can't be done yet as the Fuzz tests still have to build with an older Swift version.