### PR TITLE
reject duplicate keys in json maps

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Struct+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Struct+Extensions.swift
@@ -45,8 +45,12 @@ extension Google_Protobuf_Struct: _CustomJSONCodable {
         if decoder.scanner.skipOptionalObjectEnd() {
             return
         }
+        var keysSeen = Set<String>()
         while true {
             let key = try decoder.scanner.nextQuotedString()
+            if !keysSeen.insert(key).inserted {
+                throw JSONDecodingError.malformedMap
+            }
             try decoder.scanner.skipRequiredColon()
             var value = Google_Protobuf_Value()
             try value.decodeJSON(from: &decoder)

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -636,6 +636,7 @@ internal struct JSONDecoder: Decoder {
         if scanner.skipOptionalObjectEnd() {
             return
         }
+        var keysSeen = Set<KeyType.BaseType>()
         while true {
             // Next character must be double quote, because
             // map keys must always be quoted strings.
@@ -651,6 +652,9 @@ internal struct JSONDecoder: Decoder {
             var valueField: ValueType.BaseType?
             try ValueType.decodeSingular(value: &valueField, from: &self)
             if let keyField = keyField, let valueField = valueField {
+                if !keysSeen.insert(keyField).inserted {
+                    throw JSONDecodingError.malformedMap
+                }
                 value[keyField] = valueField
             } else {
                 throw JSONDecodingError.malformedMap
@@ -673,6 +677,7 @@ internal struct JSONDecoder: Decoder {
         if scanner.skipOptionalObjectEnd() {
             return
         }
+        var keysSeen = Set<KeyType.BaseType>()
         while true {
             // Next character must be double quote, because
             // map keys must always be quoted strings.
@@ -684,6 +689,9 @@ internal struct JSONDecoder: Decoder {
             var keyFieldOpt: KeyType.BaseType?
             try KeyType.decodeSingular(value: &keyFieldOpt, from: &self)
             guard let keyField = keyFieldOpt else {
+                throw JSONDecodingError.malformedMap
+            }
+            if !keysSeen.insert(keyField).inserted {
                 throw JSONDecodingError.malformedMap
             }
             isMapKey = false
@@ -715,6 +723,7 @@ internal struct JSONDecoder: Decoder {
         if scanner.skipOptionalObjectEnd() {
             return
         }
+        var keysSeen = Set<KeyType.BaseType>()
         while true {
             // Next character must be double quote, because
             // map keys must always be quoted strings.
@@ -730,6 +739,9 @@ internal struct JSONDecoder: Decoder {
             var valueField: ValueType?
             try decodeSingularMessageField(value: &valueField)
             if let keyField = keyField, let valueField = valueField {
+                if !keysSeen.insert(keyField).inserted {
+                    throw JSONDecodingError.malformedMap
+                }
                 value[keyField] = valueField
             } else {
                 throw JSONDecodingError.malformedMap

--- a/Tests/SwiftProtobufTests/Test_Map_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_Map_JSON.swift
@@ -326,4 +326,17 @@ final class Test_Map_JSON: XCTestCase, PBTestHelpers {
             return $0.mapInt32ForeignMessage == [7: sub7, 8: sub8]
         }
     }
+
+    func testMap_duplicateKeyRejected() {
+        // A repeated key in a JSON map is rejected rather than letting the
+        // later entry silently overwrite the earlier one, matching the
+        // reference parser (json/internal/parser.cc ParseMap).
+        assertJSONDecodeFails("{\"mapInt32Int32\":{\"1\":2,\"1\":3}}")
+        assertJSONDecodeFails("{\"mapStringString\":{\"a\":\"x\",\"a\":\"y\"}}")
+        assertJSONDecodeFails("{\"mapBoolBool\":{\"true\":false,\"true\":true}}")
+        assertJSONDecodeFails("{\"mapInt32Enum\":{\"1\":\"MAP_ENUM_FOO\",\"1\":\"MAP_ENUM_BAZ\"}}")
+        assertJSONDecodeFails("{\"mapInt32ForeignMessage\":{\"1\":{\"c\":7},\"1\":{\"c\":8}}}")
+        // Distinct keys are still accepted.
+        assertJSONDecodeSucceeds("{\"mapInt32Int32\":{\"1\":2,\"2\":3}}") { $0.mapInt32Int32 == [1: 2, 2: 3] }
+    }
 }

--- a/Tests/SwiftProtobufTests/Test_Struct.swift
+++ b/Tests/SwiftProtobufTests/Test_Struct.swift
@@ -62,6 +62,17 @@ final class Test_Struct: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("\"1\"")
     }
 
+    func test_JSON_duplicateKeyRejected() {
+        // A Struct is a map<string, Value>, so a repeated key is rejected
+        // rather than silently overwritten, matching the reference parser
+        // (json/internal/parser.cc ParseStructValue routes through ParseMap).
+        assertJSONDecodeFails("{\"a\":1,\"a\":2}")
+        assertJSONDecodeFails("{\"a\":1,\"b\":2,\"a\":3}")
+        assertJSONDecodeSucceeds("{\"a\":1,\"b\":2}") {
+            $0.fields == ["a": Google_Protobuf_Value(numberValue: 1), "b": Google_Protobuf_Value(numberValue: 2)]
+        }
+    }
+
     func test_JSON_field() throws {
         // "null" as a field value indicates the field is missing
         // (Except for Value, where "null" indicates NullValue)


### PR DESCRIPTION
JSON map decoding kept the last of a repeated key instead of rejecting it, unlike the reference parser (json/internal/parser.cc ParseMap, which tracks keys in a set):
- decodeMapField overwrote silently for the scalar, enum, and message maps
- Struct decodeJSON did the same, since a Struct is a map<string, Value>
- each now tracks the keys seen in the current object and rejects a repeat

Distinct keys still decode, and a map field repeated at the message level still merges.