### PR TITLE
Update proto files from upstream.

### DIFF
--- a/Protos/Sources/Conformance/conformance/test_protos/test_messages_edition2023.proto
+++ b/Protos/Sources/Conformance/conformance/test_protos/test_messages_edition2023.proto
@@ -205,6 +205,8 @@ enum ForeignEnumEdition2023 {
 
 extend TestAllTypesEdition2023 {
   int32 extension_int32 = 120;
+  string extension_string = 133;
+  bytes extension_bytes = 134;
 }
 
 message GroupLikeType {

--- a/Protos/Sources/Conformance/editions/test_messages_proto2_editions.proto
+++ b/Protos/Sources/Conformance/editions/test_messages_proto2_editions.proto
@@ -372,6 +372,8 @@ enum ForeignEnumProto2 {
 
 extend TestAllTypesProto2 {
   int32 extension_int32 = 120;
+  string extension_string = 133;
+  bytes extension_bytes = 134;
 }
 
 extend TestAllTypesProto2 {

--- a/Protos/Sources/Conformance/google/protobuf/test_messages_proto2.proto
+++ b/Protos/Sources/Conformance/google/protobuf/test_messages_proto2.proto
@@ -270,6 +270,8 @@ enum ForeignEnumProto2 {
 
 extend TestAllTypesProto2 {
   optional int32 extension_int32 = 120;
+  optional string extension_string = 133;
+  optional bytes extension_bytes = 134;
 }
 
 extend TestAllTypesProto2 {

--- a/Sources/Conformance/test_messages_edition2023.pb.swift
+++ b/Sources/Conformance/test_messages_edition2023.pb.swift
@@ -930,6 +930,36 @@ extension ProtobufTestMessages_Editions_TestAllTypesEdition2023 {
     clearExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_int32)
   }
 
+  var ProtobufTestMessages_Editions_extensionString: String {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_string) ?? String()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_string, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Editions_Extensions_extension_string`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Editions_extensionString: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_string)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Editions_Extensions_extension_string`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Editions_extensionString() {
+    clearExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_string)
+  }
+
+  var ProtobufTestMessages_Editions_extensionBytes: Data {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_bytes) ?? Data()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_bytes, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Editions_Extensions_extension_bytes`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Editions_extensionBytes: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_bytes)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Editions_Extensions_extension_bytes`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Editions_extensionBytes() {
+    clearExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_extension_bytes)
+  }
+
   var ProtobufTestMessages_Editions_groupLikeType: ProtobufTestMessages_Editions_GroupLikeType {
     get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_GroupLikeType) ?? ProtobufTestMessages_Editions_GroupLikeType()}
     set {setExtensionValue(ext: ProtobufTestMessages_Editions_Extensions_GroupLikeType, value: newValue)}
@@ -970,6 +1000,8 @@ extension ProtobufTestMessages_Editions_TestAllTypesEdition2023 {
 /// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufTestMessages_Editions_TestMessagesEdition2023_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufTestMessages_Editions_Extensions_extension_int32,
+  ProtobufTestMessages_Editions_Extensions_extension_string,
+  ProtobufTestMessages_Editions_Extensions_extension_bytes,
   ProtobufTestMessages_Editions_Extensions_GroupLikeType,
   ProtobufTestMessages_Editions_Extensions_delimited_ext
 ]
@@ -981,6 +1013,16 @@ let ProtobufTestMessages_Editions_TestMessagesEdition2023_Extensions: SwiftProto
 let ProtobufTestMessages_Editions_Extensions_extension_int32 = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufTestMessages_Editions_TestAllTypesEdition2023>(
   _protobuf_fieldNumber: 120,
   fieldName: "protobuf_test_messages.editions.extension_int32"
+)
+
+let ProtobufTestMessages_Editions_Extensions_extension_string = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufTestMessages_Editions_TestAllTypesEdition2023>(
+  _protobuf_fieldNumber: 133,
+  fieldName: "protobuf_test_messages.editions.extension_string"
+)
+
+let ProtobufTestMessages_Editions_Extensions_extension_bytes = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufTestMessages_Editions_TestAllTypesEdition2023>(
+  _protobuf_fieldNumber: 134,
+  fieldName: "protobuf_test_messages.editions.extension_bytes"
 )
 
 let ProtobufTestMessages_Editions_Extensions_GroupLikeType = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalGroupExtensionField<ProtobufTestMessages_Editions_GroupLikeType>, ProtobufTestMessages_Editions_TestAllTypesEdition2023>(

--- a/Sources/Conformance/test_messages_proto2.pb.swift
+++ b/Sources/Conformance/test_messages_proto2.pb.swift
@@ -2132,6 +2132,36 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2 {
     clearExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_int32)
   }
 
+  var ProtobufTestMessages_Proto2_extensionString: String {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_string) ?? String()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_string, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Proto2_Extensions_extension_string`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Proto2_extensionString: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_string)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Proto2_Extensions_extension_string`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Proto2_extensionString() {
+    clearExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_string)
+  }
+
+  var ProtobufTestMessages_Proto2_extensionBytes: Data {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_bytes) ?? Data()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_bytes, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Proto2_Extensions_extension_bytes`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Proto2_extensionBytes: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_bytes)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Proto2_Extensions_extension_bytes`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Proto2_extensionBytes() {
+    clearExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_extension_bytes)
+  }
+
   var ProtobufTestMessages_Proto2_groupField: ProtobufTestMessages_Proto2_GroupField {
     get {return getExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_GroupField) ?? ProtobufTestMessages_Proto2_GroupField()}
     set {setExtensionValue(ext: ProtobufTestMessages_Proto2_Extensions_GroupField, value: newValue)}
