### PR TITLE
reject illegal characters in field mask json paths

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -47,10 +47,7 @@ private func ProtoToJSON(name: String) -> String? {
         case "a"..."z", "0"..."9", ".", "(", ")":
             jsonPath.append(c)
         default:
-            // TODO: Change this to `return nil`
-            // once we know everything legal is handled
-            // above.
-            jsonPath.append(c)
+            return nil
         }
     }
     return jsonPath
@@ -69,10 +66,7 @@ private func JSONToProto(name: String) -> String? {
         case "a"..."z", "0"..."9", ".", "(", ")":
             path.append(c)
         default:
-            // TODO: Change to `return nil` once
-            // we know everything legal is being
-            // handled above
-            path.append(c)
+            return nil
         }
     }
     return path

--- a/Tests/SwiftProtobufTests/Test_FieldMask.swift
+++ b/Tests/SwiftProtobufTests/Test_FieldMask.swift
@@ -43,6 +43,14 @@ final class Test_FieldMask: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("foo,bar\"")
         assertJSONDecodeFails("\"H̱ܻ̻ܻ̻ܶܶAܻD\"")  // Reject non-ASCII
         assertJSONDecodeFails("abc_def")  // Reject underscores
+        // Reject characters outside [A-Za-z0-9.] in a path segment, matching the
+        // upstream parser ("unexpected character in FieldMask").
+        assertJSONDecodeFails("\"foo-bar\"")
+        assertJSONDecodeFails("\"foo/bar\"")
+        assertJSONDecodeFails("\"foo!bar\"")
+        assertJSONDecodeFails("\"foo~bar\"")
+        assertJSONDecodeFails("\"foo@bar\"")
+        assertJSONDecodeFails("\"foo bar\"")
     }
 
     func testProtobuf() {
@@ -105,8 +113,9 @@ final class Test_FieldMask: XCTestCase, PBTestHelpers {
 
     func testSerializationFailure() {
         // If the proto fieldname can't be converted to a JSON field name,
-        // then JSON serialization should fail:
-        let cases = ["foo_3_bar", "foo__bar", "fooBar", "☹️", "ȟìĳ"]
+        // then JSON serialization should fail. This includes a path holding the
+        // ',' separator, which otherwise round-trips into two separate paths.
+        let cases = ["foo_3_bar", "foo__bar", "fooBar", "☹️", "ȟìĳ", "foo,bar", "foo-bar", "foo/bar"]
         for c in cases {
             let m = Google_Protobuf_FieldMask(protoPaths: c)
             XCTAssertThrowsError(try m.jsonString())


### PR DESCRIPTION
The field mask JSON codec passed unrecognized characters straight through instead of rejecting them, unlike the upstream parser which only allows path characters in [A-Za-z0-9.]:
- JSONToProto accepted segments like "foo-bar", "foo/bar", "foo bar" into path values on decode
- ProtoToJSON did the same on encode, so a path holding the "," separator round-trips back into two separate paths

Both default branches now return nil, so decode throws malformedFieldMask and encode throws fieldMaskConversion. Legal paths and the camelCase/snake_case mapping are unchanged.