### PR TITLE
Ignore the abseil privacy manifest and bump the patch version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,9 @@ let package = Package(
         .executableTarget(
             name: "protoc",
             path: "Sources/protobuf",
+            exclude: [
+                "abseil/PrivacyInfo.xcprivacy"
+            ],
             sources: [
                 // protoc main
                 "protobuf/src/google/protobuf/compiler/main_no_generators.cc",
@@ -414,7 +417,7 @@ let package = Package(
             swiftSettings: .packageSettings
         ),
     ],
-    swiftLanguageVersions: [.v5],
+    swiftLanguageModes: [.v5],
     cxxLanguageStandard: .gnucxx17
 )
 

--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -21,7 +21,7 @@ public struct Version {
     /// Minor version.
     public static let minor = 33
     /// Revision number.
-    public static let revision = 2
+    public static let revision = 3
 
     /// String form of the version number.
     public static let versionString = "\(major).\(minor).\(revision)"

--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SwiftProtobuf'
-  s.version = '1.33.2'
+  s.version = '1.33.3'
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
   s.summary = 'Swift Protobuf Runtime Library'
   s.homepage = 'https://github.com/apple/swift-protobuf'


### PR DESCRIPTION
It appears that on macOS when building with Xcode the latest changes have resulted in a error when resolving `swift-protobuf` reported in https://github.com/apple/swift-protobuf/issues/1884.

This PR ignores the abseil privacy manifest which should fix the issue