### PR TITLE
use `package` visibility for an internal helper.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Descriptor+Extensions.swift
@@ -121,19 +121,18 @@ extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation, Pro
     /// Groups use the underlying message's name. The way groups are declared in
     /// proto files, the filed names is derived by lowercasing the Group's name,
     /// so there are no underscores, etc. to rebuild a camel case name from.
-    var namingBase: String {
-        internal_isGroupLike ? messageType!.name : name
-    }
+    var namingBase: String { isGroupLike ? messageType!.name : name }
+
+    /// TODO: Remove this when it is safe to make breaking changes.
+    @available(*, deprecated, message: "Please open a GitHub issue if you think functionality is missing.")
+    public var internal_isGroupLike: Bool { isGroupLike }
 
     /// Helper to see if this is "group-like". Edition 2024 will likely provide
     /// a new feature to better deal with this. See upsteam protobuf for more
     /// details on the problem.
     ///
-    ///  This models upstream internal::cpp::IsGroupLike().
-    ///
-    ///  TODO(thomasvl): make this `package` instead of `public` and drop the
-    ///  "internal" part from the name when 5.9 is the baseline.
-    public var internal_isGroupLike: Bool {
+    /// This models upstream internal::cpp::IsGroupLike().
+    package var isGroupLike: Bool {
         guard type == .group else {
             return false
         }

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -69,7 +69,7 @@ class FieldGeneratorBase {
         // so let's just put the field name that Protobuf Text
         // actually uses here.
         let protoName: String
-        if fieldDescriptor.internal_isGroupLike {
+        if fieldDescriptor.isGroupLike {
             protoName = fieldDescriptor.messageType!.name
         } else {
             protoName = fieldDescriptor.name
@@ -98,7 +98,7 @@ class FieldGeneratorBase {
         // we add two entries, to provide both options for TextFormat, but we add
         // the preferred one second, so when the runtime builds up the mappings,
         // it will become the default for what gets used when generating TextFormat.
-        if fieldDescriptor.internal_isGroupLike && protoName != fieldDescriptor.name {
+        if fieldDescriptor.isGroupLike && protoName != fieldDescriptor.name {
             let nameLowercase = protoName.lowercased()
             if nameLowercase == jsonName {
                 return [".same(proto: \"\(nameLowercase)\")", result]

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_Descriptor.swift
@@ -389,8 +389,8 @@ final class Test_Descriptor: XCTestCase {
         let msg = try XCTUnwrap(descriptorSet.descriptor(named: EditionsUnittest_TestDelimited.protoMessageName))
         let file = try XCTUnwrap(msg.file)
 
-        XCTAssertTrue(try XCTUnwrap(msg.field(named: "grouplike")).internal_isGroupLike)
-        XCTAssertTrue(try XCTUnwrap(file.extensionField(named: "grouplikefilescope")).internal_isGroupLike)
+        XCTAssertTrue(try XCTUnwrap(msg.field(named: "grouplike")).isGroupLike)
+        XCTAssertTrue(try XCTUnwrap(file.extensionField(named: "grouplikefilescope")).isGroupLike)
     }
 
     func testIsGroupLike_GroupLikeNotDelimited() throws {
@@ -400,8 +400,8 @@ final class Test_Descriptor: XCTestCase {
         let msg = try XCTUnwrap(descriptorSet.descriptor(named: EditionsUnittest_TestDelimited.protoMessageName))
         let file = try XCTUnwrap(msg.file)
 
-        XCTAssertFalse(try XCTUnwrap(msg.field(named: "lengthprefixed")).internal_isGroupLike)
-        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "lengthprefixed")).internal_isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(msg.field(named: "lengthprefixed")).isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "lengthprefixed")).isGroupLike)
     }
 
     func testIsGroupLike_GroupLikeMismatchedName() throws {
@@ -411,8 +411,8 @@ final class Test_Descriptor: XCTestCase {
         let msg = try XCTUnwrap(descriptorSet.descriptor(named: EditionsUnittest_TestDelimited.protoMessageName))
         let file = try XCTUnwrap(msg.file)
 
-        XCTAssertFalse(try XCTUnwrap(msg.field(named: "notgrouplike")).internal_isGroupLike)
-        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "not_group_like_scope")).internal_isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(msg.field(named: "notgrouplike")).isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "not_group_like_scope")).isGroupLike)
     }
 
     func testIsGroupLike_GroupLikeMismatchedScope() throws {
@@ -422,8 +422,8 @@ final class Test_Descriptor: XCTestCase {
         let msg = try XCTUnwrap(descriptorSet.descriptor(named: EditionsUnittest_TestDelimited.protoMessageName))
         let file = try XCTUnwrap(msg.file)
 
-        XCTAssertFalse(try XCTUnwrap(msg.field(named: "notgrouplikescope")).internal_isGroupLike)
-        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "grouplike")).internal_isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(msg.field(named: "notgrouplikescope")).isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "grouplike")).isGroupLike)
     }
 
     func testIsGroupLike_GroupLikeMismatchedFile() throws {
@@ -433,8 +433,8 @@ final class Test_Descriptor: XCTestCase {
         let msg = try XCTUnwrap(descriptorSet.descriptor(named: EditionsUnittest_TestDelimited.protoMessageName))
         let file = try XCTUnwrap(msg.file)
 
-        XCTAssertFalse(try XCTUnwrap(msg.field(named: "messageimport")).internal_isGroupLike)
-        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "messageimport")).internal_isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(msg.field(named: "messageimport")).isGroupLike)
+        XCTAssertFalse(try XCTUnwrap(file.extensionField(named: "messageimport")).isGroupLike)
     }
 
     func testExtractProto_Options() throws {


### PR DESCRIPTION
Now that the Swift min has been raised enough, use `package` visibility for a helper needed for the generator and deprecate the one that was prefixed with `internal_`