### PR TITLE
Enable Edition 2026 in the protoc plugin.

### DIFF
--- a/Sources/protoc-gen-swift/SwiftGeneratorPlugin.swift
+++ b/Sources/protoc-gen-swift/SwiftGeneratorPlugin.swift
@@ -51,7 +51,7 @@ struct SwiftGeneratorPlugin: CodeGenerator {
     ]
 
     var supportedEditionRange: ClosedRange<Google_Protobuf_Edition> {
-        Google_Protobuf_Edition.proto2...Google_Protobuf_Edition.edition2024
+        Google_Protobuf_Edition.proto2...Google_Protobuf_Edition.edition2026
     }
 
     var version: String? { "\(SwiftProtobuf.Version.versionString)" }


### PR DESCRIPTION
Tracking upstream: https://github.com/protocolbuffers/protobuf/pull/28396