### PR TITLE
[table-driven-branch] Little encoding cleaning.

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -69,8 +69,6 @@ internal struct JSONEncoder {
 
     internal init() {}
 
-    internal var dataResult: [UInt8] { data }
-
     internal var stringResult: String {
         get {
             String(decoding: data, as: UTF8.self)

--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -26,8 +26,9 @@ extension Message {
     ///   - options: The JSONEncodingOptions to use.
     /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
     public func jsonString(options: JSONEncodingOptions = JSONEncodingOptions()) throws -> String {
-        let data: [UInt8] = try jsonUTF8Bytes(options: options)
-        return String(decoding: data, as: UTF8.self)
+        var encoder = JSONEncoder()
+        try storageForRuntime.serializeJSON(into: &encoder, options: options)
+        return encoder.stringResult
     }
 
     /// Returns a `SwiftProtobufContiguousBytes` containing the UTF-8 JSON serialization of the message.

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -35,6 +35,7 @@ private let tab = [UInt8](repeating: asciiSpace, count: tabSize)
 internal struct TextFormatEncoder {
     private var data = [UInt8]()
     private var indentString: [UInt8] = []
+
     var stringResult: String {
         get {
             String(decoding: data, as: UTF8.self)


### PR DESCRIPTION
Remove unused apis.
Make sure we aren't doing some potential extra buffer copies.