### PR TITLE
[table-driven-branch] Add `allowPartial` to `BinaryDecodingOptions`.

### DIFF
--- a/Sources/SwiftProtobuf/AsyncMessageSequence.swift
+++ b/Sources/SwiftProtobuf/AsyncMessageSequence.swift
@@ -23,21 +23,47 @@ extension AsyncSequence where Element == UInt8 {
     ///   - messageType: The type of message to read.
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any extensions in
     ///    messages encoded by this sequence, or in messages nested within these messages.
-    ///   - partial: If `false` (the default),  after decoding a message, ``Message/isInitialized-6abgi`
-    ///     will be checked to ensure all fields are present.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Returns: An asynchronous sequence of messages read from the `AsyncSequence` of bytes.
     @inlinable
     public func binaryProtobufDelimitedMessages<M: Message>(
         of messageType: M.Type = M.self,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) -> AsyncMessageSequence<Self, M> {
         AsyncMessageSequence<Self, M>(
             base: self,
             extensions: extensions,
-            partial: partial,
+            options: options
+        )
+    }
+
+    /// Creates an asynchronous sequence of size-delimited messages from this sequence of bytes.
+    /// Delimited format allows a single file or stream to contain multiple messages. A delimited message
+    /// is a varint encoding the message size followed by a message of exactly that size.
+    ///
+    /// - Parameters:
+    ///   - messageType: The type of message to read.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any extensions in
+    ///    messages encoded by this sequence, or in messages nested within these messages.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Returns: An asynchronous sequence of messages read from the `AsyncSequence` of bytes.
+    @available(*, deprecated, message: "Use binaryProtobufDelimitedMessages(of:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    public func binaryProtobufDelimitedMessages<M: Message>(
+        of messageType: M.Type = M.self,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) -> AsyncMessageSequence<Self, M> {
+        var options = options
+        options.allowPartial = partial
+        return binaryProtobufDelimitedMessages(
+            of: messageType,
+            extensions: extensions,
             options: options
         )
     }
@@ -55,7 +81,6 @@ public struct AsyncMessageSequence<
 
     private let base: Base
     private let extensions: Optional<ExtensionMap>
-    private let partial: Bool
     private let options: BinaryDecodingOptions
 
     /// Reads size-delimited messages from the given sequence of bytes. Delimited
@@ -66,20 +91,41 @@ public struct AsyncMessageSequence<
     ///   - base: The `AsyncSequence` to read messages from.
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any extensions in
     ///    messages encoded by this sequence, or in messages nested within these messages.
-    ///   - partial: If `false` (the default), after decoding a message, ``Message/isInitialized-6abgi``
-    ///     will be checked to ensure all fields are present.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Returns: An asynchronous sequence of messages read from the `AsyncSequence` of bytes.
     public init(
         base: Base,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) {
         self.base = base
         self.extensions = extensions
-        self.partial = partial
         self.options = options
+    }
+
+    /// Reads size-delimited messages from the given sequence of bytes. Delimited
+    /// format allows a single file or stream to contain multiple messages. A delimited message
+    /// is a varint encoding the message size followed by a message of exactly that size.
+    ///
+    /// - Parameters:
+    ///   - base: The `AsyncSequence` to read messages from.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any extensions in
+    ///    messages encoded by this sequence, or in messages nested within these messages.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Returns: An asynchronous sequence of messages read from the `AsyncSequence` of bytes.
+    @available(*, deprecated, message: "Use init(base:extensions:options:) with options.allowPartial instead")
+    public init(
+        base: Base,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) {
+        var options = options
+        options.allowPartial = partial
+        self.init(base: base, extensions: extensions, options: options)
     }
 
     /// An asynchronous iterator that produces the messages of this asynchronous sequence.
@@ -89,19 +135,15 @@ public struct AsyncMessageSequence<
         @usableFromInline
         let extensions: Optional<ExtensionMap>
         @usableFromInline
-        let partial: Bool
-        @usableFromInline
         let options: BinaryDecodingOptions
 
         init(
             iterator: Base.AsyncIterator,
             extensions: ExtensionMap?,
-            partial: Bool,
             options: BinaryDecodingOptions
         ) {
             self.iterator = iterator
             self.extensions = extensions
-            self.partial = partial
             self.options = options
         }
 
@@ -181,7 +223,6 @@ public struct AsyncMessageSequence<
                 return try M(
                     serializedBytes: [],
                     extensions: extensions,
-                    partial: partial,
                     options: options
                 )
             }
