### PR TITLE
Remove the known api breaks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Check for API breaking changes
-      run: swift package diagnose-api-breaking-changes origin/main --breakage-allowlist-path known_api_breaks.txt
+      run: swift package diagnose-api-breaking-changes origin/main
 
   format-check:
     name: swift-format Check

--- a/known_api_breaks.txt
+++ b/known_api_breaks.txt
@@ -1,1 +1,0 @@
-API breakage: enumelement Google_Protobuf_Edition.unstable has been added as a new enum case


### PR DESCRIPTION
Was needed to just land the upstream proto change that added an enum element that isn't really considered breaking for the runtime.