### PR TITLE
Move the API check into a separate github CI config.

### DIFF
--- a/.github/workflows/api_check.yml
+++ b/.github/workflows/api_check.yml
@@ -1,0 +1,33 @@
+name: API Breakage
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  api-breakage:
+    name: Api Breakage Compared to main branch
+    runs-on: ubuntu-latest
+    container:
+      # Test on the latest Swift release. This could run on all the support
+      # Swift versions, but that doesn't seem worth it until there are Swift
+      # version specific conditionals to justify it.
+      image: swift:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Mark the workspace as safe
+      # https://github.com/actions/checkout/issues/766
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+    - name: Check for API breaking changes
+      # This can flag things related to the generated code for the upstream
+      # protos (descriptor.proto, etc.), however those should all be OK as they
+      # are limited plugin, and most of the time everything is hidden within the
+      # generation api.
+      run: swift package diagnose-api-breaking-changes origin/main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,28 +63,6 @@ jobs:
       if: ${{ matrix.swift.version != '5.10' }}
       run: make compile-tests
 
-  api-breakage:
-    name: Api Breakage Compared to main branch
-    # Only on pull requests
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    container:
-      # Test on the latest Swift release. This could run on all the support
-      # Swift versions, but that doesn't seem worth it until there are Swift
-      # version specific conditionals to justify it.
-      image: swift:latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: true
-    - name: Mark the workspace as safe
-      # https://github.com/actions/checkout/issues/766
-      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-    - name: Check for API breaking changes
-      run: swift package diagnose-api-breaking-changes origin/main --breakage-allowlist-path known_api_breaks.txt
-
   format-check:
     name: swift-format Check
     # Only on pull requests

--- a/known_api_breaks.txt
+++ b/known_api_breaks.txt
@@ -1,1 +1,0 @@
-API breakage: enumelement Google_Protobuf_Edition.unstable has been added as a new enum case


### PR DESCRIPTION
It was already running in parallel, this just makes it easier to make it not required to deal with the fact that some upstream protos can pick up new enum elements which isn't really breaking to SwiftProtobuf.

Remove the known breaks file that was used to land the last update.