### PR TITLE
[table-driven-branch] Implement caching for uncompressed reflection tables.

### DIFF
--- a/Sources/SwiftProtobuf/EnumSchema.swift
+++ b/Sources/SwiftProtobuf/EnumSchema.swift
@@ -47,11 +47,10 @@ public struct EnumSchema: @unchecked Sendable {
     @_spi(ForGeneratedCodeOnly)
     public init(schema: StaticString, reflection: StaticString, invokeWitness: @escaping InvokeWitnessFunction) {
         self.schema = schema.rawBufferPointer
-        // TODO: Use the `.compressed` form and lazily decompress and cache it.
-        self.reflection = .direct(ReflectionTable(
-            fieldCount: Self.valueCount(from: schema.rawBufferPointer),
-            data: Compression.decompress(reflection.rawBufferPointer)
-        ))
+        self.reflection = .init(
+            compressed: reflection.rawBufferPointer,
+            fieldCount: Self.valueCount(from: schema.rawBufferPointer)
+        )
         self.invokeWitness = invokeWitness
     }
 }
@@ -99,11 +98,11 @@ extension EnumSchema {
 
     /// The text and JSON name for the given enum case value.
     func textName(forEnumCase value: Int32) -> UTF8Name? {
-        reflection.table.textName(forEnumCase: value)
+        reflection.withTable { $0.textName(forEnumCase: value) }
     }
 
     /// The enum case value for the given text and JSON name.
     func enumCase(forTextName name: String) -> Int32? {
-        reflection.table.enumCase(forTextName: name)
+        reflection.withTable { $0.enumCase(forTextName: name) }
     }
 }

