### PR TITLE
[table-driven-branch] Move required field check into binary encoding.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -28,7 +28,10 @@ public struct BinaryEncodingOptions: Sendable {
     /// and subject to change.
     public var useDeterministicOrdering: Bool
 
+    internal var checkRequiredFields: Bool
+
     public init() {
         self.useDeterministicOrdering = false
+        self.checkRequiredFields = false
     }
 }

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -33,6 +33,8 @@ extension Message {
         partial: Bool = false,
         options: BinaryEncodingOptions = BinaryEncodingOptions()
     ) throws -> Bytes {
+        var options = options
+        options.checkRequiredFields = !partial
         return try storageForRuntime.serializedBytes(partial: partial, options: options)
     }
 

--- a/Sources/SwiftProtobuf/MessageStorage+BinaryEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+BinaryEncoding.swift
@@ -21,9 +21,8 @@ extension MessageStorage {
         partial: Bool,
         options: BinaryEncodingOptions
     ) throws -> Bytes {
-        if !partial && !isInitialized {
-            throw BinaryEncodingError.missingRequiredFields
-        }
+        var options = options
+        options.checkRequiredFields = !partial
 
         // Note that this assumes `options` will not change the required size.
         let requiredSize = serializedBytesSize()
@@ -54,6 +53,10 @@ extension MessageStorage {
     /// A recursion helper that serializes the message represented by this storage into the given
     /// binary encoder.
     func serializeBytes(into encoder: inout BinaryEncoder, options: BinaryEncodingOptions) throws {
+        if options.checkRequiredFields && !isMessageInitializedShallow {
+            throw BinaryEncodingError.missingRequiredFields
+        }
+
         var mapEntryWorkingSpace = MapEntryWorkingSpace(ownerSchema: schema)
         for field in schema.fields {
             guard isPresent(field) else { continue }

--- a/Sources/SwiftProtobuf/MessageStorage.swift
+++ b/Sources/SwiftProtobuf/MessageStorage.swift
@@ -1175,7 +1175,7 @@ extension MessageStorage {
     /// This is a shallow check; it does not recurse into submessages to check their initialized
     /// state.
     @inline(never)
-    private var isMessageInitializedShallow: Bool {
+    var isMessageInitializedShallow: Bool {
         // A message with no required fields is trivially considered initialized.
         guard schema.requiredCount > 0 else { return true }
 


### PR DESCRIPTION
Avoid upfront deep recursive calls to `isInitialized` by performing shallow validation on each submessage as it is traversed during serialization. This aligns with the behavior of the binary encoder in `upb` (`kUpb_EncodeOption_CheckRequired`).

- Add `checkRequiredFields` as an internal property on `BinaryEncodingOptions`.
- Set `options.checkRequiredFields = !partial` in public serialization APIs.
- Remove upfront `isInitialized` call in `MessageStorage.serializedBytes`.
- Perform shallow check `isMessageInitializedShallow` during serialization recursion in `MessageStorage.serializeBytes` if `checkRequiredFields` is enabled.