### PR TITLE
Run CompileTests in separate GitHub CI jobs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         # Looking at https://hub.docker.com/_/swift, the version only tags (i.e. - 6.1)
         # could use different Ubuntu releases. At the moment they are all the "noble",
         # which is also what would be desired, so we don't bother listing explicit ones.
-        swift: ["6.3", "6.2", "6.1"]
+        swift: &swift_versions ["6.3", "6.2", "6.1"]
         traits: ["default", "disable-default-traits", "BinaryDelimitedStreams", "FieldMaskUtilities"]
 
         include:
@@ -58,8 +58,27 @@ jobs:
     - name: Test SPM plugin
       if: ${{ matrix.traits == 'default' }}
       run: make test-spm-plugin
+
+  compile_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: *swift_versions
+    name: Swift ${{ matrix.swift }} | Compilation Tests
+    container:
+      image: swift:${{ matrix.swift }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Update and install dependencies
+      # Just ensure we have the latest `g++` for building protoc (since it is
+      # built by SwiftPM), full dependencies available at
+      # https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
+      #
+      # `make` is needed for using our own `Makefile`.
+      run: apt-get update && apt-get install -y make g++
     - name: Compilation Tests
-      if: ${{ matrix.traits == 'default' }}
       run: make compile-tests
 
   linkage-test:


### PR DESCRIPTION
These tests are separate "sub-packages" in the repo, so when they're built, they each independently rebuild the SwiftProtobuf runtime (and in some cases, protoc and the plugin). Move them into their own separate checks so they run in parallel with the main build.