--- a/Sources/SwiftProtobuf/MessageSchema.swift
+++ b/Sources/SwiftProtobuf/MessageSchema.swift
@@ -138,11 +138,10 @@ public struct MessageSchema: @unchecked Sendable {
     ) {
         self.init(
             schema: schema,
-            // TODO: Use the `.compressed` form and lazily decompress and cache it.
-            reflectionReference: .direct(ReflectionTable(
-                fieldCount: Self.fieldCount(from: schema.rawBufferPointer),
-                data: Compression.decompress(reflection.rawBufferPointer)
-            )),
+            reflectionReference: .init(
+                compressed: reflection.rawBufferPointer,
+                fieldCount: Self.fieldCount(from: schema.rawBufferPointer)
+            ),
             invokeWitness: invokeWitness,
             submessageOrEnumResolver: submessageOrEnumResolver
         )
@@ -156,11 +155,10 @@ public struct MessageSchema: @unchecked Sendable {
     public init(schema: StaticString, reflection: StaticString, invokeWitness: @escaping InvokeWitnessFunction) {
         self.init(
             schema: schema,
-            // TODO: Use the `.compressed` form and lazily decompress and cache it.
-            reflectionReference: .direct(ReflectionTable(
-                fieldCount: Self.fieldCount(from: schema.rawBufferPointer),
-                data: Compression.decompress(reflection.rawBufferPointer)
-            )),
+            reflectionReference: .init(
+                compressed: reflection.rawBufferPointer,
+                fieldCount: Self.fieldCount(from: schema.rawBufferPointer)
+            ),
             invokeWitness: invokeWitness,
             submessageOrEnumResolver: { _ in
                 preconditionFailure("This should have been unreachable; this is a generator bug")
@@ -178,7 +176,7 @@ public struct MessageSchema: @unchecked Sendable {
     ) {
         self.init(
             schema: schema,
-            reflectionReference: .direct(.mapEntry),
+            reflectionReference: .mapEntry,
             invokeWitness: MapEntryWitnesses<K, V>.perform,
             submessageOrEnumResolver: { _ in
                 preconditionFailure("This should have been unreachable; this is a generator bug")
@@ -196,7 +194,7 @@ public struct MessageSchema: @unchecked Sendable {
     ) {
         self.init(
             schema: schema,
-            reflectionReference: .direct(.mapEntry),
+            reflectionReference: .mapEntry,
             invokeWitness: MapEntryWitnesses<K, ProtobufMapMessageField<M>>.perform,
             submessageOrEnumResolver: { token in
                 guard token.index == 1 else {
@@ -217,7 +215,7 @@ public struct MessageSchema: @unchecked Sendable {
     ) {
         self.init(
             schema: schema,
-            reflectionReference: .direct(.mapEntry),
+            reflectionReference: .mapEntry,
             invokeWitness: MapEntryWitnesses<K, ProtobufMapEnumField<E>>.perform,
             submessageOrEnumResolver: { token in
                 switch token.index {
@@ -358,46 +356,48 @@ extension MessageSchema {
 extension MessageSchema {
     /// Returns the text name for the given field number.
     func textName(forFieldNumber number: UInt32) -> UTF8Name? {
-        reflection.table.textName(forFieldNumber: number)
+        reflection.withTable { $0.textName(forFieldNumber: number) }
     }
 
     /// Returns the JSON name for the given field number.
     func jsonName(forFieldNumber number: UInt32) -> UTF8Name? {
-        reflection.table.jsonName(forFieldNumber: number)
+        reflection.withTable { $0.jsonName(forFieldNumber: number) }
     }
 
     /// Returns the field number for the given text name.
     func fieldNumber(forTextName name: String) -> UInt32? {
-        // Fast path: Binary search in the reflection table.
-        if let number = reflection.table.fieldNumber(forTextName: name) {
-            return number
-        }
-        // Slow path: If it wasn't found, check if it's a group name spelled in
-        // lowercase form.
-        let lowercaseName = name.lowercased()
-        for field in fields where field.rawFieldType == .group {
-            if let textName = reflection.table.textName(forFieldNumber: field.fieldNumber),
-                String(decoding: textName.buffer, as: UTF8.self).lowercased() == lowercaseName
-            {
-                return field.fieldNumber
+        reflection.withTable { reflectionTable in
+            // Fast path: Binary search in the reflection table.
+            if let number = reflectionTable.fieldNumber(forTextName: name) {
+                return number
             }
+            // Slow path: If it wasn't found, check if it's a group name spelled in
+            // lowercase form.
+            let lowercaseName = name.lowercased()
+            for field in fields where field.rawFieldType == .group {
+                if let textName = reflectionTable.textName(forFieldNumber: field.fieldNumber),
+                    String(decoding: textName.buffer, as: UTF8.self).lowercased() == lowercaseName
+                {
+                    return field.fieldNumber
+                }
+            }
+            return nil
         }
-        return nil
     }
 
     /// Returns the field number for the given JSON name.
     func fieldNumber(forJSONName name: String) -> UInt32? {
-        reflection.table.fieldNumber(forJSONName: name)
+        reflection.withTable { $0.fieldNumber(forJSONName: name) }
     }
 
     /// Returns a value indicating whether or not the given field name is reserved.
     func isFieldNameReserved(_ name: String) -> Bool {
-        reflection.table.isNameReserved(name)
+        reflection.withTable { $0.isNameReserved(name) }
     }
 
     /// Returns a value indicating whether or not the given field number is reserved.
     func isFieldNumberReserved(_ number: UInt32) -> Bool {
-        reflection.table.isNumberReserved(number)
+        reflection.withTable { $0.isNumberReserved(number) }
     }
 }
 

--- a/Sources/SwiftProtobuf/ReflectionTable.swift
+++ b/Sources/SwiftProtobuf/ReflectionTable.swift
@@ -13,8 +13,6 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Foundation
-
 /// Provides access to the reflection data embedded in a generated message or enum.
 ///
 /// ## Reflection Table Layout
@@ -424,104 +422,31 @@ extension ReflectionTable {
 
 extension ReflectionTable {
     /// The fixed reflection table for the pseudo-message used to represent map entries.
-    package static let mapEntry: ReflectionTable = {
-        ReflectionTable(
-            fieldCount: 2,
-            data: [
-                56, 0, 0, 0,  // Offset to Section 1
-                0, 0,         // distinctJSONNameCount (0)
-                0, 0,         // reservedNameCount (0)
-                2, 0,         // textNameTableCount (2)
-                0, 0,         // Padding
-                // Field number to text offset table
-                1, 0, 0, 0,  // field 1
-                0, 0, 0, 0,  // offset 0
-                2, 0, 0, 0,  // field 2
-                4, 0, 0, 0,  // offset 4
-                // Text offset to field number table (sorted by name)
-                0, 0, 0, 0,  // offset 0 ("key")
-                1, 0, 0, 0,  // field 1
-                4, 0, 0, 0,  // offset 4 ("value")
-                2, 0, 0, 0,  // field 2
-                // Name data blob (null terminated)
-                UInt8(ascii: "k"), UInt8(ascii: "e"), UInt8(ascii: "y"), 0,
-                UInt8(ascii: "v"), UInt8(ascii: "a"), UInt8(ascii: "l"), UInt8(ascii: "u"),
-                UInt8(ascii: "e"), 0,
-                // Alignment padding
-                0, 0,
-                60, 0, 0, 0,  // Offset of Section 2
-            ]
-        )
-    }()
-}
-
-/// A reference to a reflection table, which may be inlined (embedded in the generated code) or
-/// stored as a compressed buffer.
-enum ReflectionTableReference: @unchecked Sendable {
-    /// A compressed reflection table stored as a static string in generated code.
-    ///
-    /// The pointer to the compressed data is used as a unique key to reference the table.
-    case compressed(UnsafeRawBufferPointer, fieldCount: Int)
-
-    /// Refers to a reflection table that already exists at the time a message/enum schema is
-    /// created.
-    ///
-    /// This is used for map entry pseudo-messages, which have a fixed reflection table shared
-    /// across all map entries.
-    case direct(ReflectionTable)
-
-    /// Returns the reflection table, decompressing it if necessary.
-    var table: ReflectionTable {
-        switch self {
-        case .compressed(let buffer, let fieldCount):
-            // TODO: Move this to a cache instead of decompressing every time.
-            let decompressed = Compression.decompress(buffer)
-            return ReflectionTable(fieldCount: fieldCount, data: decompressed)
-        case .direct(let table):
-            return table
-        }
-    }
-}
-
-/// A reflection table that is lazily decompressed when first accessed.
-final class LazyReflectionTable {
-    private enum State {
-        case compressed(UnsafeRawBufferPointer, fieldCount: Int)
-        case decompressed(ReflectionTable)
-    }
-
-    /// Guards `state`.
-    private let lock = NSLock()
-
-    /// Whether the table is a compressed buffer or decompressed table.
-    private var state: State
-
-    /// Initializes the lazy reflection table with a buffer to be decompressed the first time it is
-    /// requested.
-    init(compressed: UnsafeRawBufferPointer, fieldCount: Int) {
-        self.state = .compressed(compressed, fieldCount: fieldCount)
-    }
-
-    /// Initializes the lazy reflection table wrapper with an already decompressed table.
-    init(decompressed: ReflectionTable) {
-        self.state = .decompressed(decompressed)
-    }
-
-    /// The reflection table, decompressed for the first time if needed.
-    var table: ReflectionTable {
-        lock.withLock {
-            switch state {
-            case .decompressed(let table):
-                return table
-
-            case .compressed(let buffer, let fieldCount):
-                let table = ReflectionTable(
-                    fieldCount: fieldCount,
-                    data: Compression.decompress(buffer)
-                )
-                state = .decompressed(table)
-                return table
-            }
-        }
-    }
+    package static let mapEntry = ReflectionTable(
+        fieldCount: 2,
+        data: [
+            56, 0, 0, 0,  // Offset to Section 1
+            0, 0,         // distinctJSONNameCount (0)
+            0, 0,         // reservedNameCount (0)
+            2, 0,         // textNameTableCount (2)
+            0, 0,         // Padding
+            // Field number to text offset table
+            1, 0, 0, 0,  // field 1
+            0, 0, 0, 0,  // offset 0
+            2, 0, 0, 0,  // field 2
+            4, 0, 0, 0,  // offset 4
+            // Text offset to field number table (sorted by name)
+            0, 0, 0, 0,  // offset 0 ("key")
+            1, 0, 0, 0,  // field 1
+            4, 0, 0, 0,  // offset 4 ("value")
+            2, 0, 0, 0,  // field 2
+            // Name data blob (null terminated)
+            UInt8(ascii: "k"), UInt8(ascii: "e"), UInt8(ascii: "y"), 0,
+            UInt8(ascii: "v"), UInt8(ascii: "a"), UInt8(ascii: "l"), UInt8(ascii: "u"),
+            UInt8(ascii: "e"), 0,
+            // Alignment padding
+            0, 0,
+            60, 0, 0, 0,  // Offset of Section 2
+        ]
+    )
 }

--- a/Sources/SwiftProtobuf/ReflectionTableReference.swift
+++ b/Sources/SwiftProtobuf/ReflectionTableReference.swift
@@ -1,0 +1,66 @@
+// Sources/SwiftProtobuf/ReflectionTableReference.swift - Reflection table reference
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// A self-caching reference to a reflection table that may have been
+/// compressed in a `StaticString` in generated code.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+/// A reference to a reflection table, which may be inlined (embedded in the generated code) or
+/// stored as a compressed buffer.
+final class ReflectionTableReference: @unchecked Sendable {
+    private enum State {
+        case compressed(UnsafeRawBufferPointer, fieldCount: Int)
+        case direct(ReflectionTable)
+    }
+
+    /// A singleton instance that references the fixed reflection table for map entries.
+    static let mapEntry: ReflectionTableReference = .init(direct: .mapEntry)
+
+    /// Guards `state`.
+    private let lock = NSLock()
+
+    /// The state of the table, either compressed or decompressed.
+    private var state: State
+
+    /// Creates a new reflection table reference from a compressed buffer.
+    ///
+    /// The pointer to the compressed data is assumed to be immortal (either static data in
+    /// the binary or allocated in a pool that lives for the lifetime of the reference).
+    init(compressed: UnsafeRawBufferPointer, fieldCount: Int) {
+        self.state = .compressed(compressed, fieldCount: fieldCount)
+    }
+
+    /// Creates a new reference to an existing reflection table.
+    private init(direct table: ReflectionTable) {
+        self.state = .direct(table)
+    }
+
+    /// Calls the given body with the reflection table, decompressing it on the
+    /// first call if needed.
+    func withTable<R>(_ body: (borrowing ReflectionTable) throws -> R) rethrows -> R {
+        try lock.withLock {
+            switch state {
+            case .direct(let table):
+                return try body(table)
+
+            case .compressed(let buffer, let fieldCount):
+                let table = ReflectionTable(
+                    fieldCount: fieldCount,
+                    data: Compression.decompress(buffer)
+                )
+                state = .direct(table)
+                return try body(table)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Rather than have a global table that would require keeping track of a mapping between compressed pointers and uncompressed data, I've chosen to just make each table reference self-caching. This has the advantage of each reference being able to maintain an independent lock, instead of a lock around the whole mapping (or something more complex that would allow multiple readers/one writer).

`NSLock` is chosen as a lowest-common denominator since we don't want to be too limiting about supported minimum OS versions. It may be worth exploring different options on different platforms in the future, but I expect the cost of the current lock would be small compared to the actual encoding/decoding operations that use this table. I didn't notice any performance issues when introducing this compared to the original version that just decompressed the table on schema creation.