### PR TITLE
docs: use DocC double-backtick symbol links in public API comments

### DIFF
--- a/Sources/SwiftProtobuf/AnyUnpackError.swift
+++ b/Sources/SwiftProtobuf/AnyUnpackError.swift
@@ -12,17 +12,17 @@
 ///
 // -----------------------------------------------------------------------------
 
-/// Describes errors that can occur when unpacking an `Google_Protobuf_Any`
+/// Describes errors that can occur when unpacking an ``Google_Protobuf_Any``
 /// message.
 ///
-/// `Google_Protobuf_Any` messages can be decoded from protobuf binary, text
+/// ``Google_Protobuf_Any`` messages can be decoded from protobuf binary, text
 /// format, or JSON. The contents are not parsed immediately; the raw data is
-/// held in the `Google_Protobuf_Any` message until you `unpack()` it into a
+/// held in the ``Google_Protobuf_Any`` message until you `unpack()` it into a
 /// message.  At this time, any error can occur that might have occurred from a
 /// regular decoding operation.  There are also other errors that can occur due
 /// to problems with the `Any` value's structure.
 public enum AnyUnpackError: Error {
-    /// The `type_url` field in the `Google_Protobuf_Any` message did not match
+    /// The `type_url` field in the ``Google_Protobuf_Any`` message did not match
     /// the message type provided to the `unpack()` method.
     case typeMismatch
 
@@ -31,7 +31,7 @@ public enum AnyUnpackError: Error {
     /// of the well-known type.
     case malformedWellKnownTypeJSON
 
-    /// The `Google_Protobuf_Any` message was malformed in some other way not
+    /// The ``Google_Protobuf_Any`` message was malformed in some other way not
     /// covered by the other error cases.
     case malformedAnyField
 }

--- a/Sources/SwiftProtobuf/AsyncMessageSequence.swift
+++ b/Sources/SwiftProtobuf/AsyncMessageSequence.swift
@@ -23,7 +23,7 @@ extension AsyncSequence where Element == UInt8 {
     ///   - messageType: The type of message to read.
     ///   - extensions: An ``ExtensionMap`` used to look up and decode any extensions in
     ///    messages encoded by this sequence, or in messages nested within these messages.
-    ///   - partial: If `false` (the default),  after decoding a message, ``Message/isInitialized-6abgi`
+    ///   - partial: If `false` (the default),  after decoding a message, ``Message/isInitialized-6abgi``
     ///     will be checked to ensure all fields are present.
     ///   - options: The ``BinaryDecodingOptions`` to use.
     /// - Returns: An asynchronous sequence of messages read from the `AsyncSequence` of bytes.

--- a/Sources/SwiftProtobuf/BinaryEncodingError.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingError.swift
@@ -14,7 +14,7 @@
 
 /// Describes errors that can occur when decoding a message from binary format.
 public enum BinaryEncodingError: Error, Hashable {
-    /// An unexpected failure when deserializing a `Google_Protobuf_Any`.
+    /// An unexpected failure when deserializing a ``Google_Protobuf_Any``.
     case anyTranscodeFailure
     /// The definition of the message or one of its nested messages has required
     /// fields but the message being encoded did not include values for them. You

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -16,12 +16,12 @@
 
 /// A collection of extension objects.
 ///
-/// An `ExtensionMap` is used during decoding to look up
+/// An ``ExtensionMap`` is used during decoding to look up
 /// extension objects corresponding to the serialized data.
 ///
 /// This is a protocol so that developers can build their own
 /// extension handling if they need something more complex than the
-/// standard `SimpleExtensionMap` implementation.
+/// standard ``SimpleExtensionMap`` implementation.
 @preconcurrency
 public protocol ExtensionMap: Sendable {
     /// Returns the extension object describing an extension or nil

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extends the `Google_Protobuf_Any` type with various custom behaviors.
+/// Extends the ``Google_Protobuf_Any`` type with various custom behaviors.
 ///
 // -----------------------------------------------------------------------------
 
@@ -55,15 +55,15 @@ extension Google_Protobuf_Any {
         _storage.state = .message(message)
     }
 
-    /// Creates a new `Google_Protobuf_Any` by decoding the given string
+    /// Creates a new ``Google_Protobuf_Any`` by decoding the given string
     /// containing a serialized message in Protocol Buffer text format.
     ///
     /// - Parameters:
     ///   - textFormatString: The text format string to decode.
-    ///   - extensions: An `ExtensionMap` used to look up and decode any
+    ///   - extensions: An ``ExtensionMap`` used to look up and decode any
     ///     extensions in this message or messages nested within this message's
     ///     fields.
-    /// - Throws: an instance of `TextFormatDecodingError` on failure.
+    /// - Throws: an instance of ``TextFormatDecodingError`` on failure.
     @_disfavoredOverload
     public init(
         textFormatString: String,
@@ -77,7 +77,7 @@ extension Google_Protobuf_Any {
         )
     }
 
-    /// Creates a new `Google_Protobuf_Any` by decoding the given string
+    /// Creates a new ``Google_Protobuf_Any`` by decoding the given string
     /// containing a serialized message in Protocol Buffer text format.
     ///
     /// - Parameters:
@@ -114,10 +114,10 @@ extension Google_Protobuf_Any {
         }
     }
 
-    /// Returns true if this `Google_Protobuf_Any` message contains the given
+    /// Returns true if this ``Google_Protobuf_Any`` message contains the given
     /// message type.
     ///
-    /// The check is performed by looking at the passed `Message.Type` and the
+    /// The check is performed by looking at the passed ``Message`` type and the
     /// `typeURL` of this message.
     ///
     /// - Parameter type: The concrete message type.

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -128,7 +128,7 @@ private func formatDuration(seconds: Int64, nanos: Int32) -> String? {
 }
 
 extension Google_Protobuf_Duration {
-    /// Creates a new `Google_Protobuf_Duration` equal to the given number of
+    /// Creates a new ``Google_Protobuf_Duration`` equal to the given number of
     /// seconds and nanoseconds.
     ///
     /// - Parameter seconds: The number of seconds.
@@ -157,7 +157,7 @@ extension Google_Protobuf_Duration: _CustomJSONCodable {
 extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = Double
 
-    /// Creates a new `Google_Protobuf_Duration` from a floating point literal
+    /// Creates a new ``Google_Protobuf_Duration`` from a floating point literal
     /// that is interpreted as a duration in seconds, rounded to the nearest
     /// nanosecond.
     public init(floatLiteral value: Double) {
@@ -167,7 +167,7 @@ extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
 
 extension Google_Protobuf_Duration {
     #if !REMOVE_DEPRECATED_APIS
-    /// Creates a new `Google_Protobuf_Duration` that is equal to the given
+    /// Creates a new ``Google_Protobuf_Duration`` that is equal to the given
     /// `TimeInterval` (measured in seconds), rounded to the nearest nanosecond.
     ///
     /// - Parameter timeInterval: The `TimeInterval`.
@@ -177,7 +177,7 @@ extension Google_Protobuf_Duration {
     }
     #endif  // !REMOVE_DEPRECATED_APIS
 
-    /// Creates a new `Google_Protobuf_Duration` that is equal to the given
+    /// Creates a new ``Google_Protobuf_Duration`` that is equal to the given
     /// `TimeInterval` (measured in seconds), rounded to the nearest nanosecond
     /// according to the given rounding rule.
     ///
@@ -203,7 +203,7 @@ extension Google_Protobuf_Duration {
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension Google_Protobuf_Duration {
-    /// Creates a new `Google_Protobuf_Duration` by rounding a `Duration` to
+    /// Creates a new ``Google_Protobuf_Duration`` by rounding a `Duration` to
     /// the nearest nanosecond according to the given rounding rule.
     ///
     /// - Parameters:
@@ -228,12 +228,12 @@ extension Google_Protobuf_Duration {
 extension Duration {
     /// Creates a new `Duration` that is equal to the given duration.
     ///
-    /// Swift `Duration` has a strictly higher precision than `Google_Protobuf_Duration`
+    /// Swift `Duration` has a strictly higher precision than ``Google_Protobuf_Duration``
     /// (attoseconds vs. nanoseconds, respectively), so this conversion is always
     /// value-preserving.
     ///
     /// - Parameters:
-    ///   - duration: The `Google_Protobuf_Duration`.
+    ///   - duration: The ``Google_Protobuf_Duration``.
     public init(_ duration: Google_Protobuf_Duration) {
         self.init(
             secondsComponent: duration.seconds,

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -134,7 +134,7 @@ extension Google_Protobuf_FieldMask: _CustomJSONCodable {
 
 #if FieldMaskUtilities
 extension Google_Protobuf_FieldMask {
-    /// Creates a new `Google_Protobuf_FieldMask` from the given array of paths.
+    /// Creates a new ``Google_Protobuf_FieldMask`` from the given array of paths.
     ///
     /// The paths should match the names used in the .proto file, which may be
     /// different than the corresponding Swift property names.
@@ -146,7 +146,7 @@ extension Google_Protobuf_FieldMask {
         paths = protoPaths
     }
 
-    /// Creates a new `Google_Protobuf_FieldMask` from the given paths.
+    /// Creates a new ``Google_Protobuf_FieldMask`` from the given paths.
     ///
     /// The paths should match the names used in the .proto file, which may be
     /// different than the corresponding Swift property names.
@@ -157,7 +157,7 @@ extension Google_Protobuf_FieldMask {
         self.init(protoPaths: protoPaths)
     }
 
-    /// Creates a new `Google_Protobuf_FieldMask` from the given paths.
+    /// Creates a new ``Google_Protobuf_FieldMask`` from the given paths.
     ///
     /// The paths should match the JSON names of the fields, which may be
     /// different than the corresponding Swift property names.
@@ -193,7 +193,7 @@ extension Google_Protobuf_FieldMask {
     ///   - messageType: Message type to get all paths from.
     ///   - fieldNumbers: Field numbers of paths to be included.
     /// - Returns: Field mask that include paths of corresponding field numbers.
-    /// - Throws: `FieldMaskError.invalidFieldNumber` if the field number
+    /// - Throws: ``FieldMaskError/invalidFieldNumber`` if the field number
     ///  is not on the message
     public init<M: Message & _ProtoNameProviding>(
         fieldNumbers: [Int],

--- a/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_ListValue+Extensions.swift
@@ -18,8 +18,8 @@ extension Google_Protobuf_ListValue: ExpressibleByArrayLiteral {
     // bits down to values
     public typealias Element = Google_Protobuf_Value
 
-    /// Creates a new `Google_Protobuf_ListValue` from an array literal containing
-    /// `Google_Protobuf_Value` elements.
+    /// Creates a new ``Google_Protobuf_ListValue`` from an array literal containing
+    /// ``Google_Protobuf_Value`` elements.
     public init(arrayLiteral elements: Element...) {
         self.init(values: elements)
     }
@@ -65,17 +65,17 @@ extension Google_Protobuf_ListValue: _CustomJSONCodable {
 }
 
 extension Google_Protobuf_ListValue {
-    /// Creates a new `Google_Protobuf_ListValue` from the given array of
-    /// `Google_Protobuf_Value` elements.
+    /// Creates a new ``Google_Protobuf_ListValue`` from the given array of
+    /// ``Google_Protobuf_Value`` elements.
     ///
-    /// - Parameter values: The list of `Google_Protobuf_Value` messages from
-    ///   which to create the `Google_Protobuf_ListValue`.
+    /// - Parameter values: The list of ``Google_Protobuf_Value`` messages from
+    ///   which to create the ``Google_Protobuf_ListValue``.
     public init(values: [Google_Protobuf_Value]) {
         self.init()
         self.values = values
     }
 
-    /// Accesses the `Google_Protobuf_Value` at the specified position.
+    /// Accesses the ``Google_Protobuf_Value`` at the specified position.
     ///
     /// - Parameter index: The position of the element to access.
     public subscript(index: Int) -> Google_Protobuf_Value {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Struct+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Struct+Extensions.swift
@@ -17,8 +17,8 @@ extension Google_Protobuf_Struct: ExpressibleByDictionaryLiteral {
     public typealias Key = String
     public typealias Value = Google_Protobuf_Value
 
-    /// Creates a new `Google_Protobuf_Struct` from a dictionary of string keys to
-    /// values of type `Google_Protobuf_Value`.
+    /// Creates a new ``Google_Protobuf_Struct`` from a dictionary of string keys to
+    /// values of type ``Google_Protobuf_Value``.
     public init(dictionaryLiteral: (String, Google_Protobuf_Value)...) {
         self.init()
         for (k, v) in dictionaryLiteral {
@@ -64,18 +64,18 @@ extension Google_Protobuf_Struct: _CustomJSONCodable {
 }
 
 extension Google_Protobuf_Struct {
-    /// Creates a new `Google_Protobuf_Struct` from a dictionary of string keys to
-    /// values of type `Google_Protobuf_Value`.
+    /// Creates a new ``Google_Protobuf_Struct`` from a dictionary of string keys to
+    /// values of type ``Google_Protobuf_Value``.
     ///
     /// - Parameter fields: The dictionary from field names to
-    ///   `Google_Protobuf_Value` messages that should be used to create the
+    ///   ``Google_Protobuf_Value`` messages that should be used to create the
     ///   `Struct`.
     public init(fields: [String: Google_Protobuf_Value]) {
         self.init()
         self.fields = fields
     }
 
-    /// Accesses the `Google_Protobuf_Value` with the given key for reading and
+    /// Accesses the ``Google_Protobuf_Value`` with the given key for reading and
     /// writing.
     ///
     /// This key-based subscript returns the `Value` for the given key if the key

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -231,7 +231,7 @@ private func formatTimestamp(seconds: Int64, nanos: Int32) -> String? {
 }
 
 extension Google_Protobuf_Timestamp {
-    /// Creates a new `Google_Protobuf_Timestamp` equal to the given number of
+    /// Creates a new ``Google_Protobuf_Timestamp`` equal to the given number of
     /// seconds and nanoseconds.
     ///
     /// - Parameter seconds: The number of seconds.
@@ -260,7 +260,7 @@ extension Google_Protobuf_Timestamp: _CustomJSONCodable {
 
 extension Google_Protobuf_Timestamp {
     #if !REMOVE_DEPRECATED_APIS
-    /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// Creates a new ``Google_Protobuf_Timestamp`` initialized relative to 00:00:00
     /// UTC on 1 January 1970 by a given number of seconds.
     ///
     /// - Parameter timeIntervalSince1970: The `TimeInterval`, interpreted as
@@ -271,7 +271,7 @@ extension Google_Protobuf_Timestamp {
     }
     #endif  // !REMOVE_DEPRECATED_APIS
 
-    /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// Creates a new ``Google_Protobuf_Timestamp`` initialized relative to 00:00:00
     /// UTC on 1 January 1970 by a given number of seconds, rounded to the nearest
     /// nanosecond according to the given rounding rule.
     ///
@@ -291,7 +291,7 @@ extension Google_Protobuf_Timestamp {
     }
 
     #if !REMOVE_DEPRECATED_APIS
-    /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// Creates a new ``Google_Protobuf_Timestamp`` initialized relative to 00:00:00
     /// UTC on 1 January 2001 by a given number of seconds.
     ///
     /// - Parameter timeIntervalSinceReferenceDate: The `TimeInterval`,
@@ -305,7 +305,7 @@ extension Google_Protobuf_Timestamp {
     }
     #endif  // !REMOVE_DEPRECATED_APIS
 
-    /// Creates a new `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// Creates a new ``Google_Protobuf_Timestamp`` initialized relative to 00:00:00
     /// UTC on 1 January 2001 by a given number of seconds, rounded to the nearest
     /// nanosecond according to the given rounding rule.
     ///
@@ -332,7 +332,7 @@ extension Google_Protobuf_Timestamp {
         self.init(seconds: s, nanos: n)
     }
 
-    /// Creates a new `Google_Protobuf_Timestamp` initialized to the same time as
+    /// Creates a new ``Google_Protobuf_Timestamp`` initialized to the same time as
     /// the given `Date`.
     ///
     /// - Parameter date: The `Date` with which to initialize the timestamp.

--- a/Sources/SwiftProtobuf/Google_Protobuf_Value+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Value+Extensions.swift
@@ -16,7 +16,7 @@
 extension Google_Protobuf_Value: ExpressibleByIntegerLiteral {
     public typealias IntegerLiteralType = Int64
 
-    /// Creates a new `Google_Protobuf_Value` from an integer literal.
+    /// Creates a new ``Google_Protobuf_Value`` from an integer literal.
     public init(integerLiteral value: Int64) {
         self.init(kind: .numberValue(Double(value)))
     }
@@ -25,7 +25,7 @@ extension Google_Protobuf_Value: ExpressibleByIntegerLiteral {
 extension Google_Protobuf_Value: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = Double
 
-    /// Creates a new `Google_Protobuf_Value` from a floating point literal.
+    /// Creates a new ``Google_Protobuf_Value`` from a floating point literal.
     public init(floatLiteral value: Double) {
         self.init(kind: .numberValue(value))
     }
@@ -34,7 +34,7 @@ extension Google_Protobuf_Value: ExpressibleByFloatLiteral {
 extension Google_Protobuf_Value: ExpressibleByBooleanLiteral {
     public typealias BooleanLiteralType = Bool
 
-    /// Creates a new `Google_Protobuf_Value` from a boolean literal.
+    /// Creates a new ``Google_Protobuf_Value`` from a boolean literal.
     public init(booleanLiteral value: Bool) {
         self.init(kind: .boolValue(value))
     }
@@ -45,24 +45,24 @@ extension Google_Protobuf_Value: ExpressibleByStringLiteral {
     public typealias ExtendedGraphemeClusterLiteralType = String
     public typealias UnicodeScalarLiteralType = String
 
-    /// Creates a new `Google_Protobuf_Value` from a string literal.
+    /// Creates a new ``Google_Protobuf_Value`` from a string literal.
     public init(stringLiteral value: String) {
         self.init(kind: .stringValue(value))
     }
 
-    /// Creates a new `Google_Protobuf_Value` from a Unicode scalar literal.
+    /// Creates a new ``Google_Protobuf_Value`` from a Unicode scalar literal.
     public init(unicodeScalarLiteral value: String) {
         self.init(kind: .stringValue(value))
     }
 
-    /// Creates a new `Google_Protobuf_Value` from a character literal.
+    /// Creates a new ``Google_Protobuf_Value`` from a character literal.
     public init(extendedGraphemeClusterLiteral value: String) {
         self.init(kind: .stringValue(value))
     }
 }
 
 extension Google_Protobuf_Value: ExpressibleByNilLiteral {
-    /// Creates a new `Google_Protobuf_Value` from the nil literal.
+    /// Creates a new ``Google_Protobuf_Value`` from the nil literal.
     public init(nilLiteral: ()) {
         self.init(kind: .nullValue(.nullValue))
     }
@@ -109,38 +109,38 @@ extension Google_Protobuf_Value: _CustomJSONCodable {
 }
 
 extension Google_Protobuf_Value {
-    /// Creates a new `Google_Protobuf_Value` with the given kind.
+    /// Creates a new ``Google_Protobuf_Value`` with the given kind.
     fileprivate init(kind: OneOf_Kind) {
         self.init()
         self.kind = kind
     }
 
-    /// Creates a new `Google_Protobuf_Value` whose `kind` is `numberValue` with
+    /// Creates a new ``Google_Protobuf_Value`` whose `kind` is `numberValue` with
     /// the given floating-point value.
     public init(numberValue: Double) {
         self.init(kind: .numberValue(numberValue))
     }
 
-    /// Creates a new `Google_Protobuf_Value` whose `kind` is `stringValue` with
+    /// Creates a new ``Google_Protobuf_Value`` whose `kind` is `stringValue` with
     /// the given string value.
     public init(stringValue: String) {
         self.init(kind: .stringValue(stringValue))
     }
 
-    /// Creates a new `Google_Protobuf_Value` whose `kind` is `boolValue` with the
+    /// Creates a new ``Google_Protobuf_Value`` whose `kind` is `boolValue` with the
     /// given boolean value.
     public init(boolValue: Bool) {
         self.init(kind: .boolValue(boolValue))
     }
 
-    /// Creates a new `Google_Protobuf_Value` whose `kind` is `structValue` with
-    /// the given `Google_Protobuf_Struct` value.
+    /// Creates a new ``Google_Protobuf_Value`` whose `kind` is `structValue` with
+    /// the given ``Google_Protobuf_Struct`` value.
     public init(structValue: Google_Protobuf_Struct) {
         self.init(kind: .structValue(structValue))
     }
 
-    /// Creates a new `Google_Protobuf_Value` whose `kind` is `listValue` with the
-    /// given `Google_Struct_ListValue` value.
+    /// Creates a new ``Google_Protobuf_Value`` whose `kind` is `listValue` with the
+    /// given ``Google_Protobuf_ListValue`` value.
     public init(listValue: Google_Protobuf_ListValue) {
         self.init(kind: .listValue(listValue))
     }

--- a/Sources/SwiftProtobuf/JSONEncodingError.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingError.swift
@@ -28,7 +28,7 @@ public enum JSONEncodingError: Error, Hashable {
     case fieldMaskConversion
     /// Field names were not compiled into the binary
     case missingFieldNames
-    /// Instances of `Google_Protobuf_Value` can only be encoded if they have a
+    /// Instances of ``Google_Protobuf_Value`` can only be encoded if they have a
     /// valid `kind` (that is, they represent a null value, number, boolean,
     /// string, struct, or list).
     case missingValue

--- a/Sources/SwiftProtobuf/Message+AnyAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+AnyAdditions.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extends the `Message` type with `Google_Protobuf_Any`-specific behavior.
+/// Extends the ``Message`` type with ``Google_Protobuf_Any``-specific behavior.
 ///
 // -----------------------------------------------------------------------------
 
@@ -28,7 +28,7 @@ extension Message {
     /// See `Google_Protobuf_Any.unpackTo()` for more discussion.
     ///
     /// - Parameter unpackingAny: the message to decode.
-    /// - Parameter extensions: An `ExtensionMap` used to look up and decode any
+    /// - Parameter extensions: An ``ExtensionMap`` used to look up and decode any
     ///   extensions in this message or messages nested within this message's
     ///   fields.
     /// - Parameter options: The BinaryDecodingOptions to use.

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `Message` to provide binary coding and decoding.
+/// Extensions to ``Message`` to provide binary coding and decoding.
 ///
 // -----------------------------------------------------------------------------
 
@@ -25,7 +25,7 @@ extension Message {
     ///
     /// - Parameters:
     ///   - partial: If `false` (the default), this method will check
-    ///     `Message.isInitialized` before encoding to verify that all required
+    ///     ``Message/isInitialized-6abgi`` before encoding to verify that all required
     ///     fields are present. If any are missing, this method throws.
     ///     ``BinaryEncodingError/missingRequiredFields``.
     ///   - options: The ``BinaryEncodingOptions`` to use.
@@ -79,7 +79,7 @@ extension Message {
         return visitor.serializedSize
     }
 
-    /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes` value
+    /// Creates a new message by decoding the given ``SwiftProtobufContiguousBytes`` value
     /// containing a serialized message in Protocol Buffer binary format.
     ///
     /// - Parameters:
@@ -132,7 +132,7 @@ extension Message {
     }
     #endif
 
-    /// Updates the message by decoding the given `SwiftProtobufContiguousBytes` value
+    /// Updates the message by decoding the given ``SwiftProtobufContiguousBytes`` value
     /// containing a serialized message in Protocol Buffer binary format into the
     /// receiver.
     ///

--- a/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+BinaryAdditions_Data.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `Message` to provide binary coding and decoding using ``Foundation/Data``.
+/// Extensions to ``Message`` to provide binary coding and decoding using ``Foundation/Data``.
 ///
 // -----------------------------------------------------------------------------
 

--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `Message` to support JSON encoding/decoding.
+/// Extensions to ``Message`` to support JSON encoding/decoding.
 ///
 // -----------------------------------------------------------------------------
 
@@ -39,12 +39,12 @@ extension Message {
         return String(decoding: data, as: UTF8.self)
     }
 
-    /// Returns a `SwiftProtobufContiguousBytes` containing the UTF-8 JSON serialization of the message.
+    /// Returns a ``SwiftProtobufContiguousBytes`` containing the UTF-8 JSON serialization of the message.
     ///
     /// Unlike binary encoding, presence of required fields is not enforced when
     /// serializing to JSON.
     ///
-    /// - Returns: A `SwiftProtobufContiguousBytes` containing the JSON serialization of the message.
+    /// - Returns: A ``SwiftProtobufContiguousBytes`` containing the JSON serialization of the message.
     /// - Parameters:
     ///   - options: The JSONEncodingOptions to use.
     /// - Throws: ``SwiftProtobufError`` or ``JSONEncodingError`` if encoding fails.
@@ -97,7 +97,7 @@ extension Message {
         }
     }
 
-    /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes`
+    /// Creates a new message by decoding the given ``SwiftProtobufContiguousBytes``
     /// containing a serialized message in JSON format, interpreting the data as UTF-8 encoded
     /// text.
     ///
@@ -112,7 +112,7 @@ extension Message {
         try self.init(jsonUTF8Bytes: jsonUTF8Bytes, extensions: nil, options: options)
     }
 
-    /// Creates a new message by decoding the given `SwiftProtobufContiguousBytes`
+    /// Creates a new message by decoding the given ``SwiftProtobufContiguousBytes``
     /// containing a serialized message in JSON format, interpreting the data as UTF-8 encoded
     /// text.
     ///

--- a/Sources/SwiftProtobuf/Message+JSONAdditions_Data.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions_Data.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `Message` to support JSON encoding/decoding  using ``Foundation/Data``.
+/// Extensions to ``Message`` to support JSON encoding/decoding  using ``Foundation/Data``.
 ///
 // -----------------------------------------------------------------------------
 

--- a/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
@@ -38,12 +38,12 @@ extension Message {
         return String(decoding: data, as: UTF8.self)
     }
 
-    /// Returns a `SwiftProtobufContiguousBytes` containing the UTF-8 JSON serialization of the messages.
+    /// Returns a ``SwiftProtobufContiguousBytes`` containing the UTF-8 JSON serialization of the messages.
     ///
     /// Unlike binary encoding, presence of required fields is not enforced when
     /// serializing to JSON.
     ///
-    /// - Returns: A `SwiftProtobufContiguousBytes` containing the JSON serialization of the messages.
+    /// - Returns: A ``SwiftProtobufContiguousBytes`` containing the JSON serialization of the messages.
     /// - Parameters:
     ///   - collection: The list of messages to encode.
     ///   - options: The JSONEncodingOptions to use.

--- a/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+TextFormatAdditions.swift
@@ -8,7 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 ///
-/// Extensions to `Message` to support text format encoding/decoding.
+/// Extensions to ``Message`` to support text format encoding/decoding.
 ///
 // -----------------------------------------------------------------------------
 

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -8,12 +8,12 @@
 //
 
 /// The protocol which all generated protobuf messages implement.
-/// `Message` is the protocol type you should use whenever
+/// ``Message`` is the protocol type you should use whenever
 /// you need an argument or variable which holds "some message".
 ///
 /// Generated messages also implement `Hashable`, and thus `Equatable`.
 /// However, the protocol conformance is declared on a different protocol.
-/// This allows you to use `Message` as a type directly:
+/// This allows you to use ``Message`` as a type directly:
 ///
 ///     func consume(message: Message) { ... }
 ///
@@ -67,21 +67,21 @@ public protocol Message: Sendable, CustomDebugStringConvertible {
     ///
     /// This is the core method used by the deserialization machinery. It is
     /// `public` to enable users to implement their own encoding formats by
-    /// conforming to `Decoder`; it should not be called otherwise.
+    /// conforming to ``Decoder``; it should not be called otherwise.
     ///
     /// Note that this is not specific to binary encodng; formats that use
     /// textual identifiers translate those to field numbers and also go
     /// through this to decode messages.
     ///
     /// - Parameters:
-    ///   - decoder: a `Decoder`; the `Message` will call the method
+    ///   - decoder: a ``Decoder``; the ``Message`` will call the method
     ///     corresponding to the type of this field.
     /// - Throws: an error on failure or type mismatch.  The type of error
     ///     thrown depends on which decoder is used.
     mutating func decodeMessage<D: Decoder>(decoder: inout D) throws
 
     /// Traverses the fields of the message, calling the appropriate methods
-    /// of the passed `Visitor` object.
+    /// of the passed ``Visitor`` object.
     ///
     /// This is used internally by:
     ///
@@ -107,7 +107,7 @@ public protocol Message: Sendable, CustomDebugStringConvertible {
     /// `Hashable` protocol.
     func hash(into hasher: inout Hasher)
 
-    /// Helper to compare `Message`s when not having a specific type to use
+    /// Helper to compare ``Message``s when not having a specific type to use
     /// normal `Equatable`. `Equatable` is provided with specific generated
     /// types.
     func isEqualTo(message: any Message) -> Bool
@@ -172,9 +172,9 @@ extension Message {
 
 /// Implementation base for all messages; not intended for client use.
 ///
-/// In general, use `SwiftProtobuf.Message` instead when you need a variable or
+/// In general, use ``Message`` instead when you need a variable or
 /// argument that can hold any type of message. Occasionally, you can use
-/// `SwiftProtobuf.Message & Equatable` or `SwiftProtobuf.Message & Hashable` as
+/// ``Message`` & `Equatable` or ``Message`` & `Hashable` as
 /// generic constraints if you need to write generic code that can be applied to
 /// multiple message types that uses equality tests, puts messages in a `Set`,
 /// or uses them as `Dictionary` keys.

--- a/Sources/SwiftProtobuf/SwiftProtobufContiguousBytes.swift
+++ b/Sources/SwiftProtobuf/SwiftProtobufContiguousBytes.swift
@@ -20,7 +20,7 @@ import Foundation
 /// provide such a protocol.
 ///
 /// By conforming your own types to this protocol, you will be able to pass instances of said types
-/// directly to `SwiftProtobuf.Message`'s deserialisation methods
+/// directly to ``Message``'s deserialisation methods
 /// (i.e. `init(contiguousBytes:)` for binary format and `init(jsonUTF8Bytes:)` for JSON).
 public protocol SwiftProtobufContiguousBytes {
     /// An initializer for a bag of bytes type.


### PR DESCRIPTION
## Summary
- Convert single-backtick type references to DocC double-backtick symbol links in hand-written public API docs
- Focused on high-traffic `Sources/SwiftProtobuf` files (Message, extensions, encoding helpers); left stdlib/Foundation names as single backticks

Fixes #1925

## Test plan
- [x] `swift package generate-documentation --target SwiftProtobuf` (no unresolved-link warnings)
- [ ] Spot-check symbol links in Xcode documentation browser