### PR TITLE
Ensure seconds are <60 not <62.

### DIFF
--- a/Sources/Conformance/failure_list_swift.txt
+++ b/Sources/Conformance/failure_list_swift.txt
@@ -5,4 +5,3 @@ Recommended.*.JsonInput.FieldNameDuplicateDifferentCasing2 # Should have failed 
 
 # Tracking in #2132
 Required.*.JsonInput.TimestampJsonInputNonLeapFeb29 # Should have failed to parse, but didn't.
-Required.*.JsonInput.TimestampJsonInputSecondTooLarge # Should have failed to parse, but didn't.

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -107,7 +107,7 @@ private func parseTimestamp(s: String) throws -> (Int64, Int32) {
 
     // Second: 2 digits (following char is checked below)
     let second = try fromAscii2(value[17], value[18])
-    if second > Int(61) {
+    if second > Int(59) {
         throw JSONDecodingError.malformedTimestamp
     }
 


### PR DESCRIPTION
Git history doesn't really explain if this was a typo or by design, but a new upstream conformance test is testing it. timestamp.proto also makes a comment that all minutes only have 60 seconds, and leap seconds should be smeared instead, so that seems to be the only other thing to point to here.

Progress on #2132