### PR TITLE
Update Reference/upstream when updating protobuf.

### DIFF
--- a/.github/workflows/update_protobuf.yml
+++ b/.github/workflows/update_protobuf.yml
@@ -89,6 +89,18 @@ jobs:
         echo "abseil_version=$ABSEIL_TAG" >> $GITHUB_OUTPUT
         cd ../../..
 
+    - name: Update Reference Protos
+      # The Reference/upstream contents is generated from Source/protobuf/protobuf, so
+      # update them.
+      #
+      # Note: we could move the work in `make reference` to a helper script and skip the
+      # install of Make, but given it shares setup with other targets in the Makefile,
+      # not sure it's worth while.
+      if: steps.check_release.outputs.needs_update == 'true'
+      run: |
+        apt-get update && apt-get install -y make
+        make reference
+
     - name: Create Pull Request
       if: steps.check_release.outputs.needs_update == 'true'
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Since the repo no longer shadows all the protos, make the update process also update the generated files for the tests.