### PR TITLE
Reject invalid sub-second precision in Timestamp/Duration JSON decoding

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -61,14 +61,16 @@ private func parseDuration(text: String) throws -> (Int64, Int32) {
             digitCount = 0
         case "s":
             if let _ = seconds {
-                // Seconds already set, digits holds nanos
+                // Seconds already set, digits holds nanos. The fraction must
+                // have between 1 and 9 digits; matches the protobuf grammar
+                // and the reference JSON parser, which reject an empty
+                // fraction or more than nanosecond precision.
+                if digitCount < 1 || digitCount > 9 {
+                    throw JSONDecodingError.malformedDuration
+                }
                 while digitCount < 9 {
                     digits.append(Character("0"))
                     digitCount += 1
-                }
-                while digitCount > 9 {
-                    digits.removeLast()
-                    digitCount -= 1
                 }
                 let digitString = String(digits)
                 if let rawNanos = Int32(digitString) {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -152,14 +152,21 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
         var digitValue = 100_000_000
         var fractionalDigits = 0
         while pos < value.count && value[pos] >= zero && value[pos] <= nine {
+            fractionalDigits += 1
+            // The fraction may have at most 9 digits. Reject as soon as a
+            // tenth digit appears so we fail fast and never accumulate past
+            // nanosecond precision, which also keeps the Int32 math below from
+            // trapping on pathological input.
+            if fractionalDigits > 9 {
+                throw JSONDecodingError.malformedTimestamp
+            }
             nanos += Int32(digitValue * (value[pos] - zero))
             digitValue /= 10
-            fractionalDigits += 1
             pos += 1
         }
-        // The fraction must have between 1 and 9 digits; matches the
-        // RFC 3339 grammar and the reference protobuf JSON parser.
-        if fractionalDigits < 1 || fractionalDigits > 9 {
+        // The fraction must have at least one digit, matching the RFC 3339
+        // grammar and the reference protobuf JSON parser.
+        if fractionalDigits < 1 {
             throw JSONDecodingError.malformedTimestamp
         }
     }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -153,10 +153,10 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
         var fractionalDigits = 0
         while pos < value.count && value[pos] >= zero && value[pos] <= nine {
             fractionalDigits += 1
-            // The fraction may have at most 9 digits. Reject as soon as a
-            // tenth digit appears so we fail fast and never accumulate past
-            // nanosecond precision, which also keeps the Int32 math below from
-            // trapping on pathological input.
+            // Protobuf encodes sub-second time as nanoseconds, so the fraction
+            // is limited to 9 digits. Reject as soon as a tenth digit appears
+            // so we fail fast, and so the Int32 accumulation below cannot
+            // overflow on pathological input.
             if fractionalDigits > 9 {
                 throw JSONDecodingError.malformedTimestamp
             }
@@ -164,8 +164,8 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
             digitValue /= 10
             pos += 1
         }
-        // The fraction must have at least one digit, matching the RFC 3339
-        // grammar and the reference protobuf JSON parser.
+        // Protobuf JSON also requires at least one digit after the decimal
+        // point. The reference parser rejects an empty fraction.
         if fractionalDigits < 1 {
             throw JSONDecodingError.malformedTimestamp
         }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -150,10 +150,17 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
     if value[pos] == period {  // "." begins fractional seconds
         pos += 1
         var digitValue = 100_000_000
+        var fractionalDigits = 0
         while pos < value.count && value[pos] >= zero && value[pos] <= nine {
             nanos += Int32(digitValue * (value[pos] - zero))
             digitValue /= 10
+            fractionalDigits += 1
             pos += 1
+        }
+        // The fraction must have between 1 and 9 digits; matches the
+        // RFC 3339 grammar and the reference protobuf JSON parser.
+        if fractionalDigits < 1 || fractionalDigits > 9 {
+            throw JSONDecodingError.malformedTimestamp
         }
     }
 

--- a/Tests/SwiftProtobufTests/Test_Duration.swift
+++ b/Tests/SwiftProtobufTests/Test_Duration.swift
@@ -95,6 +95,22 @@ final class Test_Duration: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("\"100.001sXXX\"")
     }
 
+    func testJSON_subsecondDigits() throws {
+        // A fractional part is allowed to have between 1 and 9 digits.
+        assertJSONDecodeSucceeds("\"1.1s\"") { (o: MessageTestType) in
+            o.seconds == 1 && o.nanos == 100_000_000
+        }
+        assertJSONDecodeSucceeds("\"1.123456789s\"") { (o: MessageTestType) in
+            o.seconds == 1 && o.nanos == 123_456_789
+        }
+        // A '.' must be followed by at least one digit.
+        assertJSONDecodeFails("\"1.s\"")
+        // More than nanosecond precision (>9 fractional digits) is invalid and
+        // must not be silently truncated.
+        assertJSONDecodeFails("\"1.1234567890s\"")
+        assertJSONDecodeFails("\"1.123456789012345s\"")
+    }
+
     func testSerializationFailure() throws {
         let maxOutOfRange = Google_Protobuf_Duration(seconds: -315_576_000_001)
         XCTAssertThrowsError(try maxOutOfRange.jsonString())

--- a/Tests/SwiftProtobufTests/Test_Timestamp.swift
+++ b/Tests/SwiftProtobufTests/Test_Timestamp.swift
@@ -182,6 +182,23 @@ final class Test_Timestamp: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("\"9999-12-31T00:00:00\"")
     }
 
+    func testJSON_subsecondDigits() {
+        // A fractional part is allowed to have between 1 and 9 digits.
+        assertJSONDecodeSucceeds("\"1970-01-01T00:00:00.1Z\"") {
+            $0.seconds == 0 && $0.nanos == 100_000_000
+        }
+        assertJSONDecodeSucceeds("\"1970-01-01T00:00:00.123456789Z\"") {
+            $0.seconds == 0 && $0.nanos == 123_456_789
+        }
+        // A '.' must be followed by at least one digit.
+        assertJSONDecodeFails("\"1970-01-01T00:00:00.Z\"")
+        assertJSONDecodeFails("\"1970-01-01T00:00:00.+00:00\"")
+        // More than nanosecond precision (>9 fractional digits) is invalid and
+        // must not be silently truncated.
+        assertJSONDecodeFails("\"1970-01-01T00:00:00.1234567890Z\"")
+        assertJSONDecodeFails("\"1970-01-01T00:00:00.123456789012345Z\"")
+    }
+
     func testJSON_range() throws {
         // Check that JSON timestamps round-trip correctly over a wide range.
         // This checks about 15,000 dates scattered over a 10,000 year period


### PR DESCRIPTION
The JSON decoders for `google.protobuf.Timestamp` and `google.protobuf.Duration` accept fractional-second values that the format does not permit.

In `parseTimestamp`, the loop that reads the fraction after the `.` consumes any number of digits. Once nine digits have been read, `digitValue` has already divided down to zero, so any further digits contribute nothing and are silently discarded. A `.` with no digits after it falls straight through the loop and is treated as zero nanos rather than an error. As a result these all decode successfully today:

- `"1970-01-01T00:00:00.1234567890Z"` (ten fractional digits, the tenth silently dropped)
- `"1970-01-01T00:00:00.123456789012345Z"` (fifteen digits)
- `"1970-01-01T00:00:00.Z"` (empty fraction)

`parseDuration` has the same issue from the opposite side: it pads a short fraction out to nine digits and truncates anything longer with a `removeLast` loop, so `"1.s"` and `"1.1234567890s"` are accepted too.

The protobuf JSON spec and the reference parser (`TakeNanosAndAdvance` in `json/internal/parser.cc`) require the fraction to contain between one and nine digits and reject anything outside that range. Both decoders now count the fractional digits and throw `malformedTimestamp` / `malformedDuration` when the count is zero or greater than nine. This also removes the silent precision loss on over-long input, since such input is now an explicit error instead of being quietly rounded.

The Duration change drops the now-dead `removeLast` truncation loop, which only ran for inputs that are now rejected up front.

Verification: added decode tests for one-digit and nine-digit fractions (still accepted, with the expected nanos) plus empty and over-nine-digit fractions (now rejected) in `Test_Timestamp` and `Test_Duration`. The new cases fail before the change and pass after. The full `swift test` suite passes (960 tests, 0 failures), including the existing wide-range timestamp round-trip test.