### PR TITLE
[table-driven-branch] Pull the plugin changes to the branch.

### DIFF
--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -6,7 +6,7 @@ struct SwiftProtobufPlugin {
     /// Errors thrown by the `SwiftProtobufPlugin`
     enum PluginError: Error, CustomStringConvertible {
         /// Indicates that the target where the plugin was applied to was not `SourceModuleTarget`.
-        case invalidTarget(Target)
+        case invalidTarget(String)
         /// Indicates that the file extension of an input file was not `.proto`.
         case invalidInputFileExtension(String)
         /// Indicates that there was no configuration file at the required location.
@@ -15,7 +15,7 @@ struct SwiftProtobufPlugin {
         var description: String {
             switch self {
             case let .invalidTarget(target):
-                return "Expected a SwiftSourceModuleTarget but got '\(type(of: target))'."
+                return "Expected a SwiftSourceModuleTarget but got '\(target)'."
             case let .invalidInputFileExtension(path):
                 return "The input file '\(path)' does not have a '.proto' extension."
             case let .noConfigFound(path):
@@ -76,7 +76,32 @@ struct SwiftProtobufPlugin {
                 }
             }
 
+            enum EnumGeneration: String, Codable {
+                /// No `@nonexhaustive` attribute is emitted (default).
+                /// Open proto enums are annotated with `@nonexhaustive`.
+                case none = "None"
+                case nonexhaustive = "Nonexhaustive"
+                /// Open proto enums are annotated with `@nonexhaustive(warn)`.
+                case nonexhaustiveWarn = "NonexhaustiveWarn"
+
+                init?(rawValue: String) {
+                    switch rawValue.lowercased() {
+                    case "none":
+                        self = .none
+                    case "nonexhaustive":
+                        self = .nonexhaustive
+                    case "nonexhaustivewarn":
+                        self = .nonexhaustiveWarn
+                    default:
+                        return nil
+                    }
+                }
+            }
+
             /// An array of paths to `.proto` files for this invocation.
+            ///
+            /// If the `protoPath` parameter is specified, the files must be specified
+            /// relative to that directory. Otherwise, relative to the target source directory.
             var protoFiles: [String]
             /// The visibility of the generated files.
             var visibility: Visibility?
@@ -86,6 +111,17 @@ struct SwiftProtobufPlugin {
             var implementationOnlyImports: Bool?
             /// Whether import statements should be preceded with visibility.
             var useAccessLevelOnImports: Bool?
+            /// The enum generation strategy to use.
+            var enumGeneration: EnumGeneration?
+            /// Overrides the base directory used to find protobuf files.
+            ///
+            /// This must be specified as a path relative to the target source directory.
+            /// For example, if you are storing the protofiles at `MyLibrary/Sources/MyLib/protos`,
+            /// you should specify `protos` as the value for this parameter.
+            ///
+            /// If you have multiple subdirectories you wish to include,
+            /// you should specify multiple `invocations` instead.
+            var protoPath: String?
         }
 
         /// The path to the `protoc` binary.
@@ -107,40 +143,40 @@ struct SwiftProtobufPlugin {
     ///   - tool: The tool method from the context.
     /// - Returns: The build commands configured based on the arguments.
     func createBuildCommands(
-        pluginWorkDirectory: PackagePlugin.Path,
+        pluginWorkDirectory: URL,
         sourceFiles: FileList,
         tool: (String) throws -> PackagePlugin.PluginContext.Tool
     ) throws -> [Command] {
         guard
             let configurationFilePath = sourceFiles.first(
                 where: {
-                    $0.path.lastComponent == Self.configurationFileName
+                    $0.url.lastPathComponent == Self.configurationFileName
                 }
-            )?.path
+            )?.url
         else {
             throw PluginError.noConfigFound(Self.configurationFileName)
         }
-        let data = try Data(contentsOf: URL(fileURLWithPath: "\(configurationFilePath)"))
+        let data = try Data(contentsOf: configurationFilePath)
         let configuration = try JSONDecoder().decode(Configuration.self, from: data)
         try validateConfiguration(configuration)
 
         // We need to find the path of protoc and protoc-gen-swift
-        let protocPath: Path
+        let protocPath: URL
         if let configuredProtocPath = configuration.protocPath {
             // The user set the config path in the file. So let's take that
-            protocPath = Path(configuredProtocPath)
+            protocPath = URL(fileURLWithPath: configuredProtocPath)
         } else if let environmentPath = ProcessInfo.processInfo.environment["PROTOC_PATH"] {
             // The user set the env variable. So let's take that
-            protocPath = Path(environmentPath)
+            protocPath = URL(fileURLWithPath: environmentPath)
         } else {
             // The user didn't set anything so let's try see if SPM can find a binary for us
-            protocPath = try tool("protoc").path
+            protocPath = try tool("protoc").url
         }
-        let protocGenSwiftPath = try tool("protoc-gen-swift").path
+        let protocGenSwiftPath = try tool("protoc-gen-swift").url
 
         return configuration.invocations.map { invocation in
             self.invokeProtoc(
-                directory: configurationFilePath.removingLastComponent(),
+                directory: configurationFilePath.deletingLastPathComponent(),
                 invocation: invocation,
                 protocPath: protocPath,
                 protocGenSwiftPath: protocGenSwiftPath,
@@ -159,22 +195,27 @@ struct SwiftProtobufPlugin {
     ///   - outputDirectory: The output directory for the generated files.
     /// - Returns: The build command configured based on the arguments.
     private func invokeProtoc(
-        directory: PackagePlugin.Path,
+        directory: URL,
         invocation: Configuration.Invocation,
-        protocPath: Path,
-        protocGenSwiftPath: Path,
-        outputDirectory: Path
+        protocPath: URL,
+        protocGenSwiftPath: URL,
+        outputDirectory: URL
     ) -> Command {
         // Construct the `protoc` arguments.
         var protocArgs = [
-            "--plugin=protoc-gen-swift=\(protocGenSwiftPath)",
-            "--swift_out=\(outputDirectory)",
+            "--plugin=protoc-gen-swift=\(protocGenSwiftPath.fileSystemPath)",
+            "--swift_out=\(outputDirectory.fileSystemPath)",
         ]
 
-        // We need to add the target directory as a search path since we require the user to specify
-        // the proto files relative to it.
+        let protoDirectory =
+            if let protoPath = invocation.protoPath {
+                directory.appending(path: protoPath)
+            } else {
+                directory
+            }
+
         protocArgs.append("-I")
-        protocArgs.append("\(directory)")
+        protocArgs.append(protoDirectory.fileSystemPath)
 
         // Add the visibility if it was set
         if let visibility = invocation.visibility {
@@ -196,20 +237,24 @@ struct SwiftProtobufPlugin {
             protocArgs.append("--swift_opt=UseAccessLevelOnImports=\(useAccessLevelOnImports)")
         }
 
-        var inputFiles = [Path]()
-        var outputFiles = [Path]()
+        // Add the enum generation strategy if it was set
+        if let enumGeneration = invocation.enumGeneration {
+            protocArgs.append("--swift_opt=EnumGeneration=\(enumGeneration.rawValue)")
+        }
+        var inputFiles = [URL]()
+        var outputFiles = [URL]()
 
         for var file in invocation.protoFiles {
             // Append the file to the protoc args so that it is used for generating
-            protocArgs.append("\(file)")
-            inputFiles.append(directory.appending(file))
+            protocArgs.append(file)
+            inputFiles.append(protoDirectory.appending(path: file))
 
             // The name of the output file is based on the name of the input file.
             // We validated in the beginning that every file has the suffix of .proto
             // This means we can just drop the last 5 elements and append the new suffix
             file.removeLast(5)
             file.append("pb.swift")
-            let protobufOutputPath = outputDirectory.appending(file)
+            let protobufOutputPath = outputDirectory.appending(path: file)
 
             // Add the outputPath as an output file
             outputFiles.append(protobufOutputPath)
@@ -245,13 +290,23 @@ extension SwiftProtobufPlugin: BuildToolPlugin {
         target: Target
     ) async throws -> [Command] {
         guard let swiftTarget = target as? SwiftSourceModuleTarget else {
-            throw PluginError.invalidTarget(target)
+            throw PluginError.invalidTarget(String(describing: type(of: target)))
         }
         return try createBuildCommands(
-            pluginWorkDirectory: context.pluginWorkDirectory,
+            pluginWorkDirectory: context.pluginWorkDirectoryURL,
             sourceFiles: swiftTarget.sourceFiles,
             tool: context.tool
         )
+    }
+}
+
+extension URL {
+    fileprivate var fileSystemPath: String {
+        #if canImport(Darwin)
+        return self.path(percentEncoded: false)
+        #else
+        return self.path()
+        #endif
     }
 }
 
@@ -264,7 +319,7 @@ extension SwiftProtobufPlugin: XcodeBuildToolPlugin {
         target: XcodeTarget
     ) throws -> [Command] {
         try createBuildCommands(
-            pluginWorkDirectory: context.pluginWorkDirectory,
+            pluginWorkDirectory: context.pluginWorkDirectoryURL,
             sourceFiles: target.inputFiles,
             tool: context.tool
         )


### PR DESCRIPTION
This includes the newer options that aren't supported, but gets all the warnings to go away when building with newer Swift versions.