### PR TITLE
Move the upstream proto check back to protobuf head.

### DIFF
--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -17,6 +17,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        submodules: true
+        path: swift-protobuf
+        # Don't need the submodules since we are checking against upstream.
+    - name: Checkout protobufbuffers/protobuf
+      uses: actions/checkout@v4
+      with:
+        repository: protocolbuffers/protobuf
+        path: protobuf
     - name: Check Upstream Proto Files
-      run: make check-proto-files
+      working-directory: swift-protobuf
+      run: make check-proto-files GOOGLE_PROTOBUF_CHECKOUT=../protobuf

--- a/Makefile
+++ b/Makefile
@@ -620,6 +620,8 @@ update-proto-files: check-for-protobuf-checkout
 #
 # Helper to see if update-proto-files should be done
 #
+# Usually want to also provide `GOOGLE_PROTOBUF_CHECKOUT=some_local_head_protobuf` so
+# you are checking against a state this project hasn't adopted yet.
 check-proto-files: check-for-protobuf-checkout
 	@for p in `cd ${GOOGLE_PROTOBUF_CHECKOUT} && ls conformance/*.proto conformance/test_protos/*.proto`; do \
 		diff -u "Protos/upstream/$$p" "${GOOGLE_PROTOBUF_CHECKOUT}/$$p" \


### PR DESCRIPTION
This will give early warning again instead of trigger after we do an update.