### PR TITLE
Update FuzzTesting Package.swift.

### DIFF
--- a/FuzzTesting/Package.swift
+++ b/FuzzTesting/Package.swift
@@ -1,7 +1,4 @@
-// swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-// **NOTE**: 5.3 due to https://github.com/swiftlang/swift/issues/75800
-//   This is fixed in 6.2 but oss-fuzz is still using 6.1.
+// swift-tools-version:6.2
 
 import PackageDescription
 
@@ -11,30 +8,30 @@ let package = Package(
         .macOS(.v10_15)
     ],
     dependencies: [
-        .package(name: "SwiftProtobuf", path: "..")
+        .package(name: "SwiftProtobuf", path: "..", traits: ["BinaryDelimitedStreams"])
     ],
     targets: [
         .target(
             name: "FuzzCommon",
             dependencies: ["SwiftProtobuf"]
         ),
-        .target(
+        .executableTarget(
             name: "FuzzBinary",
             dependencies: ["SwiftProtobuf", "FuzzCommon"]
         ),
-        .target(
+        .executableTarget(
             name: "FuzzBinaryDelimited",
             dependencies: ["SwiftProtobuf", "FuzzCommon"]
         ),
-        .target(
+        .executableTarget(
             name: "FuzzAsyncMessageSequence",
             dependencies: ["SwiftProtobuf", "FuzzCommon"]
         ),
-        .target(
+        .executableTarget(
             name: "FuzzJSON",
             dependencies: ["SwiftProtobuf", "FuzzCommon"]
         ),
-        .target(
+        .executableTarget(
             name: "FuzzTextFormat",
             dependencies: ["SwiftProtobuf", "FuzzCommon"]
         ),

--- a/FuzzTesting/Tests/FuzzCommonTests/Test_Options.swift
+++ b/FuzzTesting/Tests/FuzzCommonTests/Test_Options.swift
@@ -29,12 +29,14 @@ struct TestOptions: SupportsFuzzOptions {
 
     var sets: [String] = []
 
-    static var fuzzOptionsList: [FuzzCommon.FuzzOption<Self>] = [
-        .boolean(\.bool1),
-        .boolean(\.bool2),
-        .byte(\.int1),
-        .byte(\.int2, mod: 16),
-    ]
+    static var fuzzOptionsList: [FuzzCommon.FuzzOption<Self>] {
+        [
+            .boolean(\.bool1),
+            .boolean(\.bool2),
+            .byte(\.int1),
+            .byte(\.int2, mod: 16),
+        ]
+    }
 
     init() {}
 }
@@ -74,18 +76,20 @@ struct TestOptionsLarge: SupportsFuzzOptions {
 
     var sets: [String] = []
 
-    static var fuzzOptionsList: [FuzzCommon.FuzzOption<Self>] = [
-        .boolean(\.bool1),
-        .boolean(\.bool2),
-        .boolean(\.bool3),
-        .boolean(\.bool4),
-        .byte(\.int1),
-        .boolean(\.bool5),
-        .boolean(\.bool6),
-        .boolean(\.bool7),
-        .boolean(\.bool8),
-        .byte(\.int2),
-    ]
+    static var fuzzOptionsList: [FuzzCommon.FuzzOption<Self>] {
+        [
+            .boolean(\.bool1),
+            .boolean(\.bool2),
+            .boolean(\.bool3),
+            .boolean(\.bool4),
+            .byte(\.int1),
+            .boolean(\.bool5),
+            .boolean(\.bool6),
+            .boolean(\.bool7),
+            .boolean(\.bool8),
+            .byte(\.int2),
+        ]
+    }
 
     init() {}
 }

--- a/FuzzTesting/do_build.sh
+++ b/FuzzTesting/do_build.sh
@@ -91,11 +91,11 @@ if [ "$(uname)" == "Darwin" ]; then
   CMD_BASE=(
     xcrun
       --toolchain swift
-      swift build -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library
+      swift build --sanitize=fuzzer --sanitize=address
   )
 else
   CMD_BASE=(
-    swift build -Xswiftc -sanitize=fuzzer,address -Xswiftc -parse-as-library
+    swift build --sanitize=fuzzer --sanitize=address
   )
 fi
 


### PR DESCRIPTION
Now that https://github.com/google/oss-fuzz/pull/14342 has landed, we can properly updated FuzzTesting/Package.swift to also be 6.x based.

This pulls over what @glbrntt's had attempted in #1913 but couldn't be landed because of issues in 6.0/6.1, but now that we only do fuzz testing on 6.2+ it is safe.

It also sets the explicit `traits` for SwiftProtobuf since the FieldMask additions aren't needed.