### PR TITLE
[table-driven-branch] Binary Encoding "partial" refactoring

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingOptions.swift
@@ -28,10 +28,16 @@ public struct BinaryEncodingOptions: Sendable {
     /// and subject to change.
     public var useDeterministicOrdering: Bool
 
-    internal var checkRequiredFields: Bool
+    /// Whether to allow partial messages (i.e., messages with missing required fields) to be
+    /// serialized.
+    ///
+    /// If `false` (the default), the encoder will check that all required fields are present in
+    /// the message (recursively checking any nested submessages). If any are missing, the encoder
+    /// will throw ``BinaryEncodingError/missingRequiredFields``.
+    public var allowPartial: Bool
 
     public init() {
         self.useDeterministicOrdering = false
-        self.checkRequiredFields = false
+        self.allowPartial = false
     }
 }

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -20,22 +20,37 @@ extension Message {
     /// format serialization of the message.
     ///
     /// - Parameters:
-    ///   - partial: If `false` (the default), this method will check
-    ///     `Message.isInitialized` before encoding to verify that all required
-    ///     fields are present. If any are missing, this method throws.
-    ///     ``BinaryEncodingError/missingRequiredFields``.
     ///   - options: The ``BinaryEncodingOptions`` to use.
     /// - Returns: A ``SwiftProtobufContiguousBytes`` instance containing the binary serialization
     /// of the message.
     ///
     /// - Throws: ``SwiftProtobufError`` or ``BinaryEncodingError`` if encoding fails.
     public func serializedBytes<Bytes: SwiftProtobufContiguousBytes>(
-        partial: Bool = false,
+        options: BinaryEncodingOptions = BinaryEncodingOptions()
+    ) throws -> Bytes {
+        return try storageForRuntime.serializedBytes(options: options)
+    }
+
+    /// Returns a ``SwiftProtobufContiguousBytes`` instance containing the Protocol Buffer binary
+    /// format serialization of the message.
+    ///
+    /// - Parameters:
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryEncodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryEncodingOptions`` to use.
+    /// - Returns: A ``SwiftProtobufContiguousBytes`` instance containing the binary serialization
+    /// of the message.
+    ///
+    /// - Throws: ``SwiftProtobufError`` or ``BinaryEncodingError`` if encoding fails.
+    @available(*, deprecated, message: "Use serializedBytes(options:) with options.allowPartial instead")
+    public func serializedBytes<Bytes: SwiftProtobufContiguousBytes>(
+        partial: Bool,
         options: BinaryEncodingOptions = BinaryEncodingOptions()
     ) throws -> Bytes {
         var options = options
-        options.checkRequiredFields = !partial
-        return try storageForRuntime.serializedBytes(partial: partial, options: options)
+        options.allowPartial = partial
+        return try serializedBytes(options: options)
     }
 
     /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes` value

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
@@ -207,31 +207,48 @@ extension Message {
     /// format serialization of the message.
     ///
     /// - Parameters:
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` before encoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``BinaryEncodingError/missingRequiredFields``.
     /// - Returns: A `Data` instance containing the binary serialization of the message.
     /// - Throws: ``BinaryEncodingError`` if encoding fails.
-    public func serializedData(partial: Bool = false) throws -> Data {
-        try serializedBytes(partial: partial, options: BinaryEncodingOptions())
+    @available(*, deprecated, message: "Use serializedData(options:) with options.allowPartial instead")
+    public func serializedData(partial: Bool) throws -> Data {
+        var options = BinaryEncodingOptions()
+        options.allowPartial = partial
+        return try serializedData(options: options)
     }
 
     /// Returns a `Data` instance containing the Protocol Buffer binary
     /// format serialization of the message.
     ///
     /// - Parameters:
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` before encoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryEncodingError/missingRequiredFields``.
     ///   - options: The ``BinaryEncodingOptions`` to use.
     /// - Returns: A `Data` instance containing the binary serialization of the message.
     /// - Throws: ``BinaryEncodingError`` if encoding fails.
     public func serializedData(
-        partial: Bool = false,
         options: BinaryEncodingOptions = BinaryEncodingOptions()
     ) throws -> Data {
-        try serializedBytes(partial: partial, options: options)
+        try serializedBytes(options: options)
+    }
+
+    /// Returns a `Data` instance containing the Protocol Buffer binary
+    /// format serialization of the message.
+    ///
+    /// - Parameters:
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryEncodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryEncodingOptions`` to use.
+    /// - Returns: A `Data` instance containing the binary serialization of the message.
+    /// - Throws: ``BinaryEncodingError`` if encoding fails.
+    @available(*, deprecated, message: "Use serializedData(options:) with options.allowPartial instead")
+    public func serializedData(
+        partial: Bool,
+        options: BinaryEncodingOptions = BinaryEncodingOptions()
+    ) throws -> Data {
+        var options = options
+        options.allowPartial = partial
+        return try serializedData(options: options)
     }
 }

--- a/Sources/SwiftProtobuf/MessageStorage+BinaryEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+BinaryEncoding.swift
@@ -18,11 +18,8 @@ extension MessageStorage {
     /// Serializes the message represented by this storage into binary format and returns the
     /// corresponding bytes.
     func serializedBytes<Bytes: SwiftProtobufContiguousBytes>(
-        partial: Bool,
         options: BinaryEncodingOptions
     ) throws -> Bytes {
-        var options = options
-        options.checkRequiredFields = !partial
 
         // Note that this assumes `options` will not change the required size.
         let requiredSize = serializedBytesSize()
@@ -53,7 +50,7 @@ extension MessageStorage {
     /// A recursion helper that serializes the message represented by this storage into the given
     /// binary encoder.
     func serializeBytes(into encoder: inout BinaryEncoder, options: BinaryEncodingOptions) throws {
-        if options.checkRequiredFields && !isMessageInitializedShallow {
+        if !options.allowPartial && !isMessageInitializedShallow {
             throw BinaryEncodingError.missingRequiredFields
         }
 

--- a/Sources/SwiftProtobuf/MessageStorage+JSONDecoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+JSONDecoding.swift
@@ -548,7 +548,9 @@ extension MessageStorage {
         }
 
         updateValue(of: typeURLField, to: typeURL)
-        updateValue(of: valueField, to: try messageStorage.serializedBytes(partial: true, options: BinaryEncodingOptions()))
+        var options = BinaryEncodingOptions()
+        options.allowPartial = true
+        updateValue(of: valueField, to: try messageStorage.serializedBytes(options: options))
     }
 
     /// Parses the next quoted string from the input and interprets it as the JSON representation

--- a/Sources/SwiftProtobuf/MessageStorage+TextDecoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+TextDecoding.swift
@@ -220,9 +220,11 @@ extension MessageStorage {
         }
 
         updateValue(of: KnownField.anyTypeURL(in: schema), to: typeURL)
+        var options = BinaryEncodingOptions()
+        options.allowPartial = true
         updateValue(
             of: KnownField.anyValue(in: schema),
-            to: try messageStorage.serializedBytes(partial: true, options: BinaryEncodingOptions())
+            to: try messageStorage.serializedBytes(options: options)
         )
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Required.swift
+++ b/Tests/SwiftProtobufTests/Test_Required.swift
@@ -471,7 +471,9 @@ final class Test_Required: XCTestCase, PBTestHelpers {
         line: UInt = #line
     ) {
         do {
-            let data: [UInt8] = try message.serializedBytes(partial: true)
+            var options = BinaryEncodingOptions()
+            options.allowPartial = true
+            let data: [UInt8] = try message.serializedBytes(options: options)
             XCTAssertEqual(data, expectedBytes, "While encoding \(message)", file: file, line: line)
         } catch let e {
             XCTFail("Encoding failed with error: \(e) for \(message)", file: file, line: line)
@@ -644,7 +646,9 @@ final class Test_SmallRequired: XCTestCase, PBTestHelpers {
         line: UInt = #line
     ) {
         do {
-            let data: [UInt8] = try message.serializedBytes(partial: true)
+            var options = BinaryEncodingOptions()
+            options.allowPartial = true
+            let data: [UInt8] = try message.serializedBytes(options: options)
             XCTAssertEqual(data, expectedBytes, "While encoding \(message)", file: file, line: line)
         } catch let e {
             XCTFail("Encoding failed with error: \(e) for \(message)", file: file, line: line)


### PR DESCRIPTION
- Rename `BinaryEncodingOption` `checkRequiredFields` to `allowPartial`
- Deprecate the apis taking the `partial` argument and make the options the path forward.
- Remove the use of `partial` as an argument to internal binary encoding apis.
- Update the tests to move off the deprecated apis.