### PR TITLE
Add parameter to control extension output

### DIFF
--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -170,22 +170,23 @@ extension Message {
     }
 }
 
-/// Implementation base for all messages; not intended for client use.
+// Legacy protocol; no longer used, but left to maintain source compatibility.
+@preconcurrency
+public protocol _MessageImplementationBase: _MessageEquatable, _MessageHashable {}
+
+/// Not intended for client use.
 ///
 /// In general, use `SwiftProtobuf.Message` instead when you need a variable or
 /// argument that can hold any type of message. Occasionally, you can use
-/// `SwiftProtobuf.Message & Equatable` or `SwiftProtobuf.Message & Hashable` as
-/// generic constraints if you need to write generic code that can be applied to
-/// multiple message types that uses equality tests, puts messages in a `Set`,
-/// or uses them as `Dictionary` keys.
+/// `SwiftProtobuf.Message & Equatable` as generic constraint.
 @preconcurrency
-public protocol _MessageImplementationBase: Message, Hashable {
+public protocol _MessageEquatable: Equatable {
 
     // Legacy function; no longer used, but left to maintain source compatibility.
     func _protobuf_generated_isEqualTo(other: Self) -> Bool
 }
 
-extension _MessageImplementationBase {
+extension _MessageEquatable {
     public func isEqualTo(message: any Message) -> Bool {
         guard let other = message as? Self else {
             return false
@@ -206,3 +207,11 @@ extension _MessageImplementationBase {
         self == other
     }
 }
+
+/// Not intended for client use.
+///
+/// In general, use `SwiftProtobuf.Message` instead when you need a variable or
+/// argument that can hold any type of message. Occasionally, you can use
+/// `SwiftProtobuf.Message & Hashable` as generic constraint.
+@preconcurrency
+public protocol _MessageHashable: Hashable {}

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -114,14 +114,14 @@ class EnumGenerator {
     }
 
     func generateRuntimeSupport(printer p: inout CodePrinter) {
-        p.print(
-            "",
-            "extension \(swiftFullName): \(namer.swiftProtobufModulePrefix)_ProtoNameProviding {"
-        )
-        p.withIndentation { p in
-            generateProtoNameProviding(printer: &p)
+        let nameProvidingConfiguration = generatorOptions.nameProvidingOutputConfiguration.configuration(for: swiftFullName)
+        nameProvidingConfiguration.generateExtension(
+            printer: &p,
+            typeFullName: swiftFullName,
+            extensionFullName: "\(namer.swiftProtobufModulePrefix)_ProtoNameProviding"
+        ) { p in
+            self.generateProtoNameProviding(printer: &p)
         }
-        p.print("}")
     }
 
     /// Generates the cases or statics (for alias) for the values.


### PR DESCRIPTION
Hey, guys 👋

Code generation can significantly bloat the app size in large projects. The ability to fine-tune what is generated will help minimize impact while still allowing to enable features when they are needed.

This PR just shows the general direction, and I'd love to hear your thoughts so we're aligned 🙂

**What has changed:**
1. `_MessageImplementationBase` is replaced with `_MessageEquatable` and `_MessageHashable`
2. In generated code, one code block that implements all extensions is replaced with several blocks (one per extension).

Before:
```
extension Com_Example_Player: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding { ... }
```
After:
```
extension Com_Example_Player: SwiftProtobuf.Message { ... }
extension Com_Example_Player: SwiftProtobuf._MessageEquatable { ... }
extension Com_Example_Player: SwiftProtobuf._MessageHashable { ... }
extension Com_Example_Player: SwiftProtobuf._ProtoNameProviding { ... }
```

3. Add parameter to control extension output

For example we have proto:
```
message Player { ... }
message Board { ... }
```

Here are some examples of how GenerateExtensions changes code generation:
```
// Parameter is not set
GenerateExtensions=

extension Player: SwiftProtobuf.Message { ... }
extension Player: SwiftProtobuf._MessageEquatable { ... }
extension Player: SwiftProtobuf._MessageHashable { }
extension Player: SwiftProtobuf._ProtoNameProviding { ... }
extension Board: SwiftProtobuf.Message { ... }
extension Board: SwiftProtobuf._MessageEquatable { ... }
extension Board: SwiftProtobuf._MessageHashable { }
extension Board: SwiftProtobuf._ProtoNameProviding { ... }
```


```
// Does not generate extensions for all types.
GenerateExtensions=equatable=skip;hashable=skip;nameProviding=skip

extension Player: SwiftProtobuf.Message { ... }
extension Board: SwiftProtobuf.Message { ... }
```


```
// Generates only _MessageEquatable and _MessageHashable extensions in debug for all types.
GenerateExtensions=equatable=debug_only;hashable=debug_only;nameProviding=skip

extension Player: SwiftProtobuf.Message { ... }
#if DEBUG
extension Player: SwiftProtobuf._MessageEquatable { ... }
#endif
#if DEBUG
extension Player: SwiftProtobuf._MessageHashable { ... }
#endif
extension Board: SwiftProtobuf.Message { ... }
#if DEBUG
extension Board: SwiftProtobuf._MessageEquatable { ... }
#endif
#if DEBUG
extension Board: SwiftProtobuf._MessageHashable { ... }
#endif
```


```
// Generates only _ProtoNameProviding only for Player.
GenerateExtensions=equatable=skip;hashable=skip;nameProviding=skip;Player:nameProviding=normal 

extension Player: SwiftProtobuf.Message { ... }
extension Player: SwiftProtobuf._ProtoNameProviding { ... }
extension Board: SwiftProtobuf.Message { ... }
```