@@ -2205,6 +2235,8 @@ extension ProtobufTestMessages_Proto2_TestAllTypesProto2.MessageSetCorrect {
 /// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufTestMessages_Proto2_TestMessagesProto2_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufTestMessages_Proto2_Extensions_extension_int32,
+  ProtobufTestMessages_Proto2_Extensions_extension_string,
+  ProtobufTestMessages_Proto2_Extensions_extension_bytes,
   ProtobufTestMessages_Proto2_Extensions_GroupField,
   ProtobufTestMessages_Proto2_TestAllTypesProto2.MessageSetCorrectExtension1.Extensions.message_set_extension,
   ProtobufTestMessages_Proto2_TestAllTypesProto2.MessageSetCorrectExtension2.Extensions.message_set_extension,
@@ -2220,6 +2252,16 @@ let ProtobufTestMessages_Proto2_TestMessagesProto2_Extensions: SwiftProtobuf.Sim
 let ProtobufTestMessages_Proto2_Extensions_extension_int32 = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufTestMessages_Proto2_TestAllTypesProto2>(
   _protobuf_fieldNumber: 120,
   fieldName: "protobuf_test_messages.proto2.extension_int32"
+)
+
+let ProtobufTestMessages_Proto2_Extensions_extension_string = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufTestMessages_Proto2_TestAllTypesProto2>(
+  _protobuf_fieldNumber: 133,
+  fieldName: "protobuf_test_messages.proto2.extension_string"
+)
+
+let ProtobufTestMessages_Proto2_Extensions_extension_bytes = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufTestMessages_Proto2_TestAllTypesProto2>(
+  _protobuf_fieldNumber: 134,
+  fieldName: "protobuf_test_messages.proto2.extension_bytes"
 )
 
 let ProtobufTestMessages_Proto2_Extensions_GroupField = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalGroupExtensionField<ProtobufTestMessages_Proto2_GroupField>, ProtobufTestMessages_Proto2_TestAllTypesProto2>(

--- a/Sources/Conformance/test_messages_proto2_editions.pb.swift
+++ b/Sources/Conformance/test_messages_proto2_editions.pb.swift
@@ -2133,6 +2133,36 @@ extension ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2 {
     clearExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_int32)
   }
 
+  var ProtobufTestMessages_Editions_Proto2_extensionString: String {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_string) ?? String()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_string, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Editions_Proto2_Extensions_extension_string`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Editions_Proto2_extensionString: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_string)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Editions_Proto2_Extensions_extension_string`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Editions_Proto2_extensionString() {
+    clearExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_string)
+  }
+
+  var ProtobufTestMessages_Editions_Proto2_extensionBytes: Data {
+    get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes) ?? Data()}
+    set {setExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes`
+  /// has been explicitly set.
+  var hasProtobufTestMessages_Editions_Proto2_extensionBytes: Bool {
+    return hasExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes)
+  }
+  /// Clears the value of extension `ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufTestMessages_Editions_Proto2_extensionBytes() {
+    clearExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes)
+  }
+
   var ProtobufTestMessages_Editions_Proto2_groupField: ProtobufTestMessages_Editions_Proto2_GroupField {
     get {return getExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_GroupField) ?? ProtobufTestMessages_Editions_Proto2_GroupField()}
     set {setExtensionValue(ext: ProtobufTestMessages_Editions_Proto2_Extensions_GroupField, value: newValue)}
@@ -2206,6 +2236,8 @@ extension ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2.MessageSetCorr
 /// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufTestMessages_Editions_Proto2_TestMessagesProto2Editions_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufTestMessages_Editions_Proto2_Extensions_extension_int32,
+  ProtobufTestMessages_Editions_Proto2_Extensions_extension_string,
+  ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes,
   ProtobufTestMessages_Editions_Proto2_Extensions_GroupField,
   ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2.MessageSetCorrectExtension1.Extensions.message_set_extension,
   ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2.MessageSetCorrectExtension2.Extensions.message_set_extension,
@@ -2221,6 +2253,16 @@ let ProtobufTestMessages_Editions_Proto2_TestMessagesProto2Editions_Extensions: 
 let ProtobufTestMessages_Editions_Proto2_Extensions_extension_int32 = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2>(
   _protobuf_fieldNumber: 120,
   fieldName: "protobuf_test_messages.editions.proto2.extension_int32"
+)
+
+let ProtobufTestMessages_Editions_Proto2_Extensions_extension_string = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2>(
+  _protobuf_fieldNumber: 133,
+  fieldName: "protobuf_test_messages.editions.proto2.extension_string"
+)
+
+let ProtobufTestMessages_Editions_Proto2_Extensions_extension_bytes = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2>(
+  _protobuf_fieldNumber: 134,
+  fieldName: "protobuf_test_messages.editions.proto2.extension_bytes"
 )
 
 let ProtobufTestMessages_Editions_Proto2_Extensions_GroupField = SwiftProtobuf.MessageExtension<SwiftProtobuf.OptionalGroupExtensionField<ProtobufTestMessages_Editions_Proto2_GroupField>, ProtobufTestMessages_Editions_Proto2_TestAllTypesProto2>(


### PR DESCRIPTION
The conformance tests protos got updated, picking up the changes so things can pass.

Using upstream 086093946d986ed60b98af0b412baf5d4b1145d5.

`semver/none` because the protos are only in the conformance tests, so nothing changes in the runtime at all.