### PR TITLE
Reject out-of-range float values in quoted JSON numbers

### DIFF
--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -980,7 +980,15 @@ internal struct JSONScanner {
                     throw JSONDecodingError.malformedNumber
                 }
                 advance()
-                return Float(d)
+                // A value that parses as a finite Double can still be out of
+                // range for Float (for example "1e39"), in which case the
+                // conversion yields an infinity. Reject it, matching the
+                // unquoted path below.
+                let f = Float(d)
+                if f.isFinite {
+                    return f
+                }
+                throw JSONDecodingError.malformedNumber
             } else {
                 // Slow Path: parseBareDouble returned nil: It might be
                 // a valid float, but had something that

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -621,6 +621,11 @@ final class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"optionalFloat\":\"1e3.2\"}")
         // Out-of-range numbers should fail
         assertJSONDecodeFails("{\"optionalFloat\":1e39}")
+        // A quoted out-of-range value must fail the same way an unquoted one does.
+        // The magnitude here is representable as Double but overflows Float.
+        assertJSONDecodeFails("{\"optionalFloat\":\"1e39\"}")
+        assertJSONDecodeFails("{\"optionalFloat\":\"-1e39\"}")
+        assertJSONDecodeFails("{\"optionalFloat\":\"3.5e38\"}")
 
         // A wide range of numbers should exactly round-trip
         assertRoundTripJSON { $0.optionalFloat = 0.1 }


### PR DESCRIPTION
The JSON decoder accepts numeric values for a `float` field whether they are written bare (`1.5`) or quoted (`"1.5"`), and the two forms are meant to be equivalent. They are not equivalent for out-of-range magnitudes.

Decoding `{"optionalFloat":1e39}` correctly fails: `parseBareDouble` parses the text to a finite `Double`, converting to `Float` yields an infinity, and the `isFinite` check in `nextFloat()` throws `.malformedNumber`. The existing test at `Test_JSON.swift` already asserts this.

The quoted fast path in `nextFloat()` was missing that check. After parsing the digits it did `return Float(d)` directly, so `{"optionalFloat":"1e39"}` decoded to `Float.infinity` instead of failing. So the same value is rejected bare but silently produces an infinity when quoted. The quoted slow path (the branch that re-parses the string for forms `parseBareDouble` cannot handle) already guards on `f.isFinite`, so only the fast path was affected.

The fix applies the same `isFinite` check on the quoted fast path: convert to `Float`, return it when finite, otherwise throw `.malformedNumber`, matching the bare path and the quoted slow path.

Added regression cases to `testOptionalFloat` for `"1e39"`, `"-1e39"`, and `"3.5e38"` (each representable as `Double` but overflowing `Float`). They failed before the change and pass after it. The full `SwiftProtobuf` test target passes (958 tests).