### PR TITLE
[table-driven-branch] Delete `_MessageImplementationBase`.

### DIFF
--- a/Sources/SwiftProtobuf/ExtensionStorage.swift
+++ b/Sources/SwiftProtobuf/ExtensionStorage.swift
@@ -257,7 +257,7 @@ extension ExtensionStorage {
     /// - Precondition: For read operations, the field is already known to be present.
     ///
     /// - Returns: The value returned from the closure.
-    public func performOnSubmessageStorage<T: _MessageImplementationBase>(
+    public func performOnSubmessageStorage<T: Message>(
         of ext: ExtensionSchema,
         operation: TrampolineFieldOperation,
         type: T.Type,
@@ -308,7 +308,7 @@ extension ExtensionStorage {
     ///   present.
     ///
     /// - Returns: The value returned from the last invocation of the closure.
-    public func performOnSubmessageStorage<T: _MessageImplementationBase>(
+    public func performOnSubmessageStorage<T: Message>(
         of ext: ExtensionSchema,
         operation: TrampolineFieldOperation,
         type: [T].Type,

--- a/Sources/SwiftProtobuf/ExtensionValueStorage.swift
+++ b/Sources/SwiftProtobuf/ExtensionValueStorage.swift
@@ -110,7 +110,7 @@
     /// The returned pointer must not escape the `ExtensionStorage` that owns it.
     ///
     /// - Precondition: The type of the extension field must be a message or group.
-    func unsafePointerToSubmessageWithUniqueStorage<Value: _MessageImplementationBase>(
+    func unsafePointerToSubmessageWithUniqueStorage<Value: Message>(
         as type: Value.Type,
     ) -> UnsafeMutablePointer<Value> {
         let pointer = UnsafeMutablePointer<Value>(bitPattern: Int(truncatingIfNeeded: Int64(bitPattern: storage)))!

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -159,7 +159,11 @@ extension Google_Protobuf_Any {
         guard let messageType = self.messageType(forMessageName: messageTypeName) else {
             return nil
         }
-        return (messageType as! any _MessageImplementationBase.Type).messageSchema
+        // Generated messages have a static `messageSchema` property, but there is no protocol
+        // requirement for this property. Create an instance to get the schema.
+        // TODO: Consider dropping the `Message.Type`-based URLs APIs and only support the
+        // schema-based ones.
+        return messageType.init().messageSchema
     }
 }
 

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -32,7 +32,7 @@
 /// The actual functionality is implemented either in the generated code or in
 /// default implementations of the below methods and properties.
 @preconcurrency
-public protocol Message: Sendable, CustomDebugStringConvertible {
+public protocol Message: Sendable, Equatable, Hashable, CustomDebugStringConvertible {
     /// Creates a new message with all of its fields initialized to their default
     /// values.
     init()
@@ -95,6 +95,21 @@ public protocol Message: Sendable, CustomDebugStringConvertible {
 }
 
 extension Message {
+    public func isEqualTo(message: any Message) -> Bool {
+        guard let other = message as? Self else {
+            return false
+        }
+        return self == other
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.storageForRuntime.isEqual(to: rhs.storageForRuntime)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        self.storageForRuntime.hash(into: &hasher)
+    }
+
     /// Generated proto2 messages that contain required fields, nested messages
     /// that contain required fields, and/or extensions will provide their own
     /// implementation of this property that tests that all required fields are
@@ -153,7 +168,7 @@ extension Message {
 /// multiple message types that uses equality tests, puts messages in a `Set`,
 /// or uses them as `Dictionary` keys.
 @preconcurrency
-public protocol _MessageImplementationBase: Message, Hashable {
+public protocol _MessageImplementationBase: Message {
     /// Returns the schema for all messages of this generated message type.
     ///
     /// This is identical to the instance property `messageSchema`, but provides a way to access the
@@ -169,21 +184,6 @@ extension _MessageImplementationBase {
 
     public var messageSchema: MessageSchema {
         Self.messageSchema
-    }
-
-    public func isEqualTo(message: any Message) -> Bool {
-        guard let other = message as? Self else {
-            return false
-        }
-        return self == other
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.storageForRuntime.isEqual(to: rhs.storageForRuntime)
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        self.storageForRuntime.hash(into: &hasher)
     }
 }
 

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -159,34 +159,6 @@ extension Message {
     }
 }
 
-/// Implementation base for all messages; not intended for client use.
-///
-/// In general, use `SwiftProtobuf.Message` instead when you need a variable or
-/// argument that can hold any type of message. Occasionally, you can use
-/// `SwiftProtobuf.Message & Equatable` or `SwiftProtobuf.Message & Hashable` as
-/// generic constraints if you need to write generic code that can be applied to
-/// multiple message types that uses equality tests, puts messages in a `Set`,
-/// or uses them as `Dictionary` keys.
-@preconcurrency
-public protocol _MessageImplementationBase: Message {
-    /// Returns the schema for all messages of this generated message type.
-    ///
-    /// This is identical to the instance property `messageSchema`, but provides a way to access the
-    /// statically-known schema for a message without creating an instance of it.
-    static var messageSchema: MessageSchema { get }
-}
-
-extension _MessageImplementationBase {
-    // TODO: Remove this default implementation when we've regenerated all messages.
-    public static var messageSchema: MessageSchema {
-        fatalError()
-    }
-
-    public var messageSchema: MessageSchema {
-        Self.messageSchema
-    }
-}
-
 extension Message {
     /// Convenience property for the runtime to retrieve the underlying storage for a concretely
     /// typed message.

--- a/Sources/SwiftProtobuf/MessageSchema.swift
+++ b/Sources/SwiftProtobuf/MessageSchema.swift
@@ -262,7 +262,7 @@ public struct MessageSchema: @unchecked Sendable {
     /// Creates a new message schema for the message-like storage used to encode and decode map
     /// entries where the value type is another message.
     @_spi(ForGeneratedCodeOnly)
-    public init<T: _MessageImplementationBase>(schema: StaticString, forMapEntryWithValueType type: T.Type) {
+    public init<T: Message>(schema: StaticString, forMapEntryWithValueType type: T.Type) {
         self.init(
             schema: schema,
             reflectionReference: .direct(.mapEntry),

--- a/Sources/SwiftProtobuf/ProtobufMapParticipant.swift
+++ b/Sources/SwiftProtobuf/ProtobufMapParticipant.swift
@@ -196,7 +196,7 @@ extension ProtobufMapKey where Base: Comparable {
 }
 
 /// The proxy type for submessage map values.
-@_spi(ForGeneratedCodeOnly) public struct ProtobufMapMessageField<M: _MessageImplementationBase>: ProtobufMapParticipant
+@_spi(ForGeneratedCodeOnly) public struct ProtobufMapMessageField<M: Message>: ProtobufMapParticipant
 {
     public static func value(at offset: Int, in storage: _MessageStorage, hasBit: _MessageStorage.HasBit) -> M {
         storage.value(at: offset, default: M(), hasBit: hasBit)

--- a/Sources/SwiftProtobuf/_MessageStorage.swift
+++ b/Sources/SwiftProtobuf/_MessageStorage.swift
@@ -311,7 +311,7 @@ extension _MessageStorage {
     /// - Precondition: For read operations, the field is already known to be present.
     ///
     /// - Returns: The value returned from the closure.
-    public func performOnSubmessageStorage<T: _MessageImplementationBase>(
+    public func performOnSubmessageStorage<T: Message>(
         of field: FieldSchema,
         operation: TrampolineFieldOperation,
         type: T.Type,
@@ -382,7 +382,7 @@ extension _MessageStorage {
     ///   present.
     ///
     /// - Returns: The value returned from the last invocation of the closure.
-    public func performOnSubmessageStorage<T: _MessageImplementationBase>(
+    public func performOnSubmessageStorage<T: Message>(
         of field: FieldSchema,
         operation: TrampolineFieldOperation,
         type: [T].Type,
@@ -432,7 +432,7 @@ extension _MessageStorage {
     /// - Precondition: Only the read operation is supported and the field must already be present.
     ///
     /// - Returns: The value returned from the last invocation of the closure.
-    public func performOnSubmessageStorage<K, V: _MessageImplementationBase>(
+    public func performOnSubmessageStorage<K, V: Message>(
         of field: FieldSchema,
         operation: TrampolineFieldOperation,
         type: [K: V].Type,
@@ -1656,8 +1656,8 @@ extension _MessageStorage {
 /// A token that allows the runtime to access the underlying storage of a message.
 ///
 /// This type is public because the runtime must be able to generically access the underlying
-/// storage of a message, so a protocol requirement on `_MessageImplementationBase` is provided that
-/// takes a value of this type as an argument. However, only the runtime may create instances of it.
+/// storage of a message, so a protocol requirement on `Message` is provided that takes a value of
+/// this type as an argument. However, only the runtime may create instances of it.
 public struct _MessageStorageToken {
     init() {}
 }

--- a/Sources/SwiftProtobuf/any.pb.swift
+++ b/Sources/SwiftProtobuf/any.pb.swift
@@ -204,7 +204,7 @@ public struct Google_Protobuf_Any: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Any: Message, _MessageImplementationBase {
+extension Google_Protobuf_Any: Message {
   public static let protoMessageName: String = _protobuf_package + ".Any"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -219,6 +219,7 @@ extension Google_Protobuf_Any: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "L\0\0\0P\u{10}z1fLI2u9\u{5}V\u{1f}jTjM:\u{13}.]\u{1b};\u{17}G\u{1}UT\u{3}s\u{18}tHD%\u{8}?=,*\u{7f}\u{14}K\u{2}\u{1e}1\0EE\u{1f}\u{1f}A\0\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -370,7 +370,7 @@ public struct Google_Protobuf_Mixin: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Api: Message, _MessageImplementationBase {
+extension Google_Protobuf_Api: Message {
   public static let protoMessageName: String = _protobuf_package + ".Api"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -425,12 +425,13 @@ extension Google_Protobuf_Api: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Method: Message, _MessageImplementationBase {
+extension Google_Protobuf_Method: Message {
   public static let protoMessageName: String = _protobuf_package + ".Method"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -479,12 +480,13 @@ extension Google_Protobuf_Method: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Mixin: Message, _MessageImplementationBase {
+extension Google_Protobuf_Mixin: Message {
   public static let protoMessageName: String = _protobuf_package + ".Mixin"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -499,6 +501,7 @@ extension Google_Protobuf_Mixin: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "8\0\0\0@<_)1J\0)h\0]8GlL\u{f}Y\u{c}a\u{e}C\u{14}/`\u{11}iN\u{1d}\u{4}\u{1b}H\u{2}\u{f}]k@\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/descriptor.pb.swift
+++ b/Sources/SwiftProtobuf/descriptor.pb.swift
@@ -3272,7 +3272,7 @@ extension Google_Protobuf_SymbolVisibility {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_FileDescriptorSet: Message, _MessageImplementationBase {
+extension Google_Protobuf_FileDescriptorSet: Message {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3319,6 +3319,7 @@ extension Google_Protobuf_FileDescriptorSet: Message, _MessageImplementationBase
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3328,7 +3329,7 @@ extension Google_Protobuf_FileDescriptorSet: Message, _MessageImplementationBase
 
 }
 
-extension Google_Protobuf_FileDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_FileDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3387,6 +3388,7 @@ extension Google_Protobuf_FileDescriptorProto: Message, _MessageImplementationBa
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3396,7 +3398,7 @@ extension Google_Protobuf_FileDescriptorProto: Message, _MessageImplementationBa
 
 }
 
-extension Google_Protobuf_DescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_DescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3457,6 +3459,7 @@ extension Google_Protobuf_DescriptorProto: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3466,7 +3469,7 @@ extension Google_Protobuf_DescriptorProto: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_DescriptorProto.ExtensionRange: Message, _MessageImplementationBase {
+extension Google_Protobuf_DescriptorProto.ExtensionRange: Message {
   public static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ExtensionRange"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3513,6 +3516,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: Message, _MessageImple
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3522,7 +3526,7 @@ extension Google_Protobuf_DescriptorProto.ExtensionRange: Message, _MessageImple
 
 }
 
-extension Google_Protobuf_DescriptorProto.ReservedRange: Message, _MessageImplementationBase {
+extension Google_Protobuf_DescriptorProto.ReservedRange: Message {
   public static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3537,12 +3541,13 @@ extension Google_Protobuf_DescriptorProto.ReservedRange: Message, _MessageImplem
   private static var _protobuf_reflectionData: StaticString { "8\0\0\0@<_)1J\0)h\0]8Gllg_\n'MS\u{18}\u{13}\\3]\u{10}[+!w\u{1c}v{\u{13}\u{17}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_ExtensionRangeOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_ExtensionRangeOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".ExtensionRangeOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3595,6 +3600,7 @@ extension Google_Protobuf_ExtensionRangeOptions: Message, _MessageImplementation
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3612,7 +3618,7 @@ extension Google_Protobuf_ExtensionRangeOptions.VerificationState {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_ExtensionRangeOptions.Declaration: Message, _MessageImplementationBase {
+extension Google_Protobuf_ExtensionRangeOptions.Declaration: Message {
   public static let protoMessageName: String = Google_Protobuf_ExtensionRangeOptions.protoMessageName + ".Declaration"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3627,12 +3633,13 @@ extension Google_Protobuf_ExtensionRangeOptions.Declaration: Message, _MessageIm
   private static var _protobuf_reflectionData: StaticString { " \u{1}\0\0 _\u{19}3-ZC#$,u\u{3}4[SWv14V^2\u{5}\u{4}5CS-\u{14}'1*\u{10}e/E\u{15}\u{1b}tte-,\u{b}$-~'qZ\u{f}\u{15}H-9b\u{f}2r\u{14}'B>Kl\\KH\t;\"H\u{f}KD\u{f}'\u{15}>8v\u{e}H!\u{1a}\u{19}q\u{c}?B[dB\u{7f}/dt;\u{5}&K\u{4}R\u{18}.\u{b}>" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_FieldDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_FieldDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3683,6 +3690,7 @@ extension Google_Protobuf_FieldDescriptorProto: Message, _MessageImplementationB
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3708,7 +3716,7 @@ extension Google_Protobuf_FieldDescriptorProto.Label {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_OneofDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_OneofDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3755,6 +3763,7 @@ extension Google_Protobuf_OneofDescriptorProto: Message, _MessageImplementationB
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3764,7 +3773,7 @@ extension Google_Protobuf_OneofDescriptorProto: Message, _MessageImplementationB
 
 }
 
-extension Google_Protobuf_EnumDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3817,6 +3826,7 @@ extension Google_Protobuf_EnumDescriptorProto: Message, _MessageImplementationBa
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3826,7 +3836,7 @@ extension Google_Protobuf_EnumDescriptorProto: Message, _MessageImplementationBa
 
 }
 
-extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: Message {
   public static let protoMessageName: String = Google_Protobuf_EnumDescriptorProto.protoMessageName + ".EnumReservedRange"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3841,12 +3851,13 @@ extension Google_Protobuf_EnumDescriptorProto.EnumReservedRange: Message, _Messa
   private static var _protobuf_reflectionData: StaticString { "8\0\0\0@<_)1J\0)h\0]8Gllg_\n'MS\u{18}\u{13}\\3]\u{10}[+!w\u{1c}v{\u{13}\u{17}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_EnumValueDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumValueDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3893,6 +3904,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: Message, _MessageImplementat
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3902,7 +3914,7 @@ extension Google_Protobuf_EnumValueDescriptorProto: Message, _MessageImplementat
 
 }
 
-extension Google_Protobuf_ServiceDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_ServiceDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -3951,6 +3963,7 @@ extension Google_Protobuf_ServiceDescriptorProto: Message, _MessageImplementatio
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -3960,7 +3973,7 @@ extension Google_Protobuf_ServiceDescriptorProto: Message, _MessageImplementatio
 
 }
 
-extension Google_Protobuf_MethodDescriptorProto: Message, _MessageImplementationBase {
+extension Google_Protobuf_MethodDescriptorProto: Message {
   public static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4007,6 +4020,7 @@ extension Google_Protobuf_MethodDescriptorProto: Message, _MessageImplementation
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4016,7 +4030,7 @@ extension Google_Protobuf_MethodDescriptorProto: Message, _MessageImplementation
 
 }
 
-extension Google_Protobuf_FileOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_FileOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".FileOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4067,6 +4081,7 @@ extension Google_Protobuf_FileOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4084,7 +4099,7 @@ extension Google_Protobuf_FileOptions.OptimizeMode {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_MessageOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_MessageOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".MessageOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4133,6 +4148,7 @@ extension Google_Protobuf_MessageOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4142,7 +4158,7 @@ extension Google_Protobuf_MessageOptions: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_FieldOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_FieldOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".FieldOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4203,6 +4219,7 @@ extension Google_Protobuf_FieldOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4244,7 +4261,7 @@ extension Google_Protobuf_FieldOptions.OptionTargetType {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_FieldOptions.EditionDefault: Message, _MessageImplementationBase {
+extension Google_Protobuf_FieldOptions.EditionDefault: Message {
   public static let protoMessageName: String = Google_Protobuf_FieldOptions.protoMessageName + ".EditionDefault"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4291,12 +4308,13 @@ extension Google_Protobuf_FieldOptions.EditionDefault: Message, _MessageImplemen
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_FieldOptions.FeatureSupport: Message, _MessageImplementationBase {
+extension Google_Protobuf_FieldOptions.FeatureSupport: Message {
   public static let protoMessageName: String = Google_Protobuf_FieldOptions.protoMessageName + ".FeatureSupport"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4343,12 +4361,13 @@ extension Google_Protobuf_FieldOptions.FeatureSupport: Message, _MessageImplemen
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_OneofOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_OneofOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".OneofOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4397,6 +4416,7 @@ extension Google_Protobuf_OneofOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4406,7 +4426,7 @@ extension Google_Protobuf_OneofOptions: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_EnumOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4455,6 +4475,7 @@ extension Google_Protobuf_EnumOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4464,7 +4485,7 @@ extension Google_Protobuf_EnumOptions: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_EnumValueOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumValueOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4515,6 +4536,7 @@ extension Google_Protobuf_EnumValueOptions: Message, _MessageImplementationBase 
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4524,7 +4546,7 @@ extension Google_Protobuf_EnumValueOptions: Message, _MessageImplementationBase 
 
 }
 
-extension Google_Protobuf_ServiceOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_ServiceOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4573,6 +4595,7 @@ extension Google_Protobuf_ServiceOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4582,7 +4605,7 @@ extension Google_Protobuf_ServiceOptions: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_MethodOptions: Message, _MessageImplementationBase {
+extension Google_Protobuf_MethodOptions: Message {
   public static let protoMessageName: String = _protobuf_package + ".MethodOptions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4633,6 +4656,7 @@ extension Google_Protobuf_MethodOptions: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4650,7 +4674,7 @@ extension Google_Protobuf_MethodOptions.IdempotencyLevel {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_UninterpretedOption: Message, _MessageImplementationBase {
+extension Google_Protobuf_UninterpretedOption: Message {
   public static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4697,6 +4721,7 @@ extension Google_Protobuf_UninterpretedOption: Message, _MessageImplementationBa
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4706,7 +4731,7 @@ extension Google_Protobuf_UninterpretedOption: Message, _MessageImplementationBa
 
 }
 
-extension Google_Protobuf_UninterpretedOption.NamePart: Message, _MessageImplementationBase {
+extension Google_Protobuf_UninterpretedOption.NamePart: Message {
   public static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4721,6 +4746,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: Message, _MessageImpleme
   private static var _protobuf_reflectionData: StaticString { "h\0\0\0p!p\0\u{c}\u{14}1`\u{1c}\u{4}9L#?Ah\u{10}}cC\u{3} \u{3}.|D7px\u{17}+wRM\u{11}\u{b}Y61bV\u{1b}\u{1b}P5ClLh7?zi1rR\u{18}'7\u{10}\u{15}Dz#\u{8}a\u{1a}]Td\u{3}\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4730,7 +4756,7 @@ extension Google_Protobuf_UninterpretedOption.NamePart: Message, _MessageImpleme
 
 }
 
-extension Google_Protobuf_FeatureSet: Message, _MessageImplementationBase {
+extension Google_Protobuf_FeatureSet: Message {
   public static let protoMessageName: String = _protobuf_package + ".FeatureSet"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4791,6 +4817,7 @@ extension Google_Protobuf_FeatureSet: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4856,7 +4883,7 @@ extension Google_Protobuf_FeatureSet.EnforceNamingStyle {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_FeatureSet.VisibilityFeature: Message, _MessageImplementationBase {
+extension Google_Protobuf_FeatureSet.VisibilityFeature: Message {
   public static let protoMessageName: String = Google_Protobuf_FeatureSet.protoMessageName + ".VisibilityFeature"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4871,6 +4898,7 @@ extension Google_Protobuf_FeatureSet.VisibilityFeature: Message, _MessageImpleme
   private static var _protobuf_reflectionData: StaticString { "\u{18}\0\0\0\0\u{7f}\u{f}\tA\u{7}:x_\u{18}e\u{1}p\u{1f}an\u{13}\u{11}ZF\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4884,7 +4912,7 @@ extension Google_Protobuf_FeatureSet.VisibilityFeature.DefaultSymbolVisibility {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_FeatureSetDefaults: Message, _MessageImplementationBase {
+extension Google_Protobuf_FeatureSetDefaults: Message {
   public static let protoMessageName: String = _protobuf_package + ".FeatureSetDefaults"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4933,6 +4961,7 @@ extension Google_Protobuf_FeatureSetDefaults: Message, _MessageImplementationBas
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4942,7 +4971,7 @@ extension Google_Protobuf_FeatureSetDefaults: Message, _MessageImplementationBas
 
 }
 
-extension Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault: Message, _MessageImplementationBase {
+extension Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault: Message {
   public static let protoMessageName: String = Google_Protobuf_FeatureSetDefaults.protoMessageName + ".FeatureSetEditionDefault"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4991,6 +5020,7 @@ extension Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault: Message, 
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -5000,7 +5030,7 @@ extension Google_Protobuf_FeatureSetDefaults.FeatureSetEditionDefault: Message, 
 
 }
 
-extension Google_Protobuf_SourceCodeInfo: Message, _MessageImplementationBase {
+extension Google_Protobuf_SourceCodeInfo: Message {
   public static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5047,6 +5077,7 @@ extension Google_Protobuf_SourceCodeInfo: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -5056,7 +5087,7 @@ extension Google_Protobuf_SourceCodeInfo: Message, _MessageImplementationBase {
 
 }
 
-extension Google_Protobuf_SourceCodeInfo.Location: Message, _MessageImplementationBase {
+extension Google_Protobuf_SourceCodeInfo.Location: Message {
   public static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5071,12 +5102,13 @@ extension Google_Protobuf_SourceCodeInfo.Location: Message, _MessageImplementati
   private static var _protobuf_reflectionData: StaticString { "t\u{1}\0\00\u{1f}4^Q[o\u{5}J\u{3}\u{1f}DR6kE>1YrM\"RAak-i\u{17}q\u{1a}xoNq \u{7}`EQ&\u{1}\u{2}$(]z\u{3}mNj3\u{11}\u{10}B:k\u{11}\u{14}90!z]\u{1}[u\u{17}|%[}e\u{14}~z6\u{1f}G[_\u{13}]?(|\u{4}<ug\u{14}\u{1e}\u{11}4nj\\\"#s2J[5\u{11}<\u{1b}|\u{5}\u{1b}fpq=^#\u{e}d2\u{7f}\u{5}\u{10}c1R\u{1}\0\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_GeneratedCodeInfo: Message, _MessageImplementationBase {
+extension Google_Protobuf_GeneratedCodeInfo: Message {
   public static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5123,12 +5155,13 @@ extension Google_Protobuf_GeneratedCodeInfo: Message, _MessageImplementationBase
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_GeneratedCodeInfo.Annotation: Message, _MessageImplementationBase {
+extension Google_Protobuf_GeneratedCodeInfo.Annotation: Message {
   public static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5175,6 +5208,7 @@ extension Google_Protobuf_GeneratedCodeInfo.Annotation: Message, _MessageImpleme
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/duration.pb.swift
+++ b/Sources/SwiftProtobuf/duration.pb.swift
@@ -156,7 +156,7 @@ public struct Google_Protobuf_Duration: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Duration: Message, _MessageImplementationBase {
+extension Google_Protobuf_Duration: Message {
   public static let protoMessageName: String = _protobuf_package + ".Duration"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -171,6 +171,7 @@ extension Google_Protobuf_Duration: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "<\0\0\0@^O'=J\0)h\0]8Gn0\u{10}\u{1f}\u{11}'MS\u{18}cXX>`D,\tc\u{12}\u{19}\u{16}|kV\u{11}h\u{3}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/empty.pb.swift
+++ b/Sources/SwiftProtobuf/empty.pb.swift
@@ -86,7 +86,7 @@ public struct Google_Protobuf_Empty: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Empty: Message, _MessageImplementationBase {
+extension Google_Protobuf_Empty: Message {
   public static let protoMessageName: String = _protobuf_package + ".Empty"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -101,6 +101,7 @@ extension Google_Protobuf_Empty: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/field_mask.pb.swift
+++ b/Sources/SwiftProtobuf/field_mask.pb.swift
@@ -284,7 +284,7 @@ public struct Google_Protobuf_FieldMask: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_FieldMask: Message, _MessageImplementationBase {
+extension Google_Protobuf_FieldMask: Message {
   public static let protoMessageName: String = _protobuf_package + ".FieldMask"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -299,6 +299,7 @@ extension Google_Protobuf_FieldMask: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPd\u{10}\u{11}[S\u{e}xn\u{3}P\u{1b}`\u{3}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/source_context.pb.swift
+++ b/Sources/SwiftProtobuf/source_context.pb.swift
@@ -88,7 +88,7 @@ public struct Google_Protobuf_SourceContext: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_SourceContext: Message, _MessageImplementationBase {
+extension Google_Protobuf_SourceContext: Message {
   public static let protoMessageName: String = _protobuf_package + ".SourceContext"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -103,6 +103,7 @@ extension Google_Protobuf_SourceContext: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "8\0\0\0@\\[%.MI2u9\u{5}V!T}66;\u{3}\u{3}/UEG/}LO\u{1c}$|&`\u{12}[40i\u{1e}\u{5}\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -282,7 +282,7 @@ extension Google_Protobuf_NullValue {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_Struct: Message, _MessageImplementationBase {
+extension Google_Protobuf_Struct: Message {
   public static let protoMessageName: String = _protobuf_package + ".Struct"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -339,12 +339,13 @@ extension Google_Protobuf_Struct: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Value: Message, _MessageImplementationBase {
+extension Google_Protobuf_Value: Message {
   public static let protoMessageName: String = _protobuf_package + ".Value"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -395,12 +396,13 @@ extension Google_Protobuf_Value: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_ListValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_ListValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".ListValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -447,6 +449,7 @@ extension Google_Protobuf_ListValue: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/timestamp.pb.swift
+++ b/Sources/SwiftProtobuf/timestamp.pb.swift
@@ -186,7 +186,7 @@ public struct Google_Protobuf_Timestamp: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_Timestamp: Message, _MessageImplementationBase {
+extension Google_Protobuf_Timestamp: Message {
   public static let protoMessageName: String = _protobuf_package + ".Timestamp"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -201,6 +201,7 @@ extension Google_Protobuf_Timestamp: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "<\0\0\0@^O'=J\0)h\0]8Gn0\u{10}\u{1f}\u{11}'MS\u{18}cXX>`D,\tc\u{12}\u{19}\u{16}|kV\u{11}h\u{3}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -642,7 +642,7 @@ extension Google_Protobuf_Syntax {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_Type: Message, _MessageImplementationBase {
+extension Google_Protobuf_Type: Message {
   public static let protoMessageName: String = _protobuf_package + ".Type"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -695,12 +695,13 @@ extension Google_Protobuf_Type: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Field: Message, _MessageImplementationBase {
+extension Google_Protobuf_Field: Message {
   public static let protoMessageName: String = _protobuf_package + ".Field"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -751,6 +752,7 @@ extension Google_Protobuf_Field: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -772,7 +774,7 @@ extension Google_Protobuf_Field.Cardinality {
   public static let enumSchema = EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_Enum: Message, _MessageImplementationBase {
+extension Google_Protobuf_Enum: Message {
   public static let protoMessageName: String = _protobuf_package + ".Enum"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -825,12 +827,13 @@ extension Google_Protobuf_Enum: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_EnumValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_EnumValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -877,12 +880,13 @@ extension Google_Protobuf_EnumValue: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Option: Message, _MessageImplementationBase {
+extension Google_Protobuf_Option: Message {
   public static let protoMessageName: String = _protobuf_package + ".Option"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -929,6 +933,7 @@ extension Google_Protobuf_Option: Message, _MessageImplementationBase {
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -405,7 +405,7 @@ public struct Google_Protobuf_BytesValue: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_DoubleValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".DoubleValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -420,12 +420,13 @@ extension Google_Protobuf_DoubleValue: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_FloatValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".FloatValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -440,12 +441,13 @@ extension Google_Protobuf_FloatValue: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Int64Value: Message, _MessageImplementationBase {
+extension Google_Protobuf_Int64Value: Message {
   public static let protoMessageName: String = _protobuf_package + ".Int64Value"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -460,12 +462,13 @@ extension Google_Protobuf_Int64Value: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_UInt64Value: Message, _MessageImplementationBase {
+extension Google_Protobuf_UInt64Value: Message {
   public static let protoMessageName: String = _protobuf_package + ".UInt64Value"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -480,12 +483,13 @@ extension Google_Protobuf_UInt64Value: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Int32Value: Message, _MessageImplementationBase {
+extension Google_Protobuf_Int32Value: Message {
   public static let protoMessageName: String = _protobuf_package + ".Int32Value"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -500,12 +504,13 @@ extension Google_Protobuf_Int32Value: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_UInt32Value: Message, _MessageImplementationBase {
+extension Google_Protobuf_UInt32Value: Message {
   public static let protoMessageName: String = _protobuf_package + ".UInt32Value"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -520,12 +525,13 @@ extension Google_Protobuf_UInt32Value: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_BoolValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_BoolValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".BoolValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -540,12 +546,13 @@ extension Google_Protobuf_BoolValue: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_StringValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_StringValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".StringValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -560,12 +567,13 @@ extension Google_Protobuf_StringValue: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_BytesValue: Message, _MessageImplementationBase {
+extension Google_Protobuf_BytesValue: Message {
   public static let protoMessageName: String = _protobuf_package + ".BytesValue"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -580,6 +588,7 @@ extension Google_Protobuf_BytesValue: Message, _MessageImplementationBase {
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FPi,\u{14}gJ\u{8}G>3Dr-\u{8}\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/plugin.pb.swift
@@ -405,7 +405,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: @unchecked Sendabl
 
 fileprivate let _protobuf_package = "google.protobuf.compiler"
 
-extension Google_Protobuf_Compiler_Version: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Version"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -420,12 +420,13 @@ extension Google_Protobuf_Compiler_Version: SwiftProtobuf.Message, SwiftProtobuf
   private static var _protobuf_reflectionData: StaticString { "h\0\0\0p\u{1}4\u{4}\u{f}K\0)h\0]8Gll_\u{7f}7ty\u{5}V\u{7}\u{5}'\u{1e}D\\K>\u{1}qu\u{3}\u{1e}!E>6{F\u{2}\u{3}' \u{16}@P\u{7}\u{4}#{B\u{b}D\u{1a}cN\tuk\u{1c}N\u{2}s<{~\0\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".CodeGeneratorRequest"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -474,6 +475,7 @@ extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, 
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -483,7 +485,7 @@ extension Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, 
 
 }
 
-extension Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".CodeGeneratorResponse"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -530,6 +532,7 @@ extension Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message,
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -543,7 +546,7 @@ extension Google_Protobuf_Compiler_CodeGeneratorResponse.Feature {
   public static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension Google_Protobuf_Compiler_CodeGeneratorResponse.File: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension Google_Protobuf_Compiler_CodeGeneratorResponse.File: SwiftProtobuf.Message {
   public static let protoMessageName: String = Google_Protobuf_Compiler_CodeGeneratorResponse.protoMessageName + ".File"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -590,6 +593,7 @@ extension Google_Protobuf_Compiler_CodeGeneratorResponse.File: SwiftProtobuf.Mes
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
+++ b/Sources/SwiftProtobufPluginLibrary/swift_protobuf_module_mappings.pb.swift
@@ -110,7 +110,7 @@ public struct SwiftProtobuf_GenSwift_ModuleMappings: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_protobuf.gen_swift"
 
-extension SwiftProtobuf_GenSwift_ModuleMappings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtobuf_GenSwift_ModuleMappings: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".ModuleMappings"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -157,12 +157,13 @@ extension SwiftProtobuf_GenSwift_ModuleMappings: SwiftProtobuf.Message, SwiftPro
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtobuf_GenSwift_ModuleMappings.Entry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtobuf_GenSwift_ModuleMappings.Entry: SwiftProtobuf.Message {
   public static let protoMessageName: String = SwiftProtobuf_GenSwift_ModuleMappings.protoMessageName + ".Entry"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -177,6 +178,7 @@ extension SwiftProtobuf_GenSwift_ModuleMappings.Entry: SwiftProtobuf.Message, Sw
   private static var _protobuf_reflectionData: StaticString { "t\0\0\0pg@z0p\u{11}}\ru\u{1c}i)rJ3\u{12}\u{11}u\u{7}mf{\u{3}HoR@z1B\u{16}W;\u{8}\u{1e}%%w\u{1a}\u{13}\"=t\u{2}I`Z{c\u{3}3u\no\tt\u{5}ie\u{1c}\r\u{e}M9\\bQBY3\u{5}*`\u{12}!\u{f}\u{1}\0" }
 
   public static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  public var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -232,7 +232,7 @@ class MessageGenerator {
     func generateRuntimeSupport(printer p: inout CodePrinter, file: FileGenerator, parent: MessageGenerator?) {
         p.print(
             "",
-            "extension \(swiftFullName): \(namer.swiftProtobufModulePrefix)Message, \(namer.swiftProtobufModulePrefix)_MessageImplementationBase {"
+            "extension \(swiftFullName): \(namer.swiftProtobufModulePrefix)Message {"
         )
         p.withIndentation { p in
             if let parent = parent {
@@ -428,6 +428,7 @@ class MessageGenerator {
                 "}"
             )
         }
+        p.print("\(visibility)var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }")
     }
 
     /// Generates the `isInitialized` property for the message, if needed.

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/Test_Any.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/Test_Any.swift
@@ -1157,12 +1157,10 @@ final class Test_Any: XCTestCase {
 // Dummy message class to test registration conflicts, this is basically the
 // generated code from SwiftProtoTesting_TestEmptyMessage.
 
-struct ConflictingImportMessage:
-    SwiftProtobuf.Message,
-    SwiftProtobuf._MessageImplementationBase,
-    Sendable
-{
+struct ConflictingImportMessage: SwiftProtobuf.Message, Sendable {
     static let protoMessageName: String = "swift_proto_testing.import.ImportMessage"
+
+    var messageSchema: MessageSchema { fatalError() }
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/any_test.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/any_test.pb.swift
@@ -103,7 +103,7 @@ struct SwiftProtoTesting_TestAny: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing"
 
-extension SwiftProtoTesting_TestAny: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAny: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAny"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -152,6 +152,7 @@ extension SwiftProtoTesting_TestAny: SwiftProtobuf.Message, SwiftProtobuf._Messa
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/map_unittest.pb.swift
@@ -283,7 +283,7 @@ extension SwiftProtoTesting_MapEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_TestMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMap"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -419,12 +419,13 @@ extension SwiftProtoTesting_TestMap: SwiftProtobuf.Message, SwiftProtobuf._Messa
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestRequiredMessageMap: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequiredMessageMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredMessageMap"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -481,6 +482,7 @@ extension SwiftProtoTesting_TestRequiredMessageMap: SwiftProtobuf.Message, Swift
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -490,7 +492,7 @@ extension SwiftProtoTesting_TestRequiredMessageMap: SwiftProtobuf.Message, Swift
 
 }
 
-extension SwiftProtoTesting_TestRecursiveMapMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRecursiveMapMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRecursiveMapMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -547,6 +549,7 @@ extension SwiftProtoTesting_TestRecursiveMapMessage: SwiftProtobuf.Message, Swif
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/test_messages_proto3.pb.swift
@@ -843,7 +843,7 @@ struct SwiftProtoTesting_Test3_TestAllTypesProto3: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing.test3"
 
-extension SwiftProtoTesting_Test3_TestAllTypesProto3: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Test3_TestAllTypesProto3: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypesProto3"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -1034,6 +1034,7 @@ extension SwiftProtoTesting_Test3_TestAllTypesProto3: SwiftProtobuf.Message, Swi
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -1047,7 +1048,7 @@ extension SwiftProtoTesting_Test3_TestAllTypesProto3.NestedEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_Test3_TestAllTypesProto3.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Test3_TestAllTypesProto3.NestedMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_Test3_TestAllTypesProto3.protoMessageName + ".NestedMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -1094,6 +1095,7 @@ extension SwiftProtoTesting_Test3_TestAllTypesProto3.NestedMessage: SwiftProtobu
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest.pb.swift
@@ -4021,7 +4021,7 @@ extension SwiftProtoTesting_TestEnumWithDupValue {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4096,6 +4096,7 @@ extension SwiftProtoTesting_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4109,7 +4110,7 @@ extension SwiftProtoTesting_TestAllTypes.NestedEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_TestAllTypes.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllTypes.NestedMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestAllTypes.protoMessageName + ".NestedMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4124,12 +4125,13 @@ extension SwiftProtoTesting_TestAllTypes.NestedMessage: SwiftProtobuf.Message, S
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}&pm\u{e}FPY$p:Vt(@(\u{1}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestAllTypes.OptionalGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllTypes.OptionalGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestAllTypes.protoMessageName + ".OptionalGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4144,12 +4146,13 @@ extension SwiftProtoTesting_TestAllTypes.OptionalGroup: SwiftProtobuf.Message, S
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}6PT\0BPX|\u{f}\u{6}c\u{1a}; ]\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestAllTypes.RepeatedGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllTypes.RepeatedGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestAllTypes.protoMessageName + ".RepeatedGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4164,12 +4167,13 @@ extension SwiftProtoTesting_TestAllTypes.RepeatedGroup: SwiftProtobuf.Message, S
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}NP\u{1e}-~PaX\u{15}a\u{1d}]Dh\u{3}a\u{3}" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4220,12 +4224,13 @@ extension SwiftProtoTesting_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProt
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_ForeignMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4240,12 +4245,13 @@ extension SwiftProtoTesting_ForeignMessage: SwiftProtobuf.Message, SwiftProtobuf
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`d\u{7f}\u{c}q)w.dY-\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestAllExtensions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllExtensions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllExtensions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4260,6 +4266,7 @@ extension SwiftProtoTesting_TestAllExtensions: SwiftProtobuf.Message, SwiftProto
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4269,7 +4276,7 @@ extension SwiftProtoTesting_TestAllExtensions: SwiftProtobuf.Message, SwiftProto
 
 }
 
-extension SwiftProtoTesting_OptionalGroup_extension: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_OptionalGroup_extension: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OptionalGroup_extension"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4284,12 +4291,13 @@ extension SwiftProtoTesting_OptionalGroup_extension: SwiftProtobuf.Message, Swif
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}6PT\0BPX|\u{f}\u{6}c\u{1a}; ]\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_RepeatedGroup_extension: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_RepeatedGroup_extension: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RepeatedGroup_extension"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4304,12 +4312,13 @@ extension SwiftProtoTesting_RepeatedGroup_extension: SwiftProtobuf.Message, Swif
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}NP\u{1e}-~PaX\u{15}a\u{1d}]Dh\u{3}a\u{3}" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestNestedExtension: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestNestedExtension: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestNestedExtension"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4324,12 +4333,13 @@ extension SwiftProtoTesting_TestNestedExtension: SwiftProtobuf.Message, SwiftPro
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestRequired: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequired"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4376,6 +4386,7 @@ extension SwiftProtoTesting_TestRequired: SwiftProtobuf.Message, SwiftProtobuf._
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4385,7 +4396,7 @@ extension SwiftProtoTesting_TestRequired: SwiftProtobuf.Message, SwiftProtobuf._
 
 }
 
-extension SwiftProtoTesting_TestRequiredForeign: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequiredForeign: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredForeign"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4434,6 +4445,7 @@ extension SwiftProtoTesting_TestRequiredForeign: SwiftProtobuf.Message, SwiftPro
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4443,7 +4455,7 @@ extension SwiftProtoTesting_TestRequiredForeign: SwiftProtobuf.Message, SwiftPro
 
 }
 
-extension SwiftProtoTesting_TestRequiredMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequiredMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4492,6 +4504,7 @@ extension SwiftProtoTesting_TestRequiredMessage: SwiftProtobuf.Message, SwiftPro
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4501,7 +4514,7 @@ extension SwiftProtoTesting_TestRequiredMessage: SwiftProtobuf.Message, SwiftPro
 
 }
 
-extension SwiftProtoTesting_TestEmptyMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4516,12 +4529,13 @@ extension SwiftProtoTesting_TestEmptyMessage: SwiftProtobuf.Message, SwiftProtob
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestReallyLargeTagNumber: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestReallyLargeTagNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestReallyLargeTagNumber"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4536,12 +4550,13 @@ extension SwiftProtoTesting_TestReallyLargeTagNumber: SwiftProtobuf.Message, Swi
   private static var _protobuf_reflectionData: StaticString { "4\0\0\0@\u{1a}o+%J\0)x`G`\u{4}2\u{1}(hZ\u{2}\u{17}({%\u{19}#Au:\u{14}EWBa\n\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestRecursiveMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRecursiveMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRecursiveMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4588,12 +4603,13 @@ extension SwiftProtoTesting_TestRecursiveMessage: SwiftProtobuf.Message, SwiftPr
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestFieldOrderings: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4640,6 +4656,7 @@ extension SwiftProtoTesting_TestFieldOrderings: SwiftProtobuf.Message, SwiftProt
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4649,7 +4666,7 @@ extension SwiftProtoTesting_TestFieldOrderings: SwiftProtobuf.Message, SwiftProt
 
 }
 
-extension SwiftProtoTesting_TestFieldOrderings.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestFieldOrderings.NestedMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestFieldOrderings.protoMessageName + ".NestedMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4664,12 +4681,13 @@ extension SwiftProtoTesting_TestFieldOrderings.NestedMessage: SwiftProtobuf.Mess
   private static var _protobuf_reflectionData: StaticString { "4\0\0\0@\u{1a}o+%J\0)h\0]8Gl\u{8}_\u{19}\u{6}a\u{e}Cbn-\u{1d}\u{18}\u{1e}SU\u{1c}@c\u{3}\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestExtremeDefaultValues: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestExtremeDefaultValues: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestExtremeDefaultValues"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4684,12 +4702,13 @@ extension SwiftProtoTesting_TestExtremeDefaultValues: SwiftProtobuf.Message, Swi
   private static var _protobuf_reflectionData: StaticString { "\0\n\0\0@\u{7f}\0atr\u{12}D\u{17}V6^\u{b}\u{e}\u{12}8b\u{7f}^74\0l\u{8}\u{11}%R4\u{15}4L\u{17}Ag4v\u{1d}\u{f}\u{7}P?(I0BS\u{14}\u{18}\u{1e}?!\u{8}~[F\u{1}h5E'{\0H\u{13}m\u{b}|;YF\u{12}z\u{c}\\>\u{1b}\u{7f}w[dp/-\\W\"\u{16}q\0\u{1e}J<\u{12}|\u{7f}!\u{12}\u{18}\u{f}G\\&\u{1f}R^\u{2}cd6=<Ev\u{f}\u{1b}B~>hx#d>i\u{4}\u{c}_\u{1a}\u{1e}H\u{3}[\u{b})\t\u{b}x4&\u{e}\u{15}\u{e}-\u{e}0\u{5}<K9\"i!<\u{7}&;^Z!B}\u{1e}~#\u{e}/\u{1e}<;]\"t<#1e4N6.?Hl\u{1e}0>~\u{b}\r:\u{13}T\t\u{7}Mr.C?\u{11}u\u{18}\u{5}%G>l\u{11}s\u{5};\u{2}Bg/gj\r\u{1b}p<W5\u{8}Bx\u{f}_<a<H\u{16}J8\u{1f}@J!Fv\u{19}\u{1c}{U\u{1d}4\t\u{2}y\u{11}/,!\u{19}f|/\u{1b}\u{1d}\u{7}.M0){\"\u{14}\u{13}\u{b};V#2\u{6}J&o@M\u{f}\u{b}L~M=gO?nVBf$\u{7f}0pZr(ck&!\u{3}\u{19}d\nB!,\u{18}J\u{c}P>>-_{MC\n#P[^q&4e\u{18}\u{12}\u{5}Rg\u{16}\u{2}w^{aiK`][\"%^\u{b}id\rG\u{4}+\u{16}(XUQ\u{3}]@9s\u{1f}GZ4\u{1f}-P\u{10}n.yn\u{e}z\u{c}rP\u{1f}X_zH\u{1a}O9Qt\u{10}R=wnT]9A7\u{4}\u{6}C^\u{15}\u{3}FnjW\u{5}:r9\u{6}\u{8}\u{10}e\u{1d}\u{1}S;\u{1f}n\u{7}oqt7\u{5}D\u{19}B:\u{e}r@,X\u{1d}jm\n\\o\u{1a}I8\u{19}D\u{5} Ku:\u{15}\u{3}Qoz{Y(# {U\tf5G^\u{17}a1\u{10}W9id#)Eg7gH\u{1f}6\u{1d}L\"\0S2\u{4}bm`*\u{15}'FV`W\u{b}'msNbeN\u{10}&hh\u{14}PGR^\u{f}\u{19}k\u{6}H\u{3}1WyVt3\u{2}i}yW\u{b}ZaV\u{12}\",>?\u{13}\u{16}SQkq) \u{11}\u{10}\u{1c}L\u{1a}\u{8}WesBV\u{12}VjX\u{15}$D\n&\nt[B\u{b}\u{c}ZF`Bz[\u{4}[8c`lL\u{1b}\u{19}iI~J\u{16}\u{7}\u{b}~ \u{6}3\u{1}~q\u{1d}\u{16}F2r>\u{1f}\u{11}h@G%x\"Y}u{I\u{1e}hq*rFgcw\u{1c}{xwk\u{4}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestOneof"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4738,12 +4757,13 @@ extension SwiftProtoTesting_TestOneof: SwiftProtobuf.Message, SwiftProtobuf._Mes
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestOneof.FooGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestOneof.FooGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestOneof.protoMessageName + ".FooGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4758,12 +4778,13 @@ extension SwiftProtoTesting_TestOneof.FooGroup: SwiftProtobuf.Message, SwiftProt
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}*H\u{1b}Kt9L\u{1f}hG%\u{1a}9\u{2}R\u{19}\u{12}\u{13}So/\u{6}\u{19}2\u{3}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequiredOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredOneof"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4810,6 +4831,7 @@ extension SwiftProtoTesting_TestRequiredOneof: SwiftProtobuf.Message, SwiftProto
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4819,7 +4841,7 @@ extension SwiftProtoTesting_TestRequiredOneof: SwiftProtobuf.Message, SwiftProto
 
 }
 
-extension SwiftProtoTesting_TestRequiredOneof.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestRequiredOneof.NestedMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestRequiredOneof.protoMessageName + ".NestedMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4834,6 +4856,7 @@ extension SwiftProtoTesting_TestRequiredOneof.NestedMessage: SwiftProtobuf.Messa
   private static var _protobuf_reflectionData: StaticString { "D\0\0\0\u{10}\u{7f}FH\u{1}[C#$\u{c}u|[X\u{13}i\u{12}*0=vK-\u{e}m,Ijnm\u{1e}4\u{1f}\"aLK3\u{18}7'w\u{7f}j\u{16}\u{1}\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4843,7 +4866,7 @@ extension SwiftProtoTesting_TestRequiredOneof.NestedMessage: SwiftProtobuf.Messa
 
 }
 
-extension SwiftProtoTesting_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestPackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4890,12 +4913,13 @@ extension SwiftProtoTesting_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobu
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestUnpackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4942,12 +4966,13 @@ extension SwiftProtoTesting_TestUnpackedTypes: SwiftProtobuf.Message, SwiftProto
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestPackedExtensions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestPackedExtensions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestPackedExtensions"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -4962,6 +4987,7 @@ extension SwiftProtoTesting_TestPackedExtensions: SwiftProtobuf.Message, SwiftPr
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -4971,7 +4997,7 @@ extension SwiftProtoTesting_TestPackedExtensions: SwiftProtobuf.Message, SwiftPr
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestParsingMerge"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5024,6 +5050,7 @@ extension SwiftProtoTesting_TestParsingMerge: SwiftProtobuf.Message, SwiftProtob
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -5033,7 +5060,7 @@ extension SwiftProtoTesting_TestParsingMerge: SwiftProtobuf.Message, SwiftProtob
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestParsingMerge.protoMessageName + ".RepeatedFieldsGenerator"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5084,12 +5111,13 @@ extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator: SwiftProto
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group1: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.protoMessageName + ".Group1"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5136,12 +5164,13 @@ extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group1: Swi
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group2: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.protoMessageName + ".Group2"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5188,12 +5217,13 @@ extension SwiftProtoTesting_TestParsingMerge.RepeatedFieldsGenerator.Group2: Swi
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge.OptionalGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge.OptionalGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestParsingMerge.protoMessageName + ".OptionalGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5240,12 +5270,13 @@ extension SwiftProtoTesting_TestParsingMerge.OptionalGroup: SwiftProtobuf.Messag
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_TestParsingMerge.RepeatedGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestParsingMerge.RepeatedGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestParsingMerge.protoMessageName + ".RepeatedGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -5292,6 +5323,7 @@ extension SwiftProtoTesting_TestParsingMerge.RepeatedGroup: SwiftProtobuf.Messag
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_import.pb.swift
@@ -113,7 +113,7 @@ extension SwiftProtoTesting_Import_ImportEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_Import_ImportMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Import_ImportMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ImportMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -128,6 +128,7 @@ extension SwiftProtoTesting_Import_ImportMessage: SwiftProtobuf.Message, SwiftPr
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}&pm\u{e}FP[L=\u{11}\u{f}\u{1b}sCT\u{1}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_import_public.pb.swift
@@ -90,7 +90,7 @@ struct SwiftProtoTesting_Import_PublicImportMessage: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing.import"
 
-extension SwiftProtoTesting_Import_PublicImportMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Import_PublicImportMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".PublicImportMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -105,6 +105,7 @@ extension SwiftProtoTesting_Import_PublicImportMessage: SwiftProtobuf.Message, S
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}&pm\u{e}FP\\fP\u{12}\u{3}\u{1b}sCT\u{1}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -680,7 +680,7 @@ struct SwiftProtoTesting_TestSomeRequiredTypes: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing"
 
-extension SwiftProtoTesting_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllRequiredTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllRequiredTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -741,6 +741,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftPr
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -758,7 +759,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes.NestedEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_TestAllRequiredTypes.NestedMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllRequiredTypes.NestedMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestAllRequiredTypes.protoMessageName + ".NestedMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -773,6 +774,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes.NestedMessage: SwiftProtobuf.Me
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}&pm\u{e}FPY$p:Vt(@(\u{1}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -782,7 +784,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes.NestedMessage: SwiftProtobuf.Me
 
 }
 
-extension SwiftProtoTesting_TestAllRequiredTypes.RequiredGroup: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestAllRequiredTypes.RequiredGroup: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftProtoTesting_TestAllRequiredTypes.protoMessageName + ".RequiredGroup"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -797,6 +799,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes.RequiredGroup: SwiftProtobuf.Me
   private static var _protobuf_reflectionData: StaticString { " \0\0\0\0?ck-\u{7}6PT\0BPX|\u{f}\u{6}c\u{1a}; ]\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -806,7 +809,7 @@ extension SwiftProtoTesting_TestAllRequiredTypes.RequiredGroup: SwiftProtobuf.Me
 
 }
 
-extension SwiftProtoTesting_TestSomeRequiredTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_TestSomeRequiredTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSomeRequiredTypes"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -853,6 +856,7 @@ extension SwiftProtoTesting_TestSomeRequiredTypes: SwiftProtobuf.Message, SwiftP
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_clobbering.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_clobbering.pb.swift
@@ -133,7 +133,7 @@ extension SwiftProtoTesting_EnumClobbering_Foo {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_EnumClobbering_EnumHolder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_EnumClobbering_EnumHolder: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumHolder"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -180,6 +180,7 @@ extension SwiftProtoTesting_EnumClobbering_EnumHolder: SwiftProtobuf.Message, Sw
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_proto2.pb.swift
@@ -184,7 +184,7 @@ struct SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing.enum2"
 
-extension SwiftProtoTesting_Enum2_SwiftEnumTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Enum2_SwiftEnumTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftEnumTest"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -237,6 +237,7 @@ extension SwiftProtoTesting_Enum2_SwiftEnumTest: SwiftProtobuf.Message, SwiftPro
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -274,7 +275,7 @@ extension SwiftProtoTesting_Enum2_SwiftEnumTest.EnumTestReservedWord {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftEnumWithAliasTest"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -321,6 +322,7 @@ extension SwiftProtoTesting_Enum2_SwiftEnumWithAliasTest: SwiftProtobuf.Message,
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_enum_proto3.pb.swift
@@ -307,7 +307,7 @@ struct SwiftProtoTesting_Enum3_SwiftEnumWithAliasTest: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing.enum3"
 
-extension SwiftProtoTesting_Enum3_SwiftEnumTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Enum3_SwiftEnumTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftEnumTest"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -360,6 +360,7 @@ extension SwiftProtoTesting_Enum3_SwiftEnumTest: SwiftProtobuf.Message, SwiftPro
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -397,7 +398,7 @@ extension SwiftProtoTesting_Enum3_SwiftEnumTest.EnumTestReservedWord {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftProtoTesting_Enum3_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Enum3_SwiftEnumWithAliasTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftEnumWithAliasTest"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -444,6 +445,7 @@ extension SwiftProtoTesting_Enum3_SwiftEnumWithAliasTest: SwiftProtobuf.Message,
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_required_fields.pb.swift
+++ b/Tests/ExperimentalTableDrivenSwiftProtobufTests/unittest_swift_required_fields.pb.swift
@@ -691,7 +691,7 @@ struct SwiftProtoTesting_MapWithNestedRequiredValues: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_proto_testing"
 
-extension SwiftProtoTesting_Required1: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Required1: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Required1"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -706,6 +706,7 @@ extension SwiftProtoTesting_Required1: SwiftProtobuf.Message, SwiftProtobuf._Mes
   private static var _protobuf_reflectionData: StaticString { "\u{18}\u{1}\0\0 _\u{19}3-Z\u{b}?GC\u{1f}Zbf/g4j(\u{2}\\\u{14}+n,\u{4}\rNb\tN'dss+\u{16}\u{13}\u{1}N\u{3}y7i\u{3}\u{b}=5i{V!\u{10}\u{17}\u{12}jY#et~'50\u{1a}IP\u{19}^k\u{14}9ES((\u{4}Al\u{6}dw^|)*U P\u{1e}\u{11}b:^\u{1e}\u{1}\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -715,7 +716,7 @@ extension SwiftProtoTesting_Required1: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 }
 
-extension SwiftProtoTesting_Required8: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Required8: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Required8"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -730,6 +731,7 @@ extension SwiftProtoTesting_Required8: SwiftProtobuf.Message, SwiftProtobuf._Mes
   private static var _protobuf_reflectionData: StaticString { "l\u{2}\0\00d\u{14}\\ S1?O,g;0T_6T.F\u{1e}'9\u{f}E\u{10}FW v,u*~\u{1d}.!\u{c}(}.\u{1c}E<v\u{1e}X\u{1f};l8%$\u{1f}!lT0\u{13}zoZJ\u{7}\u{10}\u{e}Me\tAbr^=\u{3}RtCAPt`=.;,~\u{5}\";\\d<,\u{1}y$\0\"\u{4}+\u{16}}b}w%:<7\u{c}Jhza{w\u{4}x\u{14}JNtqR\u{6}\u{b}@\u{5}<%E(\u{13}\u{1e}]b\u{16}*O\u{1c}w!\u{b}\u{1c}\u{18}\u{10}KH\"4\r\t/y\u{1a})/\u{6}B\u{7f}\u{7f}xF8\t#{Oik\t@+e\u{e}7jY;0\u{11}p\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -739,7 +741,7 @@ extension SwiftProtoTesting_Required8: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 }
 
-extension SwiftProtoTesting_Required9: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_Required9: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Required9"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -754,6 +756,7 @@ extension SwiftProtoTesting_Required9: SwiftProtobuf.Message, SwiftProtobuf._Mes
   private static var _protobuf_reflectionData: StaticString { "\u{14}\u{3}\0\0 _V35[S\nY.)SCZ?a1 qD;z}XSf)}gb\t\u{1b}P%+MjQOOW\u{2}EXe~WppA\u{12}GH\u{8}XC^\u{4}<\u{1e}Ll\u{b}\u{11}o\u{1d}zr\u{1f}\tJ\u{7}y(d\u{7}\u{7}u\u{1c}\u{b}\u{6}Nk6Rq\u{1a}vL\u{1a}jPJ^A4W#\u{1}\u{12}\u{3}@7\u{7}2K\u{1e}.\u{4}j|@\u{c}(J';\t6[9A\u{1d}\"E1\u{1d}\u{6}sF7\rX\u{10}n(h2l\u{1a}\u{7f}\u{7f}~2\r\u{b}jT\u{17}Oyfey \u{1f}[0%QO]|\u{1d}U\u{1f}:%HS5>\u{c}\0IB`+\u{1b}9'R&MW9(r`*H(+\u{16}\u{4}F%\0\u{1a}\0\u{2}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -763,7 +766,7 @@ extension SwiftProtoTesting_Required9: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 }
 
-extension SwiftProtoTesting_RequiredMixedOrder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_RequiredMixedOrder: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RequiredMixedOrder"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -778,6 +781,7 @@ extension SwiftProtoTesting_RequiredMixedOrder: SwiftProtobuf.Message, SwiftProt
   private static var _protobuf_reflectionData: StaticString { "$\u{2}\0\0\0?(&%ZS\u{2}BD\u{18}SCZ?\u{19}\"x<Dm\u{1f}bD`\u{f}&$f_X\"\u{1f}\u{b}A&(\u{11}$Za@\u{14}Fov\u{13}i~Bo5r\u{1e}v\u{7}Gezgs\u{1}_\r\u{10}Y\u{15}7\u{1b}A\u{8}uN+\u{16}\u{e}awO}h_ld\u{5}^ZX\u{3}sE$\u{1d}v?Mi2o\"\0(\u{c}\u{7}J\u{b}kg&\nIpH]q\"X]<w\u{1d}\u{b}x\"2I\u{b}TnQL>c\u{c}R5h|x~*K\u{18}t\u{1e}fen>\u{18}iq\rE\u{7f}\u{2}UI\u{3}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -787,7 +791,7 @@ extension SwiftProtoTesting_RequiredMixedOrder: SwiftProtobuf.Message, SwiftProt
 
 }
 
-extension SwiftProtoTesting_RequiredWithNested: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_RequiredWithNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RequiredWithNested"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -834,6 +838,7 @@ extension SwiftProtoTesting_RequiredWithNested: SwiftProtobuf.Message, SwiftProt
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -843,7 +848,7 @@ extension SwiftProtoTesting_RequiredWithNested: SwiftProtobuf.Message, SwiftProt
 
 }
 
-extension SwiftProtoTesting_RequiredWithRepeatedNested: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_RequiredWithRepeatedNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RequiredWithRepeatedNested"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -890,6 +895,7 @@ extension SwiftProtoTesting_RequiredWithRepeatedNested: SwiftProtobuf.Message, S
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -899,7 +905,7 @@ extension SwiftProtoTesting_RequiredWithRepeatedNested: SwiftProtobuf.Message, S
 
 }
 
-extension SwiftProtoTesting_NestedRequired: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_NestedRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedRequired"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -914,6 +920,7 @@ extension SwiftProtoTesting_NestedRequired: SwiftProtobuf.Message, SwiftProtobuf
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}3f\u{15}[?s'L4PX;\u{3}usBm\"xfb0c3\u{2}\u{12}YS\u{17}Cu`'\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -923,7 +930,7 @@ extension SwiftProtoTesting_NestedRequired: SwiftProtobuf.Message, SwiftProtobuf
 
 }
 
-extension SwiftProtoTesting_NoneRequired: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_NoneRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NoneRequired"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -970,12 +977,13 @@ extension SwiftProtoTesting_NoneRequired: SwiftProtobuf.Message, SwiftProtobuf._
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_NestedNoneRequired: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_NestedNoneRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedNoneRequired"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -990,12 +998,13 @@ extension SwiftProtoTesting_NestedNoneRequired: SwiftProtobuf.Message, SwiftProt
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}3f\u{15}[?s'L4PX;\u{3}usBm\"x^rf|6\u{17}\u{12}YS\u{17}Cu`'\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftProtoTesting_NoneRequiredButNestedRequired: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_NoneRequiredButNestedRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NoneRequiredButNestedRequired"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -1042,6 +1051,7 @@ extension SwiftProtoTesting_NoneRequiredButNestedRequired: SwiftProtobuf.Message
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -1051,7 +1061,7 @@ extension SwiftProtoTesting_NoneRequiredButNestedRequired: SwiftProtobuf.Message
 
 }
 
-extension SwiftProtoTesting_MapWithNestedRequiredValues: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftProtoTesting_MapWithNestedRequiredValues: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MapWithNestedRequiredValues"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -1108,6 +1118,7 @@ extension SwiftProtoTesting_MapWithNestedRequiredValues: SwiftProtobuf.Message, 
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_delimited.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_delimited.pb.swift
@@ -102,7 +102,7 @@ struct SwiftDescriptorTest_EditionsMessageForDelimited: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_descriptor_test"
 
-extension SwiftDescriptorTest_EditionsMessageForDelimited: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_EditionsMessageForDelimited: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EditionsMessageForDelimited"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -173,6 +173,7 @@ extension SwiftDescriptorTest_EditionsMessageForDelimited: SwiftProtobuf.Message
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test.pb.swift
@@ -585,7 +585,7 @@ extension SDTTopLevelEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SDTTopLevelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTTopLevelMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TopLevelMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -638,6 +638,7 @@ extension SDTTopLevelMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -651,7 +652,7 @@ extension SDTTopLevelMessage.SubEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SDTTopLevelMessage.SubMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTTopLevelMessage.SubMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = SDTTopLevelMessage.protoMessageName + ".SubMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -698,12 +699,13 @@ extension SDTTopLevelMessage.SubMessage: SwiftProtobuf.Message, SwiftProtobuf._M
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SDTTopLevelMessage2: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTTopLevelMessage2: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TopLevelMessage2"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -752,12 +754,13 @@ extension SDTTopLevelMessage2: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SDTExternalRefs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTExternalRefs: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ExternalRefs"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -806,6 +809,7 @@ extension SDTExternalRefs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -815,7 +819,7 @@ extension SDTExternalRefs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
 }
 
-extension SDTScoperForExt: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTScoperForExt: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ScoperForExt"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -830,12 +834,13 @@ extension SDTScoperForExt: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SDTProto2MessageForPresence: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SDTProto2MessageForPresence: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Proto2MessageForPresence"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -888,6 +893,7 @@ extension SDTProto2MessageForPresence: SwiftProtobuf.Message, SwiftProtobuf._Mes
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test2.pb.swift
@@ -263,7 +263,7 @@ struct SwiftDescriptorTest_OtherMessage: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_descriptor_test"
 
-extension SwiftDescriptorTest_Proto3MessageForPresence: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_Proto3MessageForPresence: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Proto3MessageForPresence"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -316,6 +316,7 @@ extension SwiftDescriptorTest_Proto3MessageForPresence: SwiftProtobuf.Message, S
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -329,7 +330,7 @@ extension SwiftDescriptorTest_Proto3MessageForPresence.SubEnum {
   static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData)
 }
 
-extension SwiftDescriptorTest_OtherMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_OtherMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OtherMessage"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -344,6 +345,7 @@ extension SwiftDescriptorTest_OtherMessage: SwiftProtobuf.Message, SwiftProtobuf
   private static var _protobuf_reflectionData: StaticString { "$\0\0\0\0?'L)\u{7}&pm\u{e}FP\\:UW2\u{1e}A\u{10}\u{3}P\u{1b}`\u{3}\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test_import.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/pluginlib_descriptor_test_import.pb.swift
@@ -160,7 +160,7 @@ struct SwiftDescriptorTest_Import_ExtendableOne: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "swift_descriptor_test.import"
 
-extension SwiftDescriptorTest_Import_Version: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_Import_Version: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Version"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -175,12 +175,13 @@ extension SwiftDescriptorTest_Import_Version: SwiftProtobuf.Message, SwiftProtob
   private static var _protobuf_reflectionData: StaticString { "h\0\0\0p\u{1}4\u{4}\u{f}K\0)h\0]8Gll_\u{7f}7ty\u{5}V\u{7}\u{5}'\u{1e}D\\K>\u{1}qu\u{3}\u{1e}!E>6{F\u{2}\u{3}' \u{16}@P\u{7}\u{4}#{B\u{b}D\u{1a}cN\tuk\u{1c}N\u{2}s<{~\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension SwiftDescriptorTest_Import_ExtendableOne: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_Import_ExtendableOne: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ExtendableOne"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -227,6 +228,7 @@ extension SwiftDescriptorTest_Import_ExtendableOne: SwiftProtobuf.Message, Swift
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -236,7 +238,7 @@ extension SwiftDescriptorTest_Import_ExtendableOne: SwiftProtobuf.Message, Swift
 
 }
 
-extension SwiftDescriptorTest_Import_ExtendableOne.ExtendableTwo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftDescriptorTest_Import_ExtendableOne.ExtendableTwo: SwiftProtobuf.Message {
   static let protoMessageName: String = SwiftDescriptorTest_Import_ExtendableOne.protoMessageName + ".ExtendableTwo"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -251,6 +253,7 @@ extension SwiftDescriptorTest_Import_ExtendableOne.ExtendableTwo: SwiftProtobuf.
   private static var _protobuf_reflectionData: StaticString { "\u{c}\0\0\0\0\u{7f}\u{f}\tA\u{7}2x6B&d\0\0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/test_features.pb.swift
@@ -168,7 +168,7 @@ let SwiftFeatureTest_Extensions_test = SwiftProtobuf.ExtensionSchema(
 
 fileprivate let _protobuf_package = "swift_feature_test"
 
-extension SwiftFeatureTest_TestFeatures: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension SwiftFeatureTest_TestFeatures: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFeatures"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -215,6 +215,7 @@ extension SwiftFeatureTest_TestFeatures: SwiftProtobuf.Message, SwiftProtobuf._M
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited.pb.swift
@@ -469,7 +469,7 @@ let EditionsUnittest_Extensions_messageimport = SwiftProtobuf.ExtensionSchema(
 
 fileprivate let _protobuf_package = "editions_unittest"
 
-extension EditionsUnittest_LengthPrefixed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_LengthPrefixed: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".LengthPrefixed"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -484,12 +484,13 @@ extension EditionsUnittest_LengthPrefixed: SwiftProtobuf.Message, SwiftProtobuf.
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension EditionsUnittest_NotGroupLikeScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_NotGroupLikeScope: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NotGroupLikeScope"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -504,12 +505,13 @@ extension EditionsUnittest_NotGroupLikeScope: SwiftProtobuf.Message, SwiftProtob
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension EditionsUnittest_GroupLikeFileScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_GroupLikeFileScope: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".GroupLikeFileScope"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -524,12 +526,13 @@ extension EditionsUnittest_GroupLikeFileScope: SwiftProtobuf.Message, SwiftProto
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension EditionsUnittest_TestDelimited: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_TestDelimited: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDelimited"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -584,6 +587,7 @@ extension EditionsUnittest_TestDelimited: SwiftProtobuf.Message, SwiftProtobuf._
     default: preconditionFailure("invalid trampoline token; this is a generator bug")
     }
   }
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
@@ -593,7 +597,7 @@ extension EditionsUnittest_TestDelimited: SwiftProtobuf.Message, SwiftProtobuf._
 
 }
 
-extension EditionsUnittest_TestDelimited.LengthPrefixed: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_TestDelimited.LengthPrefixed: SwiftProtobuf.Message {
   static let protoMessageName: String = EditionsUnittest_TestDelimited.protoMessageName + ".LengthPrefixed"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -608,12 +612,13 @@ extension EditionsUnittest_TestDelimited.LengthPrefixed: SwiftProtobuf.Message, 
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 
 }
 
-extension EditionsUnittest_TestDelimited.GroupLike: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_TestDelimited.GroupLike: SwiftProtobuf.Message {
   static let protoMessageName: String = EditionsUnittest_TestDelimited.protoMessageName + ".GroupLike"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -628,6 +633,7 @@ extension EditionsUnittest_TestDelimited.GroupLike: SwiftProtobuf.Message, Swift
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 

--- a/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited_import.pb.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/unittest_delimited_import.pb.swift
@@ -67,7 +67,7 @@ struct EditionsUnittest_MessageImport: @unchecked Sendable {
 
 fileprivate let _protobuf_package = "editions_unittest"
 
-extension EditionsUnittest_MessageImport: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase {
+extension EditionsUnittest_MessageImport: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageImport"
   #if _pointerBitWidth(_64)
     @_alwaysEmitIntoClient @inline(__always)
@@ -82,6 +82,7 @@ extension EditionsUnittest_MessageImport: SwiftProtobuf.Message, SwiftProtobuf._
   private static var _protobuf_reflectionData: StaticString { "0\0\0\0\0\u{1f}sm\u{1d}\u{7}&pmNE54\u{5}\u{14}*`D\u{7f}:9+\u{1c}gS[0\0" }
 
   static let messageSchema = SwiftProtobuf.MessageSchema(schema: _protobuf_messageSchemaString, reflection: _protobuf_reflectionData)
+  var messageSchema: SwiftProtobuf.MessageSchema { Self.messageSchema }
 
   func _protobuf_messageStorage(accessToken: SwiftProtobuf._MessageStorageToken) -> AnyObject { _storage }
 


### PR DESCRIPTION
We can move the `Equatable/Hashable` conformances to `Message` now because Swift doesn't have such hard restrictions on existentials of protocols with `Self` requirements. Since the runtime requirements for storage access got moved to `Message` already, `_MessageImplementationBase` isn't useful in its current shape.

In the future when we add reflection, we may still need a distinction between "any message" and "any generated message". For example, it probably makes sense for a "reflected message" type (one that only provides dynamic field access) to also conform to `Message`, but `Message` has an `init()` requirement and that doesn't make sense with a "reflected message" type (you need to initialize it with a schema so it knows what kind of message it is). But the current shape of `Message`/`_MessageImplementationBase` doesn't make sense anymore, so let's clean it up and revisit it later.