### PR TITLE
Validate Duration before generating JSON to match upstream.

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -2,9 +2,3 @@
 Recommended.*.JsonInput.FieldNameDuplicate # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing1 # Should have failed to parse, but didn't.
 Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed to parse, but didn't.
-
-# Tracking in #1821
-Required.*.DurationProtoNanosTooLarge.JsonOutput # Should have failed to serialize, but didn't.
-Required.*.DurationProtoNanosTooSmall.JsonOutput # Should have failed to serialize, but didn't.
-Required.*.DurationProtoNanosWrongSign.JsonOutput # Should have failed to serialize, but didn't.
-Required.*.DurationProtoNanosWrongSignNegativeSecs.JsonOutput # Should have failed to serialize, but didn't.


### PR DESCRIPTION
- Add some tests.
- Document a few places where/why things get normalized.
- Update some tests specific to normalization that don't rely on constructing something that isn't otherwise "right" (json serialization would fail).

Progress on #1821.