### PR TITLE
Always use PathToUnderscores naming for SwiftPM plugin outputs

### DIFF
--- a/PluginExamples/Package.swift
+++ b/PluginExamples/Package.swift
@@ -66,6 +66,15 @@ let package = Package(
                 .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
             ]
         ),
+        .target(
+            name: "PathToUnderscores",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
         .testTarget(
             name: "ExampleTests",
             dependencies: [
@@ -76,6 +85,7 @@ let package = Package(
                 .target(name: "CustomProtoPath"),
                 .product(name: "Nonexhaustive", package: "Subpackage"),
                 .target(name: "UsesWKTs"),
+                .target(name: "PathToUnderscores"),
             ]
         ),
     ],

--- a/PluginExamples/Package@swift-6.1.swift
+++ b/PluginExamples/Package@swift-6.1.swift
@@ -65,6 +65,15 @@ let package = Package(
                 .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
             ]
         ),
+        .target(
+            name: "PathToUnderscores",
+            dependencies: [
+                .product(name: "SwiftProtobuf", package: "swift-protobuf")
+            ],
+            plugins: [
+                .plugin(name: "SwiftProtobufPlugin", package: "swift-protobuf")
+            ]
+        ),
         .testTarget(
             name: "ExampleTests",
             dependencies: [
@@ -74,6 +83,7 @@ let package = Package(
                 .target(name: "AccessLevelOnImport"),
                 .target(name: "CustomProtoPath"),
                 .target(name: "UsesWKTs"),
+                .target(name: "PathToUnderscores"),
             ]
         ),
     ],

--- a/PluginExamples/Sources/ExampleTests/ExampleTests.swift
+++ b/PluginExamples/Sources/ExampleTests/ExampleTests.swift
@@ -1,6 +1,7 @@
 import CustomProtoPath
 import Import
 import Nested
+import PathToUnderscores
 import Simple
 import UsesWKTs
 import XCTest
@@ -60,5 +61,16 @@ final class ExampleTests: XCTestCase {
         }
         XCTAssertEqual(usesWKTs.name, "UsesWKTs")
         XCTAssertEqual(usesWKTs.aTimestamp.seconds, 2)
+    }
+
+    // The two protos in this target share the file name Duplicate.proto in different
+    // subdirectories. The build only succeeds because the plugin generates them with
+    // PathToUnderscores naming, so they land in distinctly named files instead of
+    // colliding. This is the case reported in issue 1761.
+    func testPathToUnderscores() {
+        let foo = FooDuplicate.with { $0.name = "Foo" }
+        let bar = BarDuplicate.with { $0.name = "Bar" }
+        XCTAssertEqual(foo.name, "Foo")
+        XCTAssertEqual(bar.name, "Bar")
     }
 }

--- a/PluginExamples/Sources/PathToUnderscores/Proto/bar/Duplicate.proto
+++ b/PluginExamples/Sources/PathToUnderscores/Proto/bar/Duplicate.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message BarDuplicate {
+  string name = 1;
+}

--- a/PluginExamples/Sources/PathToUnderscores/Proto/foo/Duplicate.proto
+++ b/PluginExamples/Sources/PathToUnderscores/Proto/foo/Duplicate.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message FooDuplicate {
+  string name = 1;
+}

--- a/PluginExamples/Sources/PathToUnderscores/empty.swift
+++ b/PluginExamples/Sources/PathToUnderscores/empty.swift
@@ -1,0 +1,3 @@
+/// DO NOT DELETE.
+///
+/// We need to keep this file otherwise the plugin is not running.

