### PR TITLE
Prune `nameString` to reduce runtime size of `Name`

### DIFF
--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -184,7 +184,6 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
         // coordinating the lifecycle with the lifecycle of the pool
         // where the raw UTF8 gets interned.
         fileprivate init(staticString: StaticString, pool: InternPool) {
-            self.nameString = .staticString(staticString)
             if staticString.hasPointerRepresentation {
                 self.utf8Buffer = UnsafeRawBufferPointer(
                     start: staticString.utf8Start,
@@ -201,34 +200,24 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
         fileprivate init(string: String, pool: InternPool) {
             let utf8 = string.utf8
             self.utf8Buffer = pool.intern(utf8: utf8)
-            self.nameString = .string(string)
         }
 
         // This is for building a transient `Name` object sufficient for lookup purposes.
         // It MUST NOT be exposed outside of this file.
         fileprivate init(transientUtf8Buffer: UnsafeRawBufferPointer) {
-            self.nameString = .staticString("")
             self.utf8Buffer = transientUtf8Buffer
         }
 
         // This is for building a `Name` object from a slice of a bytecode `StaticString`.
         // It MUST NOT be exposed outside of this file.
         fileprivate init(bytecodeUTF8Buffer: UnsafeBufferPointer<UInt8>) {
-            self.nameString = .immortalBuffer(bytecodeUTF8Buffer)
             self.utf8Buffer = UnsafeRawBufferPointer(bytecodeUTF8Buffer)
         }
 
-        private(set) var utf8Buffer: UnsafeRawBufferPointer
-
-        private enum NameString {
-            case string(String)
-            case staticString(StaticString)
-            case immortalBuffer(UnsafeBufferPointer<UInt8>)
-        }
-        private var nameString: NameString
+        internal let utf8Buffer: UnsafeRawBufferPointer
 
         public var description: String {
-            String(decoding: utf8Buffer, as: UTF8.self)
+            String(decoding: self.utf8Buffer, as: UTF8.self)
         }
 
         public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
Now that the bytecode is used for messages, `description` always has to construct a temporary `String` so we can just lean into that and shrink the size of `Name` by removing the second property completely.