@@ -189,7 +230,6 @@ public struct AsyncMessageSequence<
             return try M(
                 serializedBytes: buffer,
                 extensions: extensions,
-                partial: partial,
                 options: options
             )
         }
@@ -204,7 +244,6 @@ public struct AsyncMessageSequence<
         AsyncIterator(
             iterator: base.makeAsyncIterator(),
             extensions: extensions,
-            partial: partial,
             options: options
         )
     }

--- a/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
+++ b/Sources/SwiftProtobuf/BinaryDecodingOptions.swift
@@ -35,8 +35,17 @@ public struct BinaryDecodingOptions: Sendable {
     /// object graph being created.
     public var discardUnknownFields: Bool
 
+    /// Whether to allow partial messages (i.e., messages with missing required fields) to be
+    /// decoded.
+    ///
+    /// If `false` (the default), the decoder will check that all required fields are present in
+    /// the message (recursively checking any nested submessages) after decoding. If any are
+    /// missing, the decoder will throw ``BinaryDecodingError/missingRequiredFields``.
+    public var allowPartial: Bool
+
     public init() {
         self.messageDepthLimit = 100
         self.discardUnknownFields = false
+        self.allowPartial = false
     }
 }

--- a/Sources/SwiftProtobuf/BinaryDelimited.swift
+++ b/Sources/SwiftProtobuf/BinaryDelimited.swift
@@ -120,10 +120,6 @@ public enum BinaryDelimited {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Returns: The message read.
     /// - Throws: ``BinaryDelimited/Error`` or ``SwiftProtobufError`` if decoding fails,
@@ -132,7 +128,6 @@ public enum BinaryDelimited {
         messageType: M.Type,
         from stream: InputStream,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws -> M {
         var message = M()
@@ -140,10 +135,47 @@ public enum BinaryDelimited {
             into: &message,
             from: stream,
             extensions: extensions,
-            partial: partial,
             options: options
         )
         return message
+    }
+
+    /// Reads a single size-delimited message from the given stream. Delimited
+    /// format allows a single file or stream to contain multiple messages,
+    /// whereas normally parsing consumes the entire input. A delimited message
+    /// is a varint encoding the message size followed by a message of exactly
+    /// exactly that size.
+    ///
+    /// - Parameters:
+    ///   - messageType: The type of message to read.
+    ///   - stream: The `InputStream` to read the data from.  The stream is assumed
+    ///     to be ready to read from.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Returns: The message read.
+    /// - Throws: ``BinaryDelimited/Error`` or ``SwiftProtobufError`` if decoding fails,
+    /// some reading errors; or the underlying `InputStream.streamError` for a stream error.
+    @available(*, deprecated, message: "Use parse(messageType:from:extensions:options:) with options.allowPartial instead")
+    public static func parse<M: Message>(
+        messageType: M.Type,
+        from stream: InputStream,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws -> M {
+        var options = options
+        options.allowPartial = partial
+        return try parse(
+            messageType: messageType,
+            from: stream,
+            extensions: extensions,
+            options: options
+        )
     }
 
     /// Updates the message by reading a single size-delimited message from
@@ -163,10 +195,6 @@ public enum BinaryDelimited {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDelimited/Error/missingRequiredFields``.
     ///   - options: The BinaryDecodingOptions to use.
     /// - Throws: ``BinaryDelimited/Error`` or ``SwiftProtobufError`` if decoding fails,
     /// and for some reading errors; or the underlying `InputStream.streamError` for a stream error.
@@ -174,7 +202,6 @@ public enum BinaryDelimited {
         into message: inout M,
         from stream: InputStream,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         let unsignedLength = try decodeVarint(stream)
@@ -228,7 +255,48 @@ public enum BinaryDelimited {
         try message.merge(
             serializedBytes: data,
             extensions: extensions,
-            partial: partial,
+            options: options
+        )
+    }
+
+    /// Updates the message by reading a single size-delimited message from
+    /// the given stream. Delimited format allows a single file or stream to
+    /// contain multiple messages, whereas normally parsing consumes the entire
+    /// input. A delimited message is a varint encoding the message size
+    /// followed by a message of exactly that size.
+    ///
+    /// - Note: If this method throws an error, the message may still have been
+    ///   partially mutated by the binary data that was decoded before the error
+    ///   occurred.
+    ///
+    /// - Parameters:
+    ///   - message: The message to merge the data into.
+    ///   - stream: The `InputStream` to read the data from.  The stream is assumed
+    ///     to be ready to read from.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will check
+    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
+    ///     fields are present. If any are missing, this method throws
+    ///     ``BinaryDelimited/Error/missingRequiredFields``.
+    ///   - options: The BinaryDecodingOptions to use.
+    /// - Throws: ``BinaryDelimited/Error`` or ``SwiftProtobufError`` if decoding fails,
+    /// and for some reading errors; or the underlying `InputStream.streamError` for a stream error.
+    @available(*, deprecated, message: "Use merge(into:from:extensions:options:) with options.allowPartial instead")
+    public static func merge<M: Message>(
+        into message: inout M,
+        from stream: InputStream,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        var options = options
+        options.allowPartial = partial
+        try merge(
+            into: &message,
+            from: stream,
+            extensions: extensions,
             options: options
         )
     }

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -61,21 +61,44 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     @inlinable
     public init<Bytes: SwiftProtobufContiguousBytes>(
         serializedBytes bytes: Bytes,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         self.init()
-        try merge(serializedBytes: bytes, extensions: extensions, partial: partial, options: options)
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
+    }
+
+    /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes` value
+    /// containing a serialized message in Protocol Buffer binary format.
+    ///
+    /// - Parameters:
+    /// - Parameters:
+    ///   - bytes: The binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @available(*, deprecated, message: "Use init(serializedBytes:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    public init<Bytes: SwiftProtobufContiguousBytes>(
+        serializedBytes bytes: Bytes,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        self.init()
+        var options = options
+        options.allowPartial = partial
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
     }
 
     #if compiler(>=6.2)
@@ -87,10 +110,6 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     @inlinable
@@ -98,11 +117,39 @@ extension Message {
     public init(
         serializedBytes bytes: RawSpan,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         self.init()
-        try merge(serializedBytes: bytes, extensions: extensions, partial: partial, options: options)
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
+    }
+
+    /// Creates a new message by decoding the bytes provided by a `RawSpan`
+    /// containing a serialized message in Protocol Buffer binary format.
+    ///
+    /// - Parameters:
+    /// - Parameters:
+    ///   - bytes: The `RawSpan` of binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @available(*, deprecated, message: "Use init(serializedBytes:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+    public init(
+        serializedBytes bytes: RawSpan,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        self.init()
+        var options = options
+        options.allowPartial = partial
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
     }
     #endif
 
@@ -119,22 +166,49 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     @inlinable
     public mutating func merge<Bytes: SwiftProtobufContiguousBytes>(
         serializedBytes bytes: Bytes,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
-            try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
+            try _merge(rawBuffer: body, extensions: extensions, options: options)
         }
+    }
+
+    /// Updates the message by decoding the given `SwiftProtobufContiguousBytes` value
+    /// containing a serialized message in Protocol Buffer binary format into the
+    /// receiver.
+    ///
+    /// - Note: If this method throws an error, the message may still have been
+    ///   partially mutated by the binary data that was decoded before the error
+    ///   occurred.
+    ///
+    /// - Parameters:
+    /// - Parameters:
+    ///   - bytes: The binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @available(*, deprecated, message: "Use merge(serializedBytes:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    public mutating func merge<Bytes: SwiftProtobufContiguousBytes>(
+        serializedBytes bytes: Bytes,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        var options = options
+        options.allowPartial = partial
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
     }
 
     #if compiler(>=6.2)
@@ -150,10 +224,6 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     @inlinable
@@ -161,12 +231,43 @@ extension Message {
     public mutating func merge(
         serializedBytes bytes: RawSpan,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
-            try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
+            try _merge(rawBuffer: body, extensions: extensions, options: options)
         }
+    }
+
+    /// Updates the message by decoding the bytes provided by a `RawSpan` containing
+    /// a serialized message in Protocol Buffer binary format into the receiver.
+    ///
+    /// - Note: If this method throws an error, the message may still have been
+    ///   partially mutated by the binary data that was decoded before the error
+    ///   occurred.
+    ///
+    /// - Parameters:
+    /// - Parameters:
+    ///   - bytes: The `RawSpan` of binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @available(*, deprecated, message: "Use merge(serializedBytes:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+    public mutating func merge(
+        serializedBytes bytes: RawSpan,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        var options = options
+        options.allowPartial = partial
+        try merge(serializedBytes: bytes, extensions: extensions, options: options)
     }
     #endif
 
@@ -178,10 +279,9 @@ extension Message {
     mutating func _merge(
         rawBuffer body: UnsafeRawBufferPointer,
         extensions: ExtensionMap?,
-        partial: Bool,
         options: BinaryDecodingOptions
     ) throws {
         _protobuf_ensureUniqueStorage(accessToken: MessageStorageToken())
-        try storageForRuntime.merge(byReadingFrom: body, extensions: extensions, partial: partial, options: options)
+        try storageForRuntime.merge(byReadingFrom: body, extensions: extensions, options: options)
     }
 }

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
@@ -25,9 +25,8 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
@@ -51,9 +50,8 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``SwiftProtobufError/BinaryDecoding/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``SwiftProtobufError`` if decoding fails.
@@ -78,9 +76,8 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``SwiftProtobufError/BinaryDecoding/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``SwiftProtobufError`` if decoding fails.
@@ -115,9 +112,8 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``SwiftProtobufError/BinaryDecoding/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``SwiftProtobufError`` if decoding fails.
@@ -130,8 +126,10 @@ extension Message {
         partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
+        var options = options
+        options.allowPartial = partial
         try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
-            try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
+            try _merge(rawBuffer: body, extensions: extensions, options: options)
         }
     }
 
@@ -148,9 +146,8 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``SwiftProtobufError/BinaryDecoding/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``SwiftProtobufError`` if decoding fails.
@@ -168,8 +165,10 @@ extension Message {
         partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
+        var options = options
+        options.allowPartial = partial
         try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
-            try _merge(rawBuffer: body, extensions: extensions, partial: partial, options: options)
+            try _merge(rawBuffer: body, extensions: extensions, options: options)
         }
     }
     #endif  // !REMOVE_DEPRECATED_APIS
@@ -187,20 +186,46 @@ extension Message {
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     @inlinable
     public mutating func merge(
         serializedData data: Data,
         extensions: ExtensionMap? = nil,
-        partial: Bool = false,
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
-        try merge(serializedBytes: data, extensions: extensions, partial: partial, options: options)
+        try merge(serializedBytes: data, extensions: extensions, options: options)
+    }
+
+    /// Updates the message by decoding the given `Data` value
+    /// containing a serialized message in Protocol Buffer binary format into the
+    /// receiver.
+    ///
+    /// - Note: If this method throws an error, the message may still have been
+    ///   partially mutated by the binary data that was decoded before the error
+    ///   occurred.
+    ///
+    /// - Parameters:
+    ///   - data: The binary-encoded message data to decode.
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
+    ///     extensions in this message or messages nested within this message's
+    ///     fields.
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
+    ///     ``BinaryDecodingError/missingRequiredFields``.
+    ///   - options: The ``BinaryDecodingOptions`` to use.
+    /// - Throws: ``BinaryDecodingError`` if decoding fails.
+    @available(*, deprecated, message: "Use merge(serializedData:extensions:options:) with options.allowPartial instead")
+    @inlinable
+    public mutating func merge(
+        serializedData data: Data,
+        extensions: ExtensionMap? = nil,
+        partial: Bool,
+        options: BinaryDecodingOptions = BinaryDecodingOptions()
+    ) throws {
+        var options = options
+        options.allowPartial = partial
+        try merge(serializedData: data, extensions: extensions, options: options)
     }
 
     /// Returns a `Data` instance containing the Protocol Buffer binary

--- a/Sources/SwiftProtobuf/MessageStorage+BinaryDecoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+BinaryDecoding.swift
@@ -25,23 +25,18 @@ extension MessageStorage {
     ///
     /// - Parameters:
     ///   - buffer: The binary-encoded message data to decode.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
-    ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     func merge(
         byReadingFrom buffer: UnsafeRawBufferPointer,
         extensions: ExtensionMap?,
-        partial: Bool,
         options: BinaryDecodingOptions
     ) throws {
         var reader = WireFormatReader(buffer: buffer, recursionBudget: options.messageDepthLimit)
         try merge(
             byReadingFrom: &reader,
             extensions: extensions,
-            partial: partial,
+            partial: options.allowPartial,
             discardUnknownFields: options.discardUnknownFields)
     }
 
@@ -49,9 +44,8 @@ extension MessageStorage {
     ///
     /// - Parameters:
     ///   - buffer: The binary-encoded message data to decode.
-    ///   - partial: If `false` (the default), this method will check
-    ///     ``Message/isInitialized-6abgi`` after decoding to verify that all required
-    ///     fields are present. If any are missing, this method throws
+    ///   - partial: If `false` (the default), this method will verify that all required
+    ///     fields are present before encoding. If any are missing, this method throws
     ///     ``BinaryDecodingError/missingRequiredFields``.
     ///   - discardUnknownFields: If true, unknown fields will be discarded during
     ///     parsing.

--- a/Sources/SwiftProtobuf/MessageStorage+JSONEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+JSONEncoding.swift
@@ -392,7 +392,7 @@ extension MessageStorage {
         let bytes = assumedPresentValue(at: valueField.offset) as Data
         try bytes.withUnsafeBytes { buffer in
             let messageStorage = MessageStorage(schema: messageSchema)
-            try messageStorage.merge(byReadingFrom: buffer, extensions: options.extensions, partial: false, options: BinaryDecodingOptions())
+            try messageStorage.merge(byReadingFrom: buffer, extensions: options.extensions, options: BinaryDecodingOptions())
             try messageStorage.serializeJSON(into: &encoder, options: options, shouldInlineFields: !isWKT)
         }
     }

--- a/Sources/SwiftProtobuf/MessageStorage+TextEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+TextEncoding.swift
@@ -64,7 +64,6 @@ extension MessageStorage {
                     try messageStorage.merge(
                         byReadingFrom: buffer,
                         extensions: options.extensions,
-                        partial: false,
                         options: BinaryDecodingOptions()
                     )
                 }

--- a/Tests/SwiftProtobufTests/Test_Required.swift
+++ b/Tests/SwiftProtobufTests/Test_Required.swift
@@ -370,7 +370,9 @@ final class Test_Required: XCTestCase, PBTestHelpers {
         line: UInt = #line
     ) {
         do {
-            let msg = try MessageTestType(serializedBytes: bytes, partial: true)
+            var options = BinaryDecodingOptions()
+            options.allowPartial = true
+            let msg = try MessageTestType(serializedBytes: bytes, options: options)
             var expected = "SwiftProtobufTests.SwiftProtoTesting_TestAllRequiredTypes:\n"
             if !expectedTextFormat.isEmpty {
                 expected += expectedTextFormat + "\n"
@@ -580,7 +582,9 @@ final class Test_SmallRequired: XCTestCase, PBTestHelpers {
         line: UInt = #line
     ) {
         do {
-            let msg = try MessageTestType(serializedBytes: bytes, partial: true)
+            var options = BinaryDecodingOptions()
+            options.allowPartial = true
+            let msg = try MessageTestType(serializedBytes: bytes, options: options)
             var expected = "SwiftProtobufTests.SwiftProtoTesting_TestSomeRequiredTypes:\n"
             if !expectedTextFormat.isEmpty {
                 expected += expectedTextFormat + "\n"


### PR DESCRIPTION
- Add new apis that don't take the `partial` argument for decoding.
- Deprecate the old apis that took `partial` and remap them to the new apis.
- Update the tests to all use the new apis.
- Update some of the internal apis over.