--- a/PluginExamples/Sources/PathToUnderscores/swift-protobuf-config.json
+++ b/PluginExamples/Sources/PathToUnderscores/swift-protobuf-config.json
@@ -1,0 +1,11 @@
+{
+    "invocations": [
+        {
+            "protoFiles": [
+                "Proto/foo/Duplicate.proto",
+                "Proto/bar/Duplicate.proto",
+            ],
+            "visibility": "public"
+        }
+    ]
+}

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -11,8 +11,6 @@ struct SwiftProtobufPlugin {
         case invalidInputFileExtension(String)
         /// Indicates that there was no configuration file at the required location.
         case noConfigFound(String)
-        /// Indicates that the configuration set a `fileNaming` option the build plugin does not support.
-        case unsupportedFileNaming(String)
 
         var description: String {
             switch self {
@@ -24,13 +22,6 @@ struct SwiftProtobufPlugin {
                 return """
                     No configuration file found named '\(path)'. The file must not be listed in the \
                     'exclude:' argument for the target in Package.swift.
-                    """
-            case let .unsupportedFileNaming(value):
-                return """
-                    The 'fileNaming' option '\(value)' is not supported by the build plugin. The build \
-                    plugin always generates files using the 'PathToUnderscores' naming because the \
-                    generated files go into the build directory and the name is never observed. Remove \
-                    the 'fileNaming' option or set it to 'PathToUnderscores'.
                     """
             }
         }
@@ -298,10 +289,16 @@ struct SwiftProtobufPlugin {
                     throw PluginError.invalidInputFileExtension(protoFile)
                 }
             }
-            // The build plugin always uses PathToUnderscores naming. Reject any other explicit
-            // value so the setting is never silently ignored.
+            // The build plugin always uses PathToUnderscores naming. Warn on any other explicit
+            // value so the setting is never silently ignored, without breaking existing builds.
             if let fileNaming = invocation.fileNaming, fileNaming != .pathToUnderscores {
-                throw PluginError.unsupportedFileNaming(fileNaming.rawValue)
+                Diagnostics.warning(
+                    """
+                    The 'fileNaming' option '\(fileNaming.rawValue)' is ignored by the build plugin. The build \
+                    plugin always generates files using the 'PathToUnderscores' naming because the \
+                    generated files go into the build directory and the name is never observed.
+                    """
+                )
             }
         }
     }

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -228,10 +228,23 @@ struct SwiftProtobufPlugin {
             protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue)")
         }
 
+        // The build plugin always uses PathToUnderscores naming. Warn once per invocation on any
+        // other explicit value so the setting is never silently ignored, without breaking existing
+        // builds.
+        if let fileNaming = invocation.fileNaming, fileNaming != .pathToUnderscores {
+            Diagnostics.warning(
+                """
+                The 'fileNaming' option '\(fileNaming.rawValue)' is ignored by the build plugin. The build \
+                plugin always generates files using the 'PathToUnderscores' naming because the \
+                generated files go into the build directory and the name is never observed.
+                """
+            )
+        }
+
         // Always generate with PathToUnderscores naming. The declared output paths below are
         // derived the same way, so the names the build system expects can never drift from the
-        // names protoc-gen-swift actually writes. The configured fileNaming, if any, was already
-        // validated to be PathToUnderscores.
+        // names protoc-gen-swift actually writes. The configured fileNaming, if any, only triggers
+        // the warning above and does not change the naming used.
         protocArgs.append("--swift_opt=FileNaming=PathToUnderscores")
 
         // Add the implementation only imports flag if it was set
@@ -288,17 +301,6 @@ struct SwiftProtobufPlugin {
                 if !protoFile.hasSuffix(".proto") {
                     throw PluginError.invalidInputFileExtension(protoFile)
                 }
-            }
-            // The build plugin always uses PathToUnderscores naming. Warn on any other explicit
-            // value so the setting is never silently ignored, without breaking existing builds.
-            if let fileNaming = invocation.fileNaming, fileNaming != .pathToUnderscores {
-                Diagnostics.warning(
-                    """
-                    The 'fileNaming' option '\(fileNaming.rawValue)' is ignored by the build plugin. The build \
-                    plugin always generates files using the 'PathToUnderscores' naming because the \
-                    generated files go into the build directory and the name is never observed.
-                    """
-                )
             }
         }
     }

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -241,7 +241,7 @@ struct SwiftProtobufPlugin {
         // derived the same way, so the names the build system expects can never drift from the
         // names protoc-gen-swift actually writes. The configured fileNaming, if any, was already
         // validated to be PathToUnderscores.
-        protocArgs.append("--swift_opt=FileNaming=\(Configuration.Invocation.FileNaming.pathToUnderscores.rawValue)")
+        protocArgs.append("--swift_opt=FileNaming=PathToUnderscores")
 
         // Add the implementation only imports flag if it was set
         if let implementationOnlyImports = invocation.implementationOnlyImports {

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -11,6 +11,8 @@ struct SwiftProtobufPlugin {
         case invalidInputFileExtension(String)
         /// Indicates that there was no configuration file at the required location.
         case noConfigFound(String)
+        /// Indicates that the configuration set a `fileNaming` option the build plugin does not support.
+        case unsupportedFileNaming(String)
 
         var description: String {
             switch self {
@@ -22,6 +24,13 @@ struct SwiftProtobufPlugin {
                 return """
                     No configuration file found named '\(path)'. The file must not be listed in the \
                     'exclude:' argument for the target in Package.swift.
+                    """
+            case let .unsupportedFileNaming(value):
+                return """
+                    The 'fileNaming' option '\(value)' is not supported by the build plugin. The build \
+                    plugin always generates files using the 'PathToUnderscores' naming because the \
+                    generated files go into the build directory and the name is never observed. Remove \
+                    the 'fileNaming' option or set it to 'PathToUnderscores'.
                     """
             }
         }
@@ -106,6 +115,12 @@ struct SwiftProtobufPlugin {
             /// The visibility of the generated files.
             var visibility: Visibility?
             /// The file naming strategy to use.
+            ///
+            /// The build plugin always generates files with `PathToUnderscores` naming. The
+            /// generated files live in the build directory, so the file name on disk is never
+            /// observed and there is no benefit to giving users a choice here. This field is kept
+            /// for backwards compatibility: it may be omitted or set to `PathToUnderscores`. Any
+            /// other value is rejected so an explicit setting is never silently ignored.
             var fileNaming: FileNaming?
             /// Whether internal imports should be annotated as `@_implementationOnly`.
             var implementationOnlyImports: Bool?
@@ -222,10 +237,11 @@ struct SwiftProtobufPlugin {
             protocArgs.append("--swift_opt=Visibility=\(visibility.rawValue)")
         }
 
-        // Add the file naming if it was set
-        if let fileNaming = invocation.fileNaming {
-            protocArgs.append("--swift_opt=FileNaming=\(fileNaming.rawValue)")
-        }
+        // Always generate with PathToUnderscores naming. The declared output paths below are
+        // derived the same way, so the names the build system expects can never drift from the
+        // names protoc-gen-swift actually writes. The configured fileNaming, if any, was already
+        // validated to be PathToUnderscores.
+        protocArgs.append("--swift_opt=FileNaming=\(Configuration.Invocation.FileNaming.pathToUnderscores.rawValue)")
 
         // Add the implementation only imports flag if it was set
         if let implementationOnlyImports = invocation.implementationOnlyImports {
@@ -244,17 +260,19 @@ struct SwiftProtobufPlugin {
         var inputFiles = [URL]()
         var outputFiles = [URL]()
 
-        for var file in invocation.protoFiles {
+        for file in invocation.protoFiles {
             // Append the file to the protoc args so that it is used for generating
             protocArgs.append(file)
             inputFiles.append(protoDirectory.appending(path: file))
 
-            // The name of the output file is based on the name of the input file.
-            // We validated in the beginning that every file has the suffix of .proto
-            // This means we can just drop the last 5 elements and append the new suffix
-            file.removeLast(5)
-            file.append("pb.swift")
-            let protobufOutputPath = outputDirectory.appending(path: file)
+            // The output file name has to match exactly what protoc-gen-swift writes, otherwise
+            // the build system looks for a file that does not exist and the build fails. We always
+            // generate with PathToUnderscores naming, so the relative proto path becomes a single
+            // file name with the directory separators replaced by underscores. We validated up
+            // front that every file has the .proto suffix, which is dropped for .pb.swift.
+            let outputName = String(file.dropLast(".proto".count))
+                .replacingOccurrences(of: "/", with: "_") + ".pb.swift"
+            let protobufOutputPath = outputDirectory.appending(path: outputName)
 
             // Add the outputPath as an output file
             outputFiles.append(protobufOutputPath)
@@ -279,6 +297,11 @@ struct SwiftProtobufPlugin {
                 if !protoFile.hasSuffix(".proto") {
                     throw PluginError.invalidInputFileExtension(protoFile)
                 }
+            }
+            // The build plugin always uses PathToUnderscores naming. Reject any other explicit
+            // value so the setting is never silently ignored.
+            if let fileNaming = invocation.fileNaming, fileNaming != .pathToUnderscores {
+                throw PluginError.unsupportedFileNaming(fileNaming.rawValue)
             }
         }
     }

--- a/Plugins/SwiftProtobufPlugin/plugin.swift
+++ b/Plugins/SwiftProtobufPlugin/plugin.swift
@@ -274,8 +274,8 @@ struct SwiftProtobufPlugin {
             // generate with PathToUnderscores naming, so the relative proto path becomes a single
             // file name with the directory separators replaced by underscores. We validated up
             // front that every file has the .proto suffix, which is dropped for .pb.swift.
-            let outputName = String(file.dropLast(".proto".count))
-                .replacingOccurrences(of: "/", with: "_") + ".pb.swift"
+            let baseName = String(file.dropLast(".proto".count))
+            let outputName = baseName.replacingOccurrences(of: "/", with: "_") + ".pb.swift"
             let protobufOutputPath = outputDirectory.appending(path: outputName)
 
             // Add the outputPath as an output file


### PR DESCRIPTION
The SwiftProtobufPlugin build tool plugin declared the path of every generated file by taking the input proto path and swapping the .proto suffix for .pb.swift while keeping the full relative path, and it passed the configured fileNaming straight through to protoc-gen-swift.

That breaks the build whenever the declared output name does not match what protoc-gen-swift actually writes. With PathToUnderscores or DropPath the generator writes a differently named file than the plugin declared, and two protos that share a file name in different subdirectories collide. The build system then fails because the declared output does not exist. This is the problem reported in #1761.

Per the discussion on this PR: the generated files go into the build directory, so the file name on disk is never observed and there is no value in giving users a choice for file naming when using the build plugin. The plugin now always uses PathToUnderscores, the same approach grpc-swift-protobuf takes.

What changed:

- The protoc invocation is pinned to FileNaming=PathToUnderscores.
- The declared output names are derived with the same transformation, dropping the .proto suffix and replacing the directory separators with underscores. Because both sides use one strategy they can never diverge.
- The mirrored copy of FileGenerator.outputFilename is gone, so there is no logic to keep in sync with protoc-gen-swift and the maintenance concern raised in the thread disappears.

On the existing fileNaming config field: it already exists on main, so I kept decoding it for backwards compatibility. It may be omitted or set to PathToUnderscores. Any other value is now a clear configuration error rather than a silently ignored setting, since dropping a user's explicit choice on the floor would be worse.

Verification: added a PathToUnderscores example target whose two protos share the file name Duplicate.proto in different subdirectories. This only builds because of the underscore naming, which is the case from #1761. swift build and swift test --package-path PluginExamples pass, including the new testPathToUnderscores case, and the existing examples stay green under the new default. I also confirmed by hand that a DropPath or FullPath setting now produces the configuration error.

Fixes #1761