### PR TITLE
[table-driven-branch] More branch warnings

### DIFF
--- a/Sources/SwiftProtobuf/ProtobufMapParticipant.swift
+++ b/Sources/SwiftProtobuf/ProtobufMapParticipant.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// Defines the common operations for a proxy type that participates in a protobuf map (as either a
 /// key or a value).
-@_spi(ForGeneratedCodeOnly) public protocol ProtobufMapParticipant {
+@_spi(ForGeneratedCodeOnly) public protocol ProtobufMapParticipant: Sendable {
     /// The actual Swift type of the field as it is represented in memory.
     associatedtype Base: Equatable
 


### PR DESCRIPTION
Fixes for SendableMetatypes:
    
    Sources/SwiftProtobuf/MessageSchema.swift:183:28: warning: capture of non-Sendable type 'V.Type' in an isolated closure [#SendableMetatypes]
    181 |             schema: schema,
    182 |             reflectionReference: .mapEntry,
    183 |             invokeWitness: MapEntryWitnesses<K, V>.perform,
        |                            `- warning: capture of non-Sendable type 'V.Type' in an isolated closure [#SendableMetatypes]
    184 |             submessageOrEnumResolver: { _ in
    185 |                 preconditionFailure("This should have been unreachable; this is a generator bug")
    
    Sources/SwiftProtobuf/MessageSchema.swift:201:28: warning: capture of non-Sendable type 'K.Type' in an isolated closure [#SendableMetatypes]
    199 |             schema: schema,
    200 |             reflectionReference: .mapEntry,
    201 |             invokeWitness: MapEntryWitnesses<K, ProtobufMapMessageField<M>>.perform,
        |                            `- warning: capture of non-Sendable type 'K.Type' in an isolated closure [#SendableMetatypes]
    202 |             submessageOrEnumResolver: { token in
    203 |                 guard token.index == 1 else {
