### PR TITLE
Add basic RawSpan support for initializing and merging messages

### DIFF
--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -100,6 +100,34 @@ extension Message {
         try merge(serializedBytes: bytes, extensions: extensions, partial: partial, options: options)
     }
 
+    #if compiler(>=6.2)
+    /// Creates a new message by decoding the bytes provided by a `RawSpan`
+    /// containing a serialized message in Protocol Buffer binary format.
+    ///
+    /// - Parameters:
+    ///   - serializedBytes: The `RawSpan` of binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will check
+    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
+    ///     fields are present. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @inlinable
+    @available(macOS 26, iOS 26, tvOS 26, visionOS 26, *)
+    public init(
+        serializedBytes bytes: RawSpan,
+        extensions: (any ExtensionMap)? = nil,
+        partial: Bool = false,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        self.init()
+        try merge(serializedBytes: bytes, extensions: extensions, partial: partial, options: options)
+    }
+    #endif
+
     /// Updates the message by decoding the given `SwiftProtobufContiguousBytes` value
     /// containing a serialized message in Protocol Buffer binary format into the
     /// receiver.
@@ -130,6 +158,39 @@ extension Message {
             try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
         }
     }
+
+    #if compiler(>=6.2)
+    /// Updates the message by decoding the bytes provided by a `RawSpan` containing
+    /// a serialized message in Protocol Buffer binary format into the receiver.
+    ///
+    /// - Note: If this method throws an error, the message may still have been
+    ///   partially mutated by the binary data that was decoded before the error
+    ///   occurred.
+    ///
+    /// - Parameters:
+    ///   - serializedBytes: The `RawSpan` of binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will check
+    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
+    ///     fields are present. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @inlinable
+    @available(macOS 26, iOS 26, tvOS 26, visionOS 26, *)
+    public mutating func merge(
+        serializedBytes bytes: RawSpan,
+        extensions: (any ExtensionMap)? = nil,
+        partial: Bool = false,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+            try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
+        }
+    }
+    #endif
 
     // Helper for `merge()`s to keep the Decoder internal to SwiftProtobuf while
     // allowing the generic over `SwiftProtobufContiguousBytes` to get better codegen from the


### PR DESCRIPTION
On platforms targeting Swift 6.2 and later this allows a `RawSpan` in lieu of `SwiftProtobufContiguousBytes`-conforming type when creating or merging a protobuf message. This will improve memory usage by reducing allocations, for example when parsing a large document that includes protobuf messages as part of its binary. Unlike the internal `_merge` function, this does not expose unsafe API while retaining its benefits.

- I decided to make a twin declaration of the initializer and `merge` function instead of conforming `RawSpan` to `SwiftProtobufContiguousTypes`, because
  - a) `RawSpan` is not mutable, and
  - b) `Span` types are non-owning and cannot conform to initializers.
- I used the conditional compilation block and `@available` directive per analogy to [this implementation in SwiftNIO](https://github.com/apple/swift-nio/blob/main/Sources/NIOCore/ByteBuffer-core.swift#L1066).
