### PR TITLE
[table-driven-branch] Optimize required field validation during decoding

### DIFF
--- a/Sources/SwiftProtobuf/ExtensionStorage+BinaryDecoding.swift
+++ b/Sources/SwiftProtobuf/ExtensionStorage+BinaryDecoding.swift
@@ -21,6 +21,18 @@ extension ExtensionStorage {
     /// - Parameters:
     ///   - reader: The reader from which to read the next field's data.
     ///   - tag: The tag that was just read from the reader.
+    ///   - extensions: The extension map to use.
+    ///   - options: The decoding options.
+    ///   - unknownFields: The unknown fields storage.
+    ///   - isInitializedShallow: An `inout` boolean used to track if required fields are
+    ///     shallowly present across the entire message tree parsed so far. It is passed as `inout`
+    ///     because deep recursion and multi-pass partial updates (e.g. out-of-order fields)
+    ///     require accumulative status tracking across nested submessages and extensions (any
+    ///     missing required field in a nested submessage will set this to false, bubbling all the
+    ///     way up to the top-level caller), whereas the return value represents exclusively
+    ///     whether the field was successfully consumed by the parser. The caller is assumed to
+    ///     have initialized it to true before the first call, and it will be set to false if any
+    ///     message fails the initialization check while decoding.
     /// - Returns: True if the field was consumed, or false to indicate that it should be stored in
     ///   unknown fields (for example, because the field did not exist or the data on the wire did
     ///   not match the expected wire format)).
@@ -30,7 +42,8 @@ extension ExtensionStorage {
         tag: FieldTag,
         extensions: ExtensionMap?,
         options: BinaryDecodingOptions,
-        unknownFields: inout UnknownStorage
+        unknownFields: inout UnknownStorage,
+        isInitializedShallow: inout Bool
     ) throws -> Bool {
         guard tag.wireFormat != .endGroup else {
             // Just consume it; `nextTag` has already validated that it matches the last started
@@ -104,7 +117,8 @@ extension ExtensionStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -127,7 +141,8 @@ extension ExtensionStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -222,7 +237,8 @@ extension ExtensionStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -243,7 +259,8 @@ extension ExtensionStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -70,7 +70,9 @@ extension Message {
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         self.init()
-        try merge(serializedBytes: bytes, extensions: extensions, options: options)
+        try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+            try _parse(rawBuffer: body, extensions: extensions, options: options)
+        }
     }
 
     /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes` value
@@ -124,7 +126,9 @@ extension Message {
         options: BinaryDecodingOptions = BinaryDecodingOptions()
     ) throws {
         self.init()
-        try merge(serializedBytes: bytes, extensions: extensions, options: options)
+        try bytes.withUnsafeBytes { (body: UnsafeRawBufferPointer) in
+            try _parse(rawBuffer: body, extensions: extensions, options: options)
+        }
     }
 
     /// Creates a new message by decoding the bytes provided by a `RawSpan`
@@ -287,17 +291,57 @@ extension Message {
     }
     #endif
 
-    // Helper for `merge()`s to keep the Decoder internal to SwiftProtobuf while
-    // allowing the generic over `SwiftProtobufContiguousBytes` to get better codegen from the
-    // compiler by being `@inlinable`. For some discussion on this see
-    // https://github.com/apple/swift-protobuf/pull/914#issuecomment-555458153
+    // Helper for public methods that initialize a new instance. For some historical discussion on the
+    // inline usage, see https://github.com/apple/swift-protobuf/pull/914#issuecomment-555458153
+    @usableFromInline
+    mutating func _parse(
+        rawBuffer body: UnsafeRawBufferPointer,
+        extensions: ExtensionMap?,
+        options: BinaryDecodingOptions
+    ) throws {
+        _protobuf_ensureUniqueStorage(accessToken: MessageStorageToken())
+        var isShallowInitCheckPassed = true
+        try storageForRuntime.merge(
+            byReadingFrom: body,
+            extensions: extensions,
+            options: options,
+            isInitializedShallow: &isShallowInitCheckPassed
+        )
+        if !options.allowPartial && !isShallowInitCheckPassed {
+            // Fallback: A shallow check failure might be a false positive if a submessage was
+            // parsed as incomplete initially but completed by a subsequent payload block in the
+            // stream. We must run a full deep `isInitialized` check to verify actual completeness.
+            guard isInitialized else {
+                throw BinaryDecodingError.missingRequiredFields
+            }
+        }
+    }
+
+    // Helper for public methods that merge into existing instance. For some historical discussion
+    // on the inline usage, see https://github.com/apple/swift-protobuf/pull/914#issuecomment-555458153
     @usableFromInline
     mutating func _merge(
         rawBuffer body: UnsafeRawBufferPointer,
         extensions: ExtensionMap?,
         options: BinaryDecodingOptions
     ) throws {
+        // Optimization: Since we are merging into an existing message structure, we must
+        // always perform a final deep recursive `isInitialized` check at the end (because
+        // required fields in pre-existing submessages not present in the binary payload
+        // won't be visited during decoding). Therefore, we bypass all parsing-time shallow
+        // validation checks by setting `allowPartial = true` during the merge execution.
+        var subOptions = options
+        subOptions.allowPartial = true
         _protobuf_ensureUniqueStorage(accessToken: MessageStorageToken())
-        try storageForRuntime.merge(byReadingFrom: body, extensions: extensions, options: options)
+        var ignored = true
+        try storageForRuntime.merge(
+            byReadingFrom: body,
+            extensions: extensions,
+            options: subOptions,
+            isInitializedShallow: &ignored
+        )
+        if !options.allowPartial && !isInitialized {
+            throw BinaryDecodingError.missingRequiredFields
+        }
     }
 }

--- a/Sources/SwiftProtobuf/MessageStorage+BinaryDecoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+BinaryDecoding.swift
@@ -25,30 +25,47 @@ extension MessageStorage {
     ///
     /// - Parameters:
     ///   - buffer: The binary-encoded message data to decode.
+    ///   - extensions: The extension map to use.
     ///   - options: The ``BinaryDecodingOptions`` to use.
+    ///   - isInitializedShallow: An `inout` boolean used to track if required fields are
+    ///     shallowly present across the entire message tree parsed so far. It is passed as `inout`
+    ///     because deep recursion and multi-pass partial updates (e.g. out-of-order fields)
+    ///     require accumulative status tracking across nested submessages and extensions. The
+    ///     caller is assumed to have initialized it to true before the first call, and it will
+    ///     be set to false if any message fails the initialization check while decoding.
     /// - Throws: ``BinaryDecodingError`` if decoding fails.
     func merge(
         byReadingFrom buffer: UnsafeRawBufferPointer,
         extensions: ExtensionMap?,
-        options: BinaryDecodingOptions
+        options: BinaryDecodingOptions,
+        isInitializedShallow: inout Bool
     ) throws {
         var reader = WireFormatReader(buffer: buffer, recursionBudget: options.messageDepthLimit)
         try merge(
             byReadingFrom: &reader,
             extensions: extensions,
-            options: options
+            options: options,
+            isInitializedShallow: &isInitializedShallow
         )
     }
 
     /// Decodes field values from the given wire format reader into this storage class.
     ///
     /// - Parameters:
-    ///   - buffer: The binary-encoded message data to decode.
-    ///   - options: The ``BinaryDecodingOptions`` to use.
+    ///   - reader: The wire format reader from which to decode fields.
+    ///   - extensions: The extension map to use.
+    ///   - options: The decoding options.
+    ///   - isInitializedShallow: An `inout` boolean used to track if required fields are
+    ///     shallowly present across the entire message tree parsed so far. It is passed as `inout`
+    ///     because deep recursion and multi-pass partial updates (e.g. out-of-order fields)
+    ///     require accumulative status tracking across nested submessages and extensions. The
+    ///     caller is assumed to have initialized it to true before the first call, and it will
+    ///     be set to false if any message fails the initialization check while decoding.
     func merge(
         byReadingFrom reader: inout WireFormatReader,
         extensions: ExtensionMap?,
-        options: BinaryDecodingOptions
+        options: BinaryDecodingOptions,
+        isInitializedShallow: inout Bool
     ) throws {
         var mapEntryWorkingSpace = MapEntryWorkingSpace(ownerSchema: schema)
         while reader.hasAvailableData {
@@ -58,7 +75,8 @@ extension MessageStorage {
                 tag: tag,
                 extensions: extensions,
                 options: options,
-                mapEntryWorkingSpace: &mapEntryWorkingSpace
+                mapEntryWorkingSpace: &mapEntryWorkingSpace,
+                isInitializedShallow: &isInitializedShallow
             )
             if !consumed {
                 try decodeUnknownField(from: &reader, tag: tag, discard: options.discardUnknownFields)
@@ -69,9 +87,9 @@ extension MessageStorage {
             // group tracking state. If that didn't happen, then we ran out of data too early.
             throw BinaryDecodingError.truncated
         }
-        if !options.allowPartial && !isInitialized {
-            throw BinaryDecodingError.missingRequiredFields
-        }
+        // If partial decoding is not allowed, and we have any missing required fields, the message
+        // is not initialized.
+        isInitializedShallow = isInitializedShallow && (options.allowPartial || isMessageInitializedShallow)
     }
 
     /// Decodes the next field from the binary reader, assuming that its tag has already been read.
@@ -79,6 +97,18 @@ extension MessageStorage {
     /// - Parameters:
     ///   - reader: The reader from which to read the next field's data.
     ///   - tag: The tag that was just read from the reader.
+    ///   - extensions: The extension map to use.
+    ///   - options: The decoding options.
+    ///   - mapEntryWorkingSpace: Temporary storage used for map entries.
+    ///   - isInitializedShallow: An `inout` boolean used to track if required fields are
+    ///     shallowly present across the entire message tree parsed so far. It is passed as `inout`
+    ///     because deep recursion and multi-pass partial updates (e.g. out-of-order fields)
+    ///     require accumulative status tracking across nested submessages and extensions (any
+    ///     missing required field in a nested submessage will set this to false, bubbling all the
+    ///     way up to the top-level caller), whereas the return value represents exclusively
+    ///     whether the field was successfully consumed by the parser. The caller is assumed to
+    ///     have initialized it to true before the first call, and it will be set to false if any
+    ///     message fails the initialization check while decoding.
     /// - Returns: True if the field was consumed, or false to indicate that it should be stored in
     ///   unknown fields (for example, because the field did not exist or the data on the wire did
     ///   not match the expected wire format)).
@@ -87,7 +117,8 @@ extension MessageStorage {
         tag: FieldTag,
         extensions: ExtensionMap?,
         options: BinaryDecodingOptions,
-        mapEntryWorkingSpace: inout MapEntryWorkingSpace
+        mapEntryWorkingSpace: inout MapEntryWorkingSpace,
+        isInitializedShallow: inout Bool
     ) throws -> Bool {
         guard tag.wireFormat != .endGroup else {
             // Just consume it; `nextTag` has already validated that it matches the last started
@@ -102,7 +133,8 @@ extension MessageStorage {
                 return try decodeMessageSetItem(
                     from: &reader,
                     extensions: extensions,
-                    options: options
+                    options: options,
+                    isInitializedShallow: &isInitializedShallow
                 )
             }
             return false
@@ -121,7 +153,8 @@ extension MessageStorage {
                     tag: tag,
                     extensions: extensions,
                     options: options,
-                    unknownFields: &unknownFields
+                    unknownFields: &unknownFields,
+                    isInitializedShallow: &isInitializedShallow
                 )
             {
                 // The extension consumed the field so we're done.
@@ -144,7 +177,8 @@ extension MessageStorage {
                 try workingSpace.merge(
                     byReadingFrom: &subReader,
                     extensions: extensions,
-                    options: options
+                    options: options,
+                    isInitializedShallow: &isInitializedShallow
                 )
                 insertMapEntry(in: field, from: workingSpace)
                 success = true
@@ -227,7 +261,8 @@ extension MessageStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -250,7 +285,8 @@ extension MessageStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -345,7 +381,8 @@ extension MessageStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -366,7 +403,8 @@ extension MessageStorage {
                     try submessageStorage.merge(
                         byReadingFrom: &subReader,
                         extensions: extensions,
-                        options: options
+                        options: options,
+                        isInitializedShallow: &isInitializedShallow
                     )
                 }
 
@@ -640,7 +678,8 @@ extension MessageStorage {
     private func decodeMessageSetItem(
         from reader: inout WireFormatReader,
         extensions: ExtensionMap?,
-        options: BinaryDecodingOptions
+        options: BinaryDecodingOptions,
+        isInitializedShallow: inout Bool
     ) throws -> Bool {
         // This is loosely based on the C++:
         //   ExtensionSet::ParseMessageSetItem()
@@ -708,7 +747,8 @@ extension MessageStorage {
         try submessageStorage.merge(
             byReadingFrom: &subReader,
             extensions: extensions,
-            options: options
+            options: options,
+            isInitializedShallow: &isInitializedShallow
         )
         return true
     }

--- a/Sources/SwiftProtobuf/MessageStorage+JSONEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+JSONEncoding.swift
@@ -392,11 +392,19 @@ extension MessageStorage {
         let bytes = assumedPresentValue(at: valueField.offset) as Data
         try bytes.withUnsafeBytes { buffer in
             let messageStorage = MessageStorage(schema: messageSchema)
+            // TODO: Should we keep the original behavior of failing for required fields in JSON?
+            var isShallowInitCheckPassed = true
             try messageStorage.merge(
                 byReadingFrom: buffer,
                 extensions: options.extensions,
-                options: BinaryDecodingOptions()
+                options: BinaryDecodingOptions(),
+                isInitializedShallow: &isShallowInitCheckPassed
             )
+            if !isShallowInitCheckPassed {
+                guard messageStorage.isInitialized else {
+                    throw BinaryDecodingError.missingRequiredFields
+                }
+            }
             try messageStorage.serializeJSON(into: &encoder, options: options, shouldInlineFields: !isWKT)
         }
     }

--- a/Sources/SwiftProtobuf/MessageStorage+TextEncoding.swift
+++ b/Sources/SwiftProtobuf/MessageStorage+TextEncoding.swift
@@ -61,10 +61,15 @@ extension MessageStorage {
             let bytes: Data = value(of: valueField)
             do {
                 try bytes.withUnsafeBytes { buffer in
+                    // We still want the expanded verbose output even if the submessage is partial.
+                    var decodingOptions = BinaryDecodingOptions()
+                    decodingOptions.allowPartial = true
+                    var ignored = true
                     try messageStorage.merge(
                         byReadingFrom: buffer,
                         extensions: options.extensions,
-                        options: BinaryDecodingOptions()
+                        options: decodingOptions,
+                        isInitializedShallow: &ignored
                     )
                 }
                 encoder.emitExtensionFieldName(name: typeURL)


### PR DESCRIPTION
Like we did in encoding, do the validation while working on the message graph. However, there are two issues that prevent directly raising when we find a missing required field:

1.  It would throw a false positive failure if an incomplete message is seen on the wire but is later completed when the sub-message occurs again. This could happen with say binary blobs concatenated together.

2.  It would return a false success if you are decoding into a message that already has some sub-message fields present (merging). If the sub-message does not occur in the binary payload, we will never visit it and discover the incomplete sub-message.

To deal with these, we do the validation along the way and expose that issue to the caller as a hint. Then the top most layers can use that information along with the operation being done (merge vs. new load) to decided if `isInitialized` still needs to be called.

Since some of the decoding apis already have return result to indicate if things should go into unknown fields, we use a boolean `inout` parameter. This also make things slightly more clear then a boolean return result from a "merge" that isn't some sort of success/failure.

TextFormat decode of an Any doesn't bother with the validation since the expanded output would be better.