### PR TITLE
Fetch jq and curl for the run

### DIFF
--- a/.github/workflows/update_protobuf.yml
+++ b/.github/workflows/update_protobuf.yml
@@ -23,6 +23,10 @@ jobs:
         submodules: true
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Update and install dependencies
+      # This step is run before check_release because we need curl and jq
+      run: apt-get update && apt-get install -y curl jq
+
     - name: Check for new protobuf release
       id: check_release
       run: |


### PR DESCRIPTION
Looking at
https://github.com/apple/swift-protobuf/actions/runs/21272625357/job/61225732744, the base images must have dropped these as they came back as not found the other night, so ensure they are present.