### PR TITLE
[table-driven-branch] Fix the branch specific warning in the tests.

### DIFF
--- a/Tests/SwiftProtobufTests/Test_Api.swift
+++ b/Tests/SwiftProtobufTests/Test_Api.swift
@@ -36,7 +36,7 @@ final class Test_Api: XCTestCase, PBTestHelpers {
         m.methods = [method]
         var option = Google_Protobuf_Option()
         option.name = "option1"
-        option.value = try Google_Protobuf_Any(message: Google_Protobuf_StringValue("value1"))
+        option.value = try Google_Protobuf_Any(packing: Google_Protobuf_StringValue("value1"))
         m.options = [option]
         m.version = "1.0.0"
         m.syntax = .proto3

--- a/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
+++ b/Tests/SwiftProtobufTests/Test_JSONEncodingOptions.swift
@@ -108,7 +108,7 @@ final class Test_JSONEncodingOptions: XCTestCase {
         let content = SwiftProtoTesting_TestAllTypes.with {
             $0.optionalInt64 = 1_656_338_459_803
         }
-        let msg7 = try! Google_Protobuf_Any(message: content)
+        let msg7 = try! Google_Protobuf_Any(packing: content)
         XCTAssertEqual(
             try msg7.jsonString(options: asStrings),
             "{\"@type\":\"type.googleapis.com/swift_proto_testing.TestAllTypes\",\"optionalInt64\":\"1656338459803\"}"
@@ -233,7 +233,7 @@ final class Test_JSONEncodingOptions: XCTestCase {
         let content = SwiftProtoTesting_TestAllTypes.with {
             $0.optionalNestedEnum = .neg
         }
-        let msg7 = try! Google_Protobuf_Any(message: content)
+        let msg7 = try! Google_Protobuf_Any(packing: content)
         XCTAssertEqual(
             try msg7.jsonString(options: asStrings),
             "{\"@type\":\"type.googleapis.com/swift_proto_testing.TestAllTypes\",\"optionalNestedEnum\":\"NEG\"}"
@@ -330,7 +330,7 @@ final class Test_JSONEncodingOptions: XCTestCase {
         let content = SwiftProtoTesting_TestAllTypes.with {
             $0.optionalNestedEnum = .neg
         }
-        let msg7 = try! Google_Protobuf_Any(message: content)
+        let msg7 = try! Google_Protobuf_Any(packing: content)
         XCTAssertEqual(
             try msg7.jsonString(options: jsonNames),
             "{\"@type\":\"type.googleapis.com/swift_proto_testing.TestAllTypes\",\"optionalNestedEnum\":\"NEG\"}"

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Performance.swift
@@ -80,7 +80,7 @@ final class Test_TextFormat_Performance: XCTestCase, PBTestHelpers {
         let msg = MessageTestType.with {
             let child = MessageTestType.with {
                 let duration = Google_Protobuf_Duration(seconds: 123, nanos: 123_456_789)
-                $0.wktAny = try! Google_Protobuf_Any(message: duration)
+                $0.wktAny = try! Google_Protobuf_Any(packing: duration)
             }
             let array = [MessageTestType](repeating: child, count: repeats)
             $0.repeatedMessage = array

--- a/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
@@ -28,7 +28,7 @@ final class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
         let empty = MessageTestType()
         var configured = empty
         do {
-            configured.anyField = try Google_Protobuf_Any(message: message)
+            configured.anyField = try Google_Protobuf_Any(packing: message)
         } catch {
             XCTFail("Assigning to any field failed: \(error)", file: file, line: line)
         }
@@ -66,7 +66,7 @@ final class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
         // Nested any
         let a = try SwiftProtoTesting_TestWellKnownTypes.with {
             $0.anyField = try Google_Protobuf_Any(
-                message: Google_Protobuf_Any(message: Google_Protobuf_Duration(seconds: 123, nanos: 234_567_890))
+                packing: Google_Protobuf_Any(packing: Google_Protobuf_Duration(seconds: 123, nanos: 234_567_890))
             )
         }
         let a_encoded = a.textFormatString()


### PR DESCRIPTION
> warning: 'init(message:options:typePrefix:)' is deprecated: replaced by 'init(packing:options:typeURLPrefix:)'