### PR TITLE
reject unescaped control characters in json strings

### DIFF
--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -815,6 +815,10 @@ internal struct JSONScanner {
                     return nil  // Unterminated escape
                 }
                 sawBackslash = true
+            case 0..<asciiSpace:
+                // Unescaped control characters (U+0000...U+001F) are not
+                // allowed inside a JSON string; they must be escaped.
+                return nil
             default:
                 break
             }
@@ -1269,7 +1273,9 @@ internal struct JSONScanner {
         advance()
         let nameStart = index
         while hasMoreContent && currentByte != asciiDoubleQuote {
-            if currentByte == asciiBackslash {
+            if currentByte == asciiBackslash || currentByte < asciiSpace {
+                // Backslash escapes go through the slow path; unescaped control
+                // characters are invalid there and get rejected uniformly.
                 index = stringStart  // Reset to open quote
                 return nil
             }

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -753,6 +753,22 @@ final class Test_JSON: XCTestCase, PBTestHelpers {
         }
     }
 
+    func testOptionalString_rawControlCharactersRejected() {
+        // Unescaped C0 control characters (U+0000...U+001F) are not allowed
+        // inside a JSON string and must be rejected, matching the upstream
+        // protobuf JSON parser. Note the values below are literal control
+        // bytes in the input, not "\u00xx" escapes.
+        assertJSONDecodeFails("{\"optionalString\":\"\u{00}\"}")
+        assertJSONDecodeFails("{\"optionalString\":\"\u{01}\"}")
+        assertJSONDecodeFails("{\"optionalString\":\"a\u{09}b\"}")  // tab
+        assertJSONDecodeFails("{\"optionalString\":\"a\u{0a}b\"}")  // newline
+        assertJSONDecodeFails("{\"optionalString\":\"a\u{0d}b\"}")  // carriage return
+        assertJSONDecodeFails("{\"optionalString\":\"\u{1f}\"}")
+        // The escaped forms remain valid and decode to the control character.
+        assertJSONDecodeSucceeds("{\"optionalString\":\"\\u0001\"}") { $0.optionalString == "\u{01}" }
+        assertJSONDecodeSucceeds("{\"optionalString\":\"\\t\"}") { $0.optionalString == "\u{09}" }
+    }
+
     func testOptionalBytes() throws {
         // Empty bytes is default, so proto3 omits it
         var a = MessageTestType()


### PR DESCRIPTION
Two JSON string scanners accept raw control characters that RFC 8259 and the upstream parser reject:
- parseOptionalQuotedString: unescaped U+0000-U+001F bytes pass straight into decoded string values and map keys
- nextOptionalKey repeats the same scan for field and enum names
Reject bytes below 0x20 inside a string in both; the escaped forms stay valid.
