### PR TITLE
[table-driven-branch] Fix some copy/deinit bugs.

### DIFF
--- a/Sources/SwiftProtobuf/_MessageStorage.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage.swift
@@ -229,10 +229,13 @@ extension _MessageStorage {
             }
         }
 
-        // Copy all of the trivial values (including has-bits) in bitwise fashion.
-        if firstNontrivialStorageOffset != 0 {
-            destination.buffer.copyMemory(from: .init(rebasing: buffer[..<firstNontrivialStorageOffset]))
-        }
+        // Copy all of the trivial field values, has-bits, and any oneof tracking in bitwise
+        // fashion.
+        destination.buffer.copyMemory(from: .init(rebasing: buffer[..<firstNontrivialStorageOffset]))
+
+        destination.unknownFields = unknownFields
+        // TODO: Handle extension fields.
+
         return destination
     }
 


### PR DESCRIPTION
For copying, we were computing the size of the bitwise-copied range incorrectly. We were tracking the offset of the first non-trivial field we found, but this isn't correct because we iterate over them in *field number* order, not based on their *storage kind*. Instead, we need to track the *lowest* offset. It may be worth it to store this in the layout after all so that we don't have to recompute it each time.

For both copy and deinit, I had to fill in the missing oneof support. It's surprising that the tests passed without this, but I think that was by coincidence with the bug above, since it was causing us to bitwise-copy *more* data than we otherwise would have, and things just happened to line up correctly.