### PR TITLE
Deprecate another helper.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Compiler_CodeGeneratorResponse+Extensions.swift
@@ -14,6 +14,7 @@
 
 extension Google_Protobuf_Compiler_CodeGeneratorResponse {
     /// Helper to make a response with an error.
+    @available(*, deprecated, message: "Please move your plugin to the CodeGenerator interface")
     public init(error: String) {
         self.init()
         self.error = error


### PR DESCRIPTION
Like the others, these shouldn't be needed if using CodeGenerator.