### PR TITLE
Optimize the CI setup some now that `protoc` is built by SwiftPM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,12 @@ jobs:
       run: make build ${{ matrix.swift.hook }}
     - name: Test runtime
       run: make test-runtime ${{ matrix.swift.hook }}
+    - name: Test plugin
+      run: make test-plugin
+    - name: Test SPM plugin
+      run: make test-spm-plugin
+    - name: Compilation Tests
+      run: make compile-tests
     - name: Build protobuf
       working-directory: Sources/protobuf/protobuf
       # https://github.com/protocolbuffers/protobuf/blob/main/cmake/README.md#c-version
@@ -62,15 +68,9 @@ jobs:
           -Dprotobuf_BUILD_CONFORMANCE=ON \
           -S ..
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
-        make -j "${NUM_CPUS}" protoc conformance_test_runner
-    - name: Test plugin
-      run: make test-plugin PROTOC=Sources/protobuf/protobuf/cmake_build/protoc
+        make -j "${NUM_CPUS}" conformance_test_runner
     - name: Test conformance
       run: make test-conformance CONFORMANCE_TEST_RUNNER=Sources/protobuf/protobuf/cmake_build/conformance_test_runner
-    - name: Test SPM plugin
-      run: make test-spm-plugin PROTOC=Sources/protobuf/protobuf/cmake_build/protoc
-    - name: Compilation Tests
-      run: make compile-tests PROTOC=Sources/protobuf/protobuf/cmake_build/protoc
 
   api-breakage:
     name: Api Breakage Compared to main branch
@@ -139,7 +139,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-      
+
     - name: Test
       run: |
         set -eu

--- a/.github/workflows/regular_conformance.yml
+++ b/.github/workflows/regular_conformance.yml
@@ -60,6 +60,6 @@ jobs:
           -Dprotobuf_BUILD_CONFORMANCE=ON \
           -S ..
         NUM_CPUS=$(getconf _NPROCESSORS_ONLN)
-        make -j "${NUM_CPUS}" protoc conformance_test_runner
+        make -j "${NUM_CPUS}" conformance_test_runner
     - name: Test conformance
       run: make test-conformance CONFORMANCE_TEST_RUNNER=Sources/protobuf/protobuf/cmake_build/conformance_test_runner


### PR DESCRIPTION
- Don't override the `PROTOC` value when running tests, let the in tree one be used.
- For conformance tests, only build the runner in the protobuf checkout (no need to force a `protoc` build also)
- Move the protobuf conformance runner build and the conformance tests to be after all the other steps, might as well let everything else finish first to catch issues before waiting on protobuf to build.