### PR TITLE
Flip the order of the diff in `test-plugin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ test-plugin: build ${PROTOC_GEN_SWIFT} ${PROTOC}
 		--tfiws_opt=EnumGeneration=NonExhaustive \
 		--tfiws_out=_test/Tests/protoc-gen-swiftTests/NonExhaustive \
 		Protos/Tests/protoc-gen-swiftTests/enum_generation_test.proto
-	diff -ru _test Reference
+	diff -ru Reference _test
 
 # Test the SPM plugin.
 test-spm-plugin:


### PR DESCRIPTION
When this failed on CI the other day it looked a little odd as the "-" lines were the ones that were the new state. So flip the order so the "+" lines are how it should be generated vs. what is currently checked in to the Reference directory. i.e. - the output becomes "the patch to apply to reference" instead of the output being what would get applied to the "generator".
