### PR TITLE
Include Swift 6.2 in the CI config.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
         # could use different Ubuntu releases. At the moment they are all the "noble",
         # which is also what would be desired, so we don't bother listing explicit ones.
         swift:
+        - version: "6.2"
+          hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
         - version: "6.1"
           hook: "SWIFT_BUILD_TEST_HOOK=\"-Xswiftc -warnings-as-errors\""
         - version: "6.0"

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -33,7 +33,7 @@ jobs:
         # could use different Ubuntu releases. At the moment they are all the "noble",
         # which is also what would be desired, so we don't bother listing explicit ones.
         swift:
-        - "6.1"
+        - "6.2"
         # protobuf_git can reference a commit, tag, or branch
         # commit: "commits/6935eae45c99926a000ecbef0be20dfd3d159e71"
         # tag: "ref/tags/v3.11.4"


### PR DESCRIPTION
- Add it into the mix for builds.
- Move conformance config to 6.2.

NOTE: Not removing 5.10 at this time. Per policy it can be removed, but waiting until nio has so we stay in sync on supported OSes for grpc.