### PR TITLE
Add explicit watchOS 9 platform minimum for Xcode 27

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,9 @@ let resources = [Resource]()
 
 let package = Package(
     name: "SwiftProtobuf",
+    platforms: [
+        .watchOS(.v9),
+    ],
     products: [
         .executable(
             name: "protoc-gen-swift",


### PR DESCRIPTION
Xcode 27 infers watchOS 8.0 for Swift packages without an explicit watchOS deployment target in Package.swift, which is below the supported range (9.0–27.x) and triggers deprecated armv7k architecture errors.

Declare watchOS 9 as the package minimum so SPM uses a supported deployment target. This matches the workaround recommended on Apple Developer Forums and fixes watchOS builds without changing runtime behavior for apps already targeting watchOS 9+.

Refs:
- https://github.com/swiftlang/swift-package-manager/issues/10187
- https://developer.apple.com/forums/thread/831681