### PR TITLE
Version bump for a release.

### DIFF
--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -19,9 +19,9 @@ public struct Version {
     /// Major version.
     public static let major = 1
     /// Minor version.
-    public static let minor = 31
+    public static let minor = 32
     /// Revision number.
-    public static let revision = 2
+    public static let revision = 0
 
     /// String form of the version number.
     public static let versionString = "\(major).\(minor).\(revision)"

--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SwiftProtobuf'
-  s.version = '1.31.2'
+  s.version = '1.32.0'
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
   s.summary = 'Swift Protobuf Runtime Library'
   s.homepage = 'https://github.com/apple/swift-protobuf'


### PR DESCRIPTION
The `Span` support was a _minor_ bump, so left that out of the previous release so folks would get the assertion fix if they were only accepting bug fixes.