### PR TITLE
[table-driven-branch] Enable warnings to errors on CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,9 @@ jobs:
       # `make` is needed for using our own `Makefile`.
       run: apt-get update && apt-get install -y make g++
     - name: Build
-      # TODO: Some warnings for apis to migrate.
-      # run: make build SWIFT_BUILD_TEST_HOOK="-Xswiftc -warnings-as-errors"
-      run: make build
+      run: make build SWIFT_BUILD_TEST_HOOK="-Xswiftc -warnings-as-errors"
     - name: Test runtime
-      # TODO: Some warnings for apis to migrate.
-      # run: make test-runtime SWIFT_BUILD_TEST_HOOK="-Xswiftc -warnings-as-errors"
-      run: make test-runtime
+      run: make test-runtime SWIFT_BUILD_TEST_HOOK="-Xswiftc -warnings-as-errors"
     - name: Test plugin
       run: make test-plugin
     - name: Test SPM plugin

--- a/Tests/SwiftProtobufTests/Test_FieldOrdering.swift
+++ b/Tests/SwiftProtobufTests/Test_FieldOrdering.swift
@@ -25,35 +25,36 @@ final class Test_FieldOrdering: XCTestCase {
 
     func test_FieldOrdering() throws {
         throw XCTSkip("Disabling until we decide on extension serialization determinism strategy")
-        var m = MessageTestType()
-        m.myString = "abc"
-        m.myInt = 1
-        m.myFloat = 1.0
-        var nest = MessageTestType.NestedMessage()
-        nest.oo = 1
-        nest.bb = 2
-        m.optionalNestedMessage = nest
-        m.SwiftProtoTesting_Order_myExtensionInt = 12
-        m.SwiftProtoTesting_Order_myExtensionString = "def"
-        m.oneofInt32 = 7
-
-        let encoded1: [UInt8] = try m.serializedBytes()
-        XCTAssertEqual(
-            [
-                8, 1, 40, 12, 80, 7, 90, 3, 97, 98, 99, 146, 3, 3, 100, 101, 102, 173, 6, 0, 0, 128, 63, 194, 12, 4, 8,
-                2, 16, 1,
-            ],
-            encoded1
-        )
-
-        m.oneofInt64 = 8
-        let encoded2: [UInt8] = try m.serializedBytes()
-        XCTAssertEqual(
-            [
-                8, 1, 40, 12, 90, 3, 97, 98, 99, 146, 3, 3, 100, 101, 102, 224, 3, 8, 173, 6, 0, 0, 128, 63, 194, 12, 4,
-                8, 2, 16, 1,
-            ],
-            encoded2
-        )
+        // TODO: Revisit and figure out how/what to test since extensions now come after normal fields.
+        // var m = MessageTestType()
+        // m.myString = "abc"
+        // m.myInt = 1
+        // m.myFloat = 1.0
+        // var nest = MessageTestType.NestedMessage()
+        // nest.oo = 1
+        // nest.bb = 2
+        // m.optionalNestedMessage = nest
+        // m.SwiftProtoTesting_Order_myExtensionInt = 12
+        // m.SwiftProtoTesting_Order_myExtensionString = "def"
+        // m.oneofInt32 = 7
+        //
+        // let encoded1: [UInt8] = try m.serializedBytes()
+        // XCTAssertEqual(
+        //     [
+        //         8, 1, 40, 12, 80, 7, 90, 3, 97, 98, 99, 146, 3, 3, 100, 101, 102, 173, 6, 0, 0, 128, 63, 194, 12, 4, 8,
+        //         2, 16, 1,
+        //     ],
+        //     encoded1
+        // )
+        //
+        // m.oneofInt64 = 8
+        // let encoded2: [UInt8] = try m.serializedBytes()
+        // XCTAssertEqual(
+        //     [
+        //         8, 1, 40, 12, 90, 3, 97, 98, 99, 146, 3, 3, 100, 101, 102, 224, 3, 8, 173, 6, 0, 0, 128, 63, 194, 12, 4,
+        //         8, 2, 16, 1,
+        //     ],
+        //     encoded2
+        // )
     }
 }

--- a/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_Unknown.swift
@@ -423,8 +423,9 @@ final class Test_TextFormat_Unknown: XCTestCase, PBTestHelpers {
         do {
             let _ = try MessageTestType(textFormatString: "1536870911: 1", options: opts)
             XCTFail("Shouldn't get here")
-        } catch let error as SwiftProtobufError {
+        } catch let e as SwiftProtobufError {
             // This is what should have happened.
+            XCTAssertTrue(e.message.contains(#/: Expected an integer no larger than /#))
         } catch {
             XCTFail("Unexpected error: \(error)")
         }


### PR DESCRIPTION
Match 'main' by enabling this.

Validate the error in one case were weren't using the local let.

Comment out the code after the Skip to avoid warnings about code that won't run.