### PR TITLE
Remove redundant branch.

### DIFF
--- a/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
+++ b/Sources/SwiftProtobufPluginLibrary/Google_Protobuf_Edition+Extensions.swift
@@ -17,16 +17,8 @@ import SwiftProtobuf
 
 /// The spec for editions calls out them being ordered and comparable.
 /// https://github.com/protocolbuffers/protobuf/blob/main/docs/design/editions/edition-naming.md
-#if compiler(>=6)
 extension Google_Protobuf_Edition: Comparable {
     public static func < (lhs: Google_Protobuf_Edition, rhs: Google_Protobuf_Edition) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 }
-#else
-extension Google_Protobuf_Edition: Comparable {
-    public static func < (lhs: Google_Protobuf_Edition, rhs: Google_Protobuf_Edition) -> Bool {
-        lhs.rawValue < rhs.rawValue
-    }
-}
-#endif


### PR DESCRIPTION
Both sides are the same. This seems to go back to
https://github.com/apple/swift-protobuf/pull/1775/commits/30194871ab93ab8e9005d5e98abae48e9fd1905e where we didn't catch that they two were now the same.