### PR TITLE
Float the bugfix version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,21 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Looking at https://hub.docker.com/_/swift, the version only tags (i.e.
-        # - 5.9.2) can use different Ubuntu releases. But just to be safe we use
-        # the specific OS release.
+        # We "float" the bug fix so we pick up new ones. This helps since the GitHub CI
+        # is set to ensure the actions pass, thus updates are only needed when the
+        # "major.minor" pairs changes.
         #
-        # We could use less specific tags (i.e. - 5.9), so they "float" as
-        # new point release come, but to help make history/logs more clear,
-        # being explicit (at the cost of having to update with point releases)
-        # seems better. This should also ensure protobuf caching changes with
-        # each new image incase system in the Swift image are changed/updated.
+        # Looking at https://hub.docker.com/_/swift, the version only tags (i.e. - 6.1)
+        # could use different Ubuntu releases. At the moment they are all the "noble",
+        # which is also what would be desired, so we don't bother listing explicit ones.
         swift:
-        - version: 6.1.3-noble
+        - version: "6.1"
           hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
-        - version: 6.0.3-noble
+        - version: "6.0"
           hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
-        - version: 5.10.1-noble
+        - version: "5.10"
           # No "hook", see https://github.com/apple/swift-protobuf/issues/1560 for the
           # current issue with using -warnings-as-errors on linux.
         # protobuf_git can reference a commit, tag, or branch

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -25,17 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Looking at https://hub.docker.com/_/swift, the version only tags (i.e.
-        # - 5.9.2) can use different Ubuntu releases. But just to be safe we use
-        # the specific OS release.
+        # We "float" the bug fix so we pick up new ones. This helps since the GitHub CI
+        # is set to ensure the actions pass, thus updates are only needed when the
+        # "major.minor" pairs changes.
         #
-        # We could use less specific tags (i.e. - 5.9), so they "float" as
-        # new point release come, but to help make history/logs more clear,
-        # being explicit (at the cost of having to update with point releases)
-        # seems better. This should also ensure protobuf caching changes with
-        # each new image incase system in the Swift image are changed/updated.
+        # Looking at https://hub.docker.com/_/swift, the version only tags (i.e. - 6.1)
+        # could use different Ubuntu releases. At the moment they are all the "noble",
+        # which is also what would be desired, so we don't bother listing explicit ones.
         swift:
-        - 6.1.3-noble
+        - "6.1"
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"


### PR DESCRIPTION
This will mean less update to the github CI for require actions; and it follows what nio is doing.