### PR TITLE
[table-driven-branch] Implement JSON for `FieldMask`.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -13,18 +13,6 @@
 ///
 // -----------------------------------------------------------------------------
 
-// True if the string only contains printable (non-control)
-// ASCII characters.  Note: This follows the ASCII standard;
-// space is not a "printable" character.
-private func isPrintableASCII(_ s: String) -> Bool {
-    for u in s.utf8 {
-        if u <= 0x20 || u >= 0x7f {
-            return false
-        }
-    }
-    return true
-}
-
 private func ProtoToJSON(name: String) -> String? {
     guard isPrintableASCII(name) else { return nil }
     var jsonPath = String()

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -113,3 +113,15 @@ extension Unicode.Scalar {
         return Self(value & 0x5f)!
     }
 }
+
+// True if the string only contains printable (non-control)
+// ASCII characters.  Note: This follows the ASCII standard;
+// space is not a "printable" character.
+func isPrintableASCII(_ s: String) -> Bool {
+    for u in s.utf8 {
+        if u <= 0x20 || u >= 0x7f {
+            return false
+        }
+    }
+    return true
+}

--- a/Sources/SwiftProtobuf/_MessageStorage+JSONDecoding.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage+JSONDecoding.swift
@@ -607,9 +607,10 @@ extension _MessageStorage {
     ///
     /// - Precondition: The receiver must be the storage for `google.protobuf.FieldMask`.
     private func parseAsFieldMask(from reader: inout JSONReader) throws {
+        let pathsField = schema[fieldNumber: 1]!
         let fieldMaskString = try reader.scanner.nextQuotedString()
         try parseFieldMask(fieldMaskString) { name in
-            appendValue(name, to: schema[fieldNumber: 1]!)
+            appendValue(name, to: pathsField)
         }
     }
 

--- a/Sources/SwiftProtobuf/_MessageStorage+JSONDecoding.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage+JSONDecoding.swift
@@ -73,6 +73,9 @@ extension _MessageStorage {
         case .duration:
             try parseAsDuration(from: &reader)
 
+        case .fieldMask:
+            try parseAsFieldMask(from: &reader)
+
         case .floatValue:
             try disallowingNull {
                 updateValue(of: schema[fieldNumber: 1]!, to: try reader.scanner.nextFloat())
@@ -126,10 +129,6 @@ extension _MessageStorage {
 
         case .value:
             try parseAsValue(from: &reader)
-
-        case .fieldMask:
-            // TODO: Actually implement these. For now, just fall through to the default.
-            fallthrough
 
         case .notWellKnown:
             // This is the common case.
@@ -603,6 +602,17 @@ extension _MessageStorage {
         updateValue(of: schema[fieldNumber: 2]!, to: nanos)
     }
 
+    /// Parses the next quoted string from the input and interprets it as the JSON representation
+    /// of a well-known type `FieldMask`.
+    ///
+    /// - Precondition: The receiver must be the storage for `google.protobuf.FieldMask`.
+    private func parseAsFieldMask(from reader: inout JSONReader) throws {
+        let fieldMaskString = try reader.scanner.nextQuotedString()
+        try parseFieldMask(fieldMaskString) { name in
+            appendValue(name, to: schema[fieldNumber: 1]!)
+        }
+    }
+
     /// Parses the next value from the input and interprets it as the JSON representation of a
     /// well-known type `ListValue`.
     ///
@@ -772,4 +782,59 @@ func scanArray(
 // registry, just do this minimal validation check.
 func isTypeURLValid(_ typeURL: String) -> Bool {
     typeURL.contains(where: { $0 == "/" })
+}
+
+private func parseFieldMask(_ names: String, receive: (String) -> Void) throws {
+    var fieldNameCount = 0
+    var fieldName = String()
+    for c in names {
+        switch c {
+        case ",":
+            if fieldNameCount == 0 {
+                throw JSONEncodingError.fieldMaskConversion
+            }
+            if let pbName = protoName(forJSONFieldMaskPath: fieldName) {
+                receive(pbName)
+            } else {
+                throw JSONEncodingError.fieldMaskConversion
+            }
+            fieldName = String()
+            fieldNameCount = 0
+        default:
+            fieldName.append(c)
+            fieldNameCount += 1
+        }
+    }
+    if fieldNameCount == 0 {  // Last field name can't be empty
+        throw JSONEncodingError.fieldMaskConversion
+    }
+    if let pbName = protoName(forJSONFieldMaskPath: fieldName) {
+        receive(pbName)
+    } else {
+        throw JSONEncodingError.fieldMaskConversion
+    }
+}
+
+/// Returns the protobuf form of the field mask path with the given JSON name, or nil if it was not
+/// possible to convert it to a protobuf form.
+private func protoName(forJSONFieldMaskPath name: String) -> String? {
+    guard isPrintableASCII(name) else { return nil }
+    var path = String()
+    for c in name {
+        switch c {
+        case "_":
+            return nil
+        case "A"..."Z":
+            path.append(Character("_"))
+            path.append(String(c).lowercased())
+        case "a"..."z", "0"..."9", ".", "(", ")":
+            path.append(c)
+        default:
+            // TODO: Change to `return nil` once
+            // we know everything legal is being
+            // handled above
+            path.append(c)
+        }
+    }
+    return path
 }

--- a/Sources/SwiftProtobuf/_MessageStorage+JSONEncoding.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage+JSONEncoding.swift
@@ -54,6 +54,9 @@ extension _MessageStorage {
         case .duration:
             try emitAsDuration(into: &encoder)
 
+        case .fieldMask:
+            try emitAsFieldMask(into: &encoder)
+
         case .floatValue:
             encoder.putFloatValue(value: value(of: schema[fieldNumber: 1]!))
 
@@ -95,10 +98,6 @@ extension _MessageStorage {
 
         case .value:
             try emitAsValue(into: &encoder, options: options)
-
-        case .fieldMask:
-            // TODO: Actually implement these. For now, just fall through to the default.
-            fallthrough
 
         case .notWellKnown:
             // This is the common case.
@@ -454,6 +453,24 @@ extension _MessageStorage {
         encoder.putStringValue(value: formatted)
     }
 
+    /// Emits a double-quoted string to the encoder that is the JSON representation of the receiver
+    /// as a well-known-type `FieldMask`.
+    ///
+    /// - Precondition: The receiver must be the storage for `google.protobuf.FieldMask`.
+    private func emitAsFieldMask(into encoder: inout JSONEncoder) throws {
+        let paths = value(of: schema[fieldNumber: 1]!, default: []) as [String]
+        var jsonPaths = [String]()
+        jsonPaths.reserveCapacity(paths.count)
+        for path in paths {
+            if let jsonPath = jsonName(forProtoFieldMaskPath: path) {
+                jsonPaths.append(jsonPath)
+            } else {
+                throw JSONEncodingError.fieldMaskConversion
+            }
+        }
+        encoder.putStringValue(value: jsonPaths.joined(separator: ","))
+    }
+
     /// Emits a JSON array to the encoder that is the JSON representation of the receiver as a
     /// well-known-type `ListValue`.
     ///
@@ -574,4 +591,37 @@ extension _MessageStorage {
             throw JSONEncodingError.missingValue
         }
     }
+}
+
+/// Returns the JSON form of the field mask path with the given proto name, or nil if it was not
+/// possible to convert it to a JSON form.
+private func jsonName(forProtoFieldMaskPath name: String) -> String? {
+    guard isPrintableASCII(name) else { return nil }
+    var jsonPath = String()
+    var chars = name.makeIterator()
+    while let c = chars.next() {
+        switch c {
+        case "_":
+            if let toupper = chars.next() {
+                switch toupper {
+                case "a"..."z":
+                    jsonPath.append(String(toupper).uppercased())
+                default:
+                    return nil
+                }
+            } else {
+                return nil
+            }
+        case "A"..."Z":
+            return nil
+        case "a"..."z", "0"..."9", ".", "(", ")":
+            jsonPath.append(c)
+        default:
+            // TODO: Change this to `return nil`
+            // once we know everything legal is handled
+            // above.
+            jsonPath.append(c)
+        }
+    }
+    return jsonPath
 }

--- a/Sources/SwiftProtobuf/_MessageStorage.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage.swift
@@ -1071,6 +1071,18 @@ extension _MessageStorage {
         }
     }
 
+    /// Returns the array value of the given field, or the default value if it is not present.
+    func value<T>(of field: FieldSchema, default: [T] = []) -> [T] {
+        guard isPresent(field) else { return `default` }
+        let offset = field.offset
+        switch field.presence {
+        case .hasBit(let hasByteOffset, let hasMask):
+            return value(at: offset, hasBit: (hasByteOffset, hasMask))
+        case .oneOfMember:
+            preconditionFailure("Unreachable")
+        }
+    }
+
     /// Returns the field number of the oneof member that is populated, using the given field to
     /// look up its containing oneof.
     public func populatedOneofMember(of field: FieldSchema) -> UInt32 {

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/Test_Any.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/Test_Any.swift
@@ -359,8 +359,7 @@ final class Test_Any: XCTestCase {
         }
     }
 
-    // TODO: Re-enable after we implement custom JSON for field masks.
-    func DISABLED_test_Any_FieldMask_JSON_roundtrip() throws {
+    func test_Any_FieldMask_JSON_roundtrip() throws {
         let start =
             "{\"optionalAny\":{\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\",\"value\":\"foo,bar.bazQuux\"}}"
         do {
@@ -381,8 +380,7 @@ final class Test_Any: XCTestCase {
         }
     }
 
-    // TODO: Re-enable after we implement custom JSON for field masks.
-    func DISABLED_test_Any_FieldMask_transcode() throws {
+    func test_Any_FieldMask_transcode() throws {
         let start =
             "{\"optionalAny\":{\"@type\":\"type.googleapis.com/google.protobuf.FieldMask\",\"value\":\"foo,bar.bazQuux\"}}"
         do {


### PR DESCRIPTION
I haven't brought over the full `FieldMask` tests because the vast majority of them depend on visitor/decoder infrastructure that's going to be deleted. When I do that deletion, this branch will be in a transitional state where those APIs are no longer supported. The plan will be to have them use the future reflection API instead, since that will be the only way to generically operate on a message.