### PR TITLE
Mark the legacy _NameMap initializer as deprecated.

### DIFF
--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -304,6 +304,11 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
     #else  // !REMOVE_LEGACY_NAMEMAP_INITIALIZERS
 
     /// Build the bidirectional maps between numbers and proto/JSON names.
+    @available(
+        *,
+        deprecated,
+        message: "Please regenerate your .pb.swift files with the current version of the SwiftProtobuf protoc plugin."
+    )
     public init(
         reservedNames: [String],
         reservedRanges: [Range<Int32>],
@@ -316,6 +321,11 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
     }
 
     /// Build the bidirectional maps between numbers and proto/JSON names.
+    @available(
+        *,
+        deprecated,
+        message: "Please regenerate your .pb.swift files with the current version of the SwiftProtobuf protoc plugin."
+    )
     public init(dictionaryLiteral elements: (Int, NameDescription)...) {
         initHelper(elements)
     }


### PR DESCRIPTION
No one calls these directly, but the old generated code code. This will hopefully nudge folks to regenerate their sources to take advantage of the newer generation that comes from smaller codegen and has some better memory overhead during startup.