### PR TITLE
Prevent `make reference` from failing the protobuf & abseil updates.

### DIFF
--- a/.github/workflows/check_upstream_protos.yml
+++ b/.github/workflows/check_upstream_protos.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build:
+    # Only do this job on the main repo (and not forks of it).
+    if: github.repository == 'apple/swift-protobuf'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   semver-label-check:
     name: Semantic version label check
+    # Only do this job on the main repo (and not forks of it).
+    if: github.repository == 'apple/swift-protobuf'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/update_protobuf.yml
+++ b/.github/workflows/update_protobuf.yml
@@ -35,13 +35,37 @@ jobs:
 
     - name: Update Reference Protos
       if: steps.update.outputs.updated == 'true'
+      id: make_reference_protos
       # The Reference/upstream contents is generated from Source/protobuf/protobuf, so
       # update them.
+      #
+      # If this fails, it likely means protobuf and/or abseil have changed and
+      # Package.swift need to be updated. In that case, we'll revert Reference/ and let
+      # the PR get created, it will fail CI, but serve as a notice that something needs
+      # to be done to update things.
       #
       # Note: we could move the work in `make reference` to a helper script and skip the
       # install of Make, but given it shares setup with other targets in the Makefile,
       # not sure it's worth while.
-      run: make reference
+      run: |
+        if echo make reference ; then
+          echo 'as_draft=false' >> $GITHUB_OUTPUT
+          echo 'message=' >> $GITHUB_OUTPUT
+        else
+          echo 'as_draft=true' >> $GITHUB_OUTPUT
+
+          echo 'message<<EOF' >> $GITHUB_OUTPUT
+          echo '' >> $GITHUB_OUTPUT
+          echo '> [!WARNING]' >> $GITHUB_OUTPUT
+          echo '> _make reference_ failed, this PR likely needs _Package.swift_ to be fixed!' >> $GITHUB_OUTPUT
+          echo '' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+          echo ''
+          echo 'WARNING: "make reference" failed, the PR will likely be incomplete.'
+          echo ''
+          git checkout -- Reference
+        fi
 
     - name: Create Pull Request
       if: steps.update.outputs.updated == 'true'
@@ -55,12 +79,13 @@ jobs:
           - Update vendored abseil to required commit from protobuf_deps.bzl
         branch: automated/update-protobuf-${{ steps.update.outputs.protobuf_tag }}
         delete-branch: true
+        draft: ${{ steps.make_reference_protos.outputs.as_draft }}
         title: 'Update protobuf to ${{ steps.update.outputs.protobuf_tag }}'
         body: |
           ## Automated Protobuf Update
 
           This PR automatically updates the vendored protobuf and abseil-cpp sources.
-
+          ${{ steps.make_reference_protos.outputs.message }}
           ### Changes
           - **Protobuf**: Updated to `${{ steps.update.outputs.protobuf_tag }}`
           - **Abseil-cpp**: Updated to commit required by protobuf `${{ steps.update.outputs.abseil_commit }}`


### PR DESCRIPTION
If `make reference` fails, revert the changes to `Reference/` that did happen, and then make the PR opened a _Draft_ and add a warning to the PR message to draw attention to the fact that it is likely incomplete and the `Package.swift` will need updated.

While at it, mark two other workflows as only for the apple/swift-protobuf repo so they don't run in forks.