### PR TITLE
Update proto files from upstream.

### DIFF
--- a/Protos/Sources/SwiftProtobuf/google/protobuf/descriptor.proto
+++ b/Protos/Sources/SwiftProtobuf/google/protobuf/descriptor.proto
@@ -476,7 +476,18 @@ message FileOptions {
   // named by java_outer_classname.  However, the wrapper class will still be
   // generated to contain the file's getDescriptor() method as well as any
   // top-level extensions defined in the file.
-  optional bool java_multiple_files = 10 [default = false];
+  optional bool java_multiple_files = 10 [
+    default = false,
+    feature_support = {
+      edition_introduced: EDITION_PROTO2
+      edition_removed: EDITION_2024
+      removal_error: "The `java_multiple_files` behavior is enabled by "
+                     "default in editions 2024 and above. To disable it, "
+                     "you can set `features.(pb.java).nest_in_file_class = YES` "
+                     "on individual messages, enums, or services."
+
+    }
+  ];
 
   // This option does nothing.
   optional bool java_generate_equals_and_hash = 20 [deprecated=true];

--- a/Protos/upstream/google/protobuf/descriptor.proto
+++ b/Protos/upstream/google/protobuf/descriptor.proto
@@ -476,7 +476,18 @@ message FileOptions {
   // named by java_outer_classname.  However, the wrapper class will still be
   // generated to contain the file's getDescriptor() method as well as any
   // top-level extensions defined in the file.
-  optional bool java_multiple_files = 10 [default = false];
+  optional bool java_multiple_files = 10 [
+    default = false,
+    feature_support = {
+      edition_introduced: EDITION_PROTO2
+      edition_removed: EDITION_2024
+      removal_error: "The `java_multiple_files` behavior is enabled by "
+                     "default in editions 2024 and above. To disable it, "
+                     "you can set `features.(pb.java).nest_in_file_class = YES` "
+                     "on individual messages, enums, or services."
+
+    }
+  ];
 
   // This option does nothing.
   optional bool java_generate_equals_and_hash = 20 [deprecated=true];


### PR DESCRIPTION
The additional information doesn't factor into the Swift generation, so no need to regenerate/etc.

Used upstream 9a98695003398ef186ca8a9c8ab0feba0595029c.