### PR TITLE
Support blocking deprecated apis from the runtime.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -149,6 +149,7 @@ extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
 }
 
 extension Google_Protobuf_Duration {
+    #if !REMOVE_DEPRECATED_APIS
     /// Creates a new `Google_Protobuf_Duration` that is equal to the given
     /// `TimeInterval` (measured in seconds), rounded to the nearest nanosecond.
     ///
@@ -157,6 +158,7 @@ extension Google_Protobuf_Duration {
     public init(timeInterval: TimeInterval) {
         self.init(rounding: timeInterval, rule: .toNearestOrAwayFromZero)
     }
+    #endif  // !REMOVE_LEGACY_NAMEMAP_INITIALIZERS
 
     /// Creates a new `Google_Protobuf_Duration` that is equal to the given
     /// `TimeInterval` (measured in seconds), rounded to the nearest nanosecond

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -229,6 +229,7 @@ extension Google_Protobuf_Timestamp: _CustomJSONCodable {
 }
 
 extension Google_Protobuf_Timestamp {
+    #if !REMOVE_DEPRECATED_APIS
     /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
     /// UTC on 1 January 1970 by a given number of seconds.
     ///
@@ -238,6 +239,7 @@ extension Google_Protobuf_Timestamp {
     public init(timeIntervalSince1970: TimeInterval) {
         self.init(roundingTimeIntervalSince1970: timeIntervalSince1970, rule: .toNearestOrAwayFromZero)
     }
+    #endif  // !REMOVE_DEPRECATED_APIS
 
     /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
     /// UTC on 1 January 1970 by a given number of seconds, rounded to the nearest
@@ -257,6 +259,7 @@ extension Google_Protobuf_Timestamp {
         self.init(seconds: s, nanos: n)
     }
 
+    #if !REMOVE_DEPRECATED_APIS
     /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
     /// UTC on 1 January 2001 by a given number of seconds.
     ///
@@ -269,6 +272,7 @@ extension Google_Protobuf_Timestamp {
             rule: .toNearestOrAwayFromZero
         )
     }
+    #endif  // !REMOVE_DEPRECATED_APIS
 
     /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
     /// UTC on 1 January 2001 by a given number of seconds, rounded to the nearest

--- a/Sources/SwiftProtobuf/Internal.swift
+++ b/Sources/SwiftProtobuf/Internal.swift
@@ -20,6 +20,7 @@ import Foundation
 /// - Important: NOT INTENDED TO BE CALLED BY CLIENTS.
 public enum Internal {
 
+    #if !REMOVE_DEPRECATED_APIS
     /// A singleton instance of an empty data that is used by the generated code
     /// for default values. This is a performance enhancement to work around the
     /// fact that the `Data` type in Swift involves a new heap allocation every
@@ -33,6 +34,7 @@ public enum Internal {
             "Internal.emptyData isn't used any longer in newer versions of the generator. Generate code with a version later than 1.10.2 to get performance improvements. See https://github.com/apple/swift-protobuf/pull/1028 for more information."
     )
     public static let emptyData = Data()
+    #endif  // !REMOVE_DEPRECATED_APIS
 
     /// Helper to loop over a list of Messages to see if they are all
     /// initialized (see Message.isInitialized for what that means).

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
@@ -16,6 +16,7 @@ import Foundation
 
 /// Binary encoding and decoding methods for messages.
 extension Message {
+    #if !REMOVE_DEPRECATED_APIS
     /// Creates a new message by decoding the given `Data` value
     /// containing a serialized message in Protocol Buffer binary format.
     ///
@@ -171,6 +172,7 @@ extension Message {
             try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
         }
     }
+    #endif  // !REMOVE_DEPRECATED_APIS
 
     /// Updates the message by decoding the given `Data` value
     /// containing a serialized message in Protocol Buffer binary format into the


### PR DESCRIPTION
Tested with `swift test -Xswiftc -DREMOVE_DEPRECATED_APIS`.