### PR TITLE
Let users opt of fetching protoc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,6 @@ let package = Package(
             name: "protoc-gen-swift",
             targets: ["protoc-gen-swift"]
         ),
-        .executable(
-            name: "protoc",
-            targets: ["protoc"]
-        ),
         .library(
             name: "SwiftProtobuf",
             targets: ["SwiftProtobuf"]
@@ -54,12 +50,6 @@ let package = Package(
             dependencies: ["SwiftProtobuf"],
             swiftSettings: .packageSettings
         ),
-        .binaryTarget(
-            name: "protoc",
-            url:
-                "https://github.com/apple/swift-protobuf/releases/download/protoc-artifactbundle-v31.1/protoc-31.1.artifactbundle.zip",
-            checksum: "f18bf2cfbbebd83133a4c29733b01871e3afdc73c102d62949a841d4f9bab86f"
-        ),
         .executableTarget(
             name: "protoc-gen-swift",
             dependencies: ["SwiftProtobufPluginLibrary", "SwiftProtobuf"],
@@ -75,7 +65,7 @@ let package = Package(
         .plugin(
             name: "SwiftProtobufPlugin",
             capability: .buildTool(),
-            dependencies: ["protoc-gen-swift", "protoc"]
+            dependencies: ["protoc-gen-swift"]
         ),
         .testTarget(
             name: "SwiftProtobufTests",
@@ -95,6 +85,37 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v5]
 )
+
+// Including protoc as a binary artifact can cause build issues in some environments. As a
+// temporary measure offer an opt-out by setting PROTOBUF_NO_PROTOC=true.
+let includeProtoc: Bool
+if let noProtoc = Context.environment["PROTOBUF_NO_PROTOC"] {
+    includeProtoc = !(noProtoc.lowercased() == "true" || noProtoc == "1")
+} else {
+    includeProtoc = true
+}
+
+if includeProtoc {
+    package.products.append(
+        .executable(
+            name: "protoc",
+            targets: ["protoc"]
+        )
+    )
+
+    package.targets.append(
+        .binaryTarget(
+            name: "protoc",
+            url:
+                "https://github.com/apple/swift-protobuf/releases/download/protoc-artifactbundle-v31.1/protoc-31.1.artifactbundle.zip",
+            checksum: "f18bf2cfbbebd83133a4c29733b01871e3afdc73c102d62949a841d4f9bab86f"
+        )
+    )
+
+    if let target = package.targets.first(where: { $0.name == "SwiftProtobufPlugin" }) {
+        target.dependencies.append("protoc")
+    }
+}
 
 // Settings for every Swift target in this package, like project-level settings
 // in an Xcode project.

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,15 @@
 
 import PackageDescription
 
+// Including protoc as a binary artifact can cause build issues in some environments. As a
+// temporary measure offer an opt-out by setting PROTOBUF_NO_PROTOC=true.
+let includeProtoc: Bool
+if let noProtoc = Context.environment["PROTOBUF_NO_PROTOC"] {
+    includeProtoc = !(noProtoc.lowercased() == "true" || noProtoc == "1")
+} else {
+    includeProtoc = true
+}
+
 let package = Package(
     name: "SwiftProtobuf",
     products: [
@@ -85,15 +94,6 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v5]
 )
-
-// Including protoc as a binary artifact can cause build issues in some environments. As a
-// temporary measure offer an opt-out by setting PROTOBUF_NO_PROTOC=true.
-let includeProtoc: Bool
-if let noProtoc = Context.environment["PROTOBUF_NO_PROTOC"] {
-    includeProtoc = !(noProtoc.lowercased() == "true" || noProtoc == "1")
-} else {
-    includeProtoc = true
-}
 
 if includeProtoc {
     package.products.append(


### PR DESCRIPTION
Motivation:

In some build environments fetching the protoc binary artifact doesn't work as expected (e.g. using '--build-system xcode'). This isn't an issue with SwiftProtobuf but this workardound unblocks users broken by the inclusion of protoc.

Modifications:

- Allow users to specify 'PROTOBUF_NO_PROTOC=true' or 'PROTOBUF_NO_PROTOC=1' to remove protoc from the package manifest.

Result:

Unblocks broken users