### PR TITLE
Example using a WKT

### DIFF
--- a/PluginExamples/Package.swift
+++ b/PluginExamples/Package.swift
@@ -56,6 +56,15 @@ let package = Package(
                 .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
             ]
         ),
+        .target(
+            name: "UsesWKTs",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
         .testTarget(
             name: "ExampleTests",
             dependencies: [
@@ -64,6 +73,7 @@ let package = Package(
                 .target(name: "Import"),
                 .target(name: "AccessLevelOnImport"),
                 .target(name: "CustomProtoPath"),
+                .target(name: "UsesWKTs"),
             ]
         ),
     ],

--- a/PluginExamples/Sources/ExampleTests/ExampleTests.swift
+++ b/PluginExamples/Sources/ExampleTests/ExampleTests.swift
@@ -2,6 +2,7 @@ import CustomProtoPath
 import Import
 import Nested
 import Simple
+import UsesWKTs
 import XCTest
 
 final class ExampleTests: XCTestCase {
@@ -27,5 +28,14 @@ final class ExampleTests: XCTestCase {
         }
         XCTAssertEqual(main.bar.name, "Bar")
         XCTAssertEqual(main.foo.bar.name, "BarInFoo")
+    }
+
+    func testUsesWKTs() {
+        let usesWKTs = UsesWKTs.with {
+            $0.name = "UsesWKTs"
+            $0.aTimestamp.seconds = 2
+        }
+        XCTAssertEqual(usesWKTs.name, "UsesWKTs")
+        XCTAssertEqual(usesWKTs.aTimestamp.seconds, 2)
     }
 }

--- a/PluginExamples/Sources/UsesWKTs/UsesWKTs.proto
+++ b/PluginExamples/Sources/UsesWKTs/UsesWKTs.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message UsesWKTs {
+  string name = 1;
+
+  google.protobuf.Timestamp a_timestamp = 2;
+}

--- a/PluginExamples/Sources/UsesWKTs/empty.swift
+++ b/PluginExamples/Sources/UsesWKTs/empty.swift
@@ -1,0 +1,3 @@
+/// DO NOT DELETE.
+///
+/// We need to keep this file otherwise the plugin is not running.

--- a/PluginExamples/Sources/UsesWKTs/swift-protobuf-config.json
+++ b/PluginExamples/Sources/UsesWKTs/swift-protobuf-config.json
@@ -1,0 +1,10 @@
+{
+    "invocations": [
+        {
+            "protoFiles": [
+                "UsesWKTs.proto",
+            ],
+            "visibility": "public"
+        }
+    ]
+}


### PR DESCRIPTION
This does not work with the protoc built locally because the WKTs aren't found. If you try building using the env variable to provide a full `protoc` install, then it works since that bundles all the WKTs and the proto compiler auto finds the bundled files.

See #1943 for some of the research into options in this space.