### PR TITLE
Drop the API break file.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       # https://github.com/actions/checkout/issues/766
       run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Check for API breaking changes
-      run: swift package diagnose-api-breaking-changes origin/main --breakage-allowlist-path known_api_breaks.txt
+      run: swift package diagnose-api-breaking-changes origin/main
 
   format-check:
     name: swift-format Check

--- a/known_api_breaks.txt
+++ b/known_api_breaks.txt
@@ -1,1 +1,0 @@
-API breakage: enumelement Google_Protobuf_Edition.edition2026 has been added as a new enum case


### PR DESCRIPTION
Like last time, only needed to land descriptor updates; which we don't control and only plugins rely on the information and the plugin api we expose hides these types of details, but we need to update the proto file to part newer files.