### PR TITLE
[table-driven-branch] Fix memory leaks.

### DIFF
--- a/Sources/SwiftProtobuf/ExtensionStorage+Witnesses.swift
+++ b/Sources/SwiftProtobuf/ExtensionStorage+Witnesses.swift
@@ -145,16 +145,7 @@ extension ExtensionStorage {
         guard let value = values.removeValue(forKey: ext.field.fieldNumber) else {
             return
         }
-        value.releaseMessageValue()
-    }
-
-    /// Clears the repeated or map field.
-    ///
-    /// If the field is not present, this method does nothing.
-    ///
-    /// - Precondition: The field must be a repeated or map field.
-    func clearRepeatedField(_ ext: ExtensionSchema) {
-        // TODO
+        value.release()
     }
 }
 

--- a/Sources/SwiftProtobuf/ExtensionStorage.swift
+++ b/Sources/SwiftProtobuf/ExtensionStorage.swift
@@ -32,44 +32,7 @@ public final class ExtensionStorage {
 
     deinit {
         for (_, value) in values {
-            let ext = value.schema
-            let field = ext.field
-            switch field.fieldMode.cardinality {
-            case .map:
-                preconditionFailure("Unreachable")
-
-            case .array:
-                switch field.rawFieldType {
-                case .bool: value.release(type: [Bool].self)
-                case .bytes: value.release(type: [Data].self)
-                case .double: value.release(type: [Double].self)
-                case .enum:
-                    ext.enumSchema.invokeWitness(.arrayDeinitialize(pointer: value.unsafeMutableRawPointer))
-                case .group, .message:
-                    ext.messageSchema.invokeWitness(.arrayDeinitialize(pointer: value.unsafeMutableRawPointer))
-                case .fixed32, .uint32: value.release(type: [UInt32].self)
-                case .fixed64, .uint64: value.release(type: [UInt64].self)
-                case .float: value.release(type: [Float].self)
-                case .int32, .sfixed32, .sint32: value.release(type: [Int32].self)
-                case .int64, .sfixed64, .sint64: value.release(type: [Int64].self)
-                case .string: value.release(type: [String].self)
-                default: preconditionFailure("Unreachable")
-                }
-
-            case .scalar:
-                switch field.rawFieldType {
-                case .bytes: value.release(type: Data.self)
-                case .string: value.release(type: String.self)
-                case .group, .message:
-                    ext.messageSchema.invokeWitness(.messageDeinitialize(pointer: value.unsafeMutableRawPointer))
-                default:
-                    // Ignore trivial fields; no deinitialization is necessary.
-                    break
-                }
-
-            default:
-                preconditionFailure("Unreachable")
-            }
+            value.release()
         }
     }
 
@@ -230,14 +193,8 @@ extension ExtensionStorage {
 
     /// Clears the value of the given message extension.
     @_alwaysEmitIntoClient @inline(__always)
-    public func clearValue<Value: BitwiseCopyable>(of ext: ExtensionSchema, type: Value.Type) {
-        values.removeValue(forKey: ext.field.fieldNumber)
-    }
-
-    /// Clears the value of the given message extension.
-    @_alwaysEmitIntoClient @inline(__always)
     public func clearValue<Value>(of ext: ExtensionSchema, type: Value.Type) {
-        values.removeValue(forKey: ext.field.fieldNumber)?.release(type: Value.self)
+        values.removeValue(forKey: ext.field.fieldNumber)?.release()
     }
 
     /// Appends the given value to the array-typed value of the message extension, creating a new

--- a/Sources/SwiftProtobuf/ExtensionValueStorage.swift
+++ b/Sources/SwiftProtobuf/ExtensionValueStorage.swift
@@ -12,6 +12,8 @@
 ///
 // -----------------------------------------------------------------------------
 
+import Foundation
+
 /// The storage for a single extension field in a message.
 ///
 /// This can be thought of as a miniature version of `MessageStorage`, but which only holds the
@@ -69,25 +71,62 @@
         self.storage = UInt64(UInt(bitPattern: pointer))
     }
 
+    /// Deinitializes the value stored in the receiver and deallocates its heap storage if it uses
+    /// any.
+    ///
+    /// The receiver should not be used after this method is called.
+    @usableFromInline
+    func release() {
+        let field = schema.field
+        switch field.fieldMode.cardinality {
+        case .map:
+            preconditionFailure("Unreachable")
+
+        case .array:
+            switch field.rawFieldType {
+            case .bool: release(type: [Bool].self)
+            case .bytes: release(type: [Data].self)
+            case .double: release(type: [Double].self)
+            case .enum:
+                schema.enumSchema.invokeWitness(.arrayDeinitialize(pointer: unsafeMutableRawPointer))
+                unsafeMutableRawPointer.deallocate()
+            case .group, .message:
+                schema.messageSchema.invokeWitness(.arrayDeinitialize(pointer: unsafeMutableRawPointer))
+                unsafeMutableRawPointer.deallocate()
+            case .fixed32, .uint32: release(type: [UInt32].self)
+            case .fixed64, .uint64: release(type: [UInt64].self)
+            case .float: release(type: [Float].self)
+            case .int32, .sfixed32, .sint32: release(type: [Int32].self)
+            case .int64, .sfixed64, .sint64: release(type: [Int64].self)
+            case .string: release(type: [String].self)
+            default: preconditionFailure("Unreachable")
+            }
+
+        case .scalar:
+            switch field.rawFieldType {
+            case .bytes: release(type: Data.self)
+            case .string: release(type: String.self)
+            case .group, .message:
+                schema.messageSchema.invokeWitness(.messageDeinitialize(pointer: unsafeMutableRawPointer))
+                unsafeMutableRawPointer.deallocate()
+            default:
+                // Ignore trivial fields; no deinitialization is necessary.
+                break
+            }
+
+        default:
+            preconditionFailure("Unreachable")
+        }
+    }
+
     /// Deinitializes the stored value in the receiver and then deallocates its heap storage.
     ///
     /// - Precondition: This must only be called on values for which `storage` is a pointer to
     ///   heap-allocated storage.
     @_alwaysEmitIntoClient @inline(__always)
-    func release<Value>(type: Value.Type) {
+    private func release<Value>(type: Value.Type) {
         let pointer = UnsafeMutablePointer<Value>(bitPattern: Int(truncatingIfNeeded: Int64(bitPattern: storage)))!
         pointer.deinitialize(count: 1)
-        pointer.deallocate()
-    }
-
-    /// Deinitializes the singular message value stored in the receiver and deallocates its heap
-    /// storage.
-    ///
-    /// - Precondition: This must only be called on values for which `storage` is a pointer to
-    ///   heap-allocated storage and contains an initialized concrete message instance.
-    func releaseMessageValue() {
-        let pointer = unsafeMutableRawPointer
-        schema.messageSchema.invokeWitness(.messageDeinitialize(pointer: pointer))
         pointer.deallocate()
     }
 

--- a/Sources/SwiftProtobuf/MessageStorage.swift
+++ b/Sources/SwiftProtobuf/MessageStorage.swift
@@ -68,10 +68,13 @@ import Foundation
         buffer.deallocate()
     }
 
-    /// Deinitializes the given field.
+    /// Deinitializes the given field if it is present.
     @usableFromInline func deinitializeField(_ field: FieldSchema) {
         guard isPresent(field) else { return }
+        deinitializeFieldForced(field)
+    }
 
+    @usableFromInline func deinitializeFieldForced(_ field: FieldSchema) {
         switch field.fieldMode.cardinality {
         case .map:
             messageSchema(for: field).invokeWitness(.mapDeinitialize(pointer: buffer.baseAddress! + field.offset))
@@ -267,9 +270,14 @@ extension MessageStorage {
     /// Updates the presence of a field, returning the old presence value before it was changed.
     @_alwaysEmitIntoClient @inline(__always)
     func updatePresence(hasBit: HasBit, willBeSet: Bool) -> Bool {
-        let oldValue = buffer.load(fromByteOffset: hasBit.offset, as: UInt8.self) & ~hasBit.mask
-        buffer.storeBytes(of: oldValue | (willBeSet ? hasBit.mask : 0), toByteOffset: hasBit.offset, as: UInt8.self)
-        return oldValue != 0
+        let presenceByte = buffer.load(fromByteOffset: hasBit.offset, as: UInt8.self)
+        let wasSet = presenceByte & hasBit.mask != 0
+        buffer.storeBytes(
+            of: (presenceByte & ~hasBit.mask) | (willBeSet ? hasBit.mask : 0),
+            toByteOffset: hasBit.offset,
+            as: UInt8.self
+        )
+        return wasSet
     }
 }
 
@@ -1156,10 +1164,14 @@ extension MessageStorage {
     /// - Precondition: The value associated with this field must be initialized.
     @_alwaysEmitIntoClient @inline(__always)
     private func deinitializeOneofMember(_ field: FieldSchema) {
+        // If this is being called when a value is being updated, we will have already updated the
+        // presence of the field, so we have to use `deinitializeFieldForced` to avoid an incorrect
+        // presence check.
+        deinitializeFieldForced(field)
+
         // TODO: We could skip zeroing out the backing storage if this is part of a mutation that
         // is setting the same member that's being deinitialized. Determine if that's a worthwhile
         // optimization.
-        deinitializeField(field)
         let stride = field.scalarStride
         (buffer.baseAddress! + field.offset).withMemoryRebound(to: UInt8.self, capacity: stride) { bytes in
             bytes.initialize(repeating: 0, count: stride)

--- a/Tests/SwiftProtobufTests/Test_Leaks.swift
+++ b/Tests/SwiftProtobufTests/Test_Leaks.swift
@@ -1,4 +1,4 @@
-// Tests/SwiftProtobufTests/Test_Leaks.swift - Proto3 coding/decoding
+// Tests/SwiftProtobufTests/Test_Leaks.swift - Memory leak detection
 //
 // Copyright (c) 2014 - 2026 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Tests/SwiftProtobufTests/Test_Leaks.swift
+++ b/Tests/SwiftProtobufTests/Test_Leaks.swift
@@ -1,0 +1,90 @@
+// Tests/SwiftProtobufTests/Test_Leaks.swift - Proto3 coding/decoding
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Detect memory leaks in the SwiftProtobuf runtime.
+///
+/// To enable this, you must be on macOS and run `DETECT_LEAKS=1 swift test`
+/// (without `--parallel`, see below). (`DETECT_LEAKS` only needs to be set;
+/// the value does not matter.)
+///
+/// Fuzz testing does this for us on Linux (since it enables ASan), but when
+/// doing local development on macOS, it's helpful to have a way to explicitly
+/// check for them without reaching for Instruments. Unfortunately the `leaks`
+/// tool does not report leaks by default for .xctest bundles run under the
+/// `xctest` tool, so we have to use this trick of invoking `leaks` with the
+/// current PID in an `atexit` handler. If leaks are detected, we'll print the
+/// output and exit with a failure code.
+///
+/// Note that this only works for serialized test runs (i.e., `swift test`
+/// without the `--parallel` flag), because serialized runs are run in a single
+/// process whereas `--parallel` spawns multiple processes with subsets of
+/// tests.
+///
+// -----------------------------------------------------------------------------
+
+#if os(macOS)
+
+import Foundation
+import XCTest
+
+final class Test_Leaks: XCTestCase {
+    func test_registerLeaksCheck() {
+        guard getenv("DETECT_LEAKS") != nil else {
+            return
+        }
+        // Since this is a global variable, it will only be initialized once. This ensures that the
+        // installed `atexit` handler only runs once, even if the test runs multiple times for some
+        // reason.
+        _ = checkLeaks
+    }
+}
+
+let checkLeaks = {
+    atexit {
+        // We run `leaks` twice; first to determine if there actually were any leaks, and then
+        // again if the first run indicated that there were leaks, this time writing to stderr
+        // so that the user sees the output. This is honestly easier than using `Process`'s APIs to
+        // capture the output into a string the first time.
+        let process = computeLeaks(writingOutputTo: "/dev/null")
+        let exitCode = process.terminationStatus
+        guard process.terminationReason == .exit && [0, 1].contains(exitCode) else {
+            print(
+                """
+                ================
+                Unexpected termination from leaks:
+
+                Reason: \(process.terminationReason)
+                Exit code: \(exitCode)
+                """
+            )
+            exit(255)
+        }
+        if exitCode == 1 {
+            print("================")
+            print("Memory leaks detected!")
+            _ = computeLeaks(writingOutputTo: "/dev/stderr")
+        }
+        exit(exitCode)
+    }
+}()
+
+func computeLeaks(writingOutputTo path: String) -> Process {
+    let outputHandle = FileHandle(forWritingAtPath: path)!
+    let process = Process()
+    process.launchPath = "/usr/bin/leaks"
+    process.arguments = ["\(getpid())"]
+    process.standardOutput = outputHandle
+    process.standardError = outputHandle
+    process.launch()
+    process.waitUntilExit()
+    return process
+}
+
+#endif  // os(macOS)


### PR DESCRIPTION
This fixes three leaks that were in the table-driven implementation:

* When deinitializing `ExtensionStorage`, we were correctly deinitializing any submessages/repeated fields that were in extension fields, but we were not deallocating the heap-allocated buffer that held them.
* `updatePresence` had a bit-masking bug that was causing it to return false when a field was overwritten, thus failing to deinitialize the old value.
* When a `oneof` member is overwritten by another `oneof` member, we update the presence _before_ deinitializing the old value, but `deinitializeField` exits early if the field isn't present, which it would not be in this case.

Since running `leaks` on `xctest` bundles is nontrivial, I've added a test case that does this at process exit when an environment variable is set.