### PR TITLE
[table-driven-branch] Add our own `Lock` that doesn't require Foundation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,22 +82,21 @@ jobs:
     - name: Compilation Tests
       run: make compile-tests
 
-# TODO: Enable this when the NSLock usage is resolved.
-#   linkage-test:
-#     runs-on: ubuntu-latest
-#     name: Foundation linkage test
-#     container:
-#       image: swift:latest
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v6
-#     - name: Update and install dependencies
-#       # Just ensure we have the latest `g++` for building protoc (since it is
-#       # built by SwiftPM), full dependencies available at
-#       # https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
-#       run: apt-get update && apt-get install -y g++
-#     - name: Run linkage test
-#       run: ./scripts/run-linkage-test.sh
+  linkage-test:
+    runs-on: ubuntu-latest
+    name: Foundation linkage test
+    container:
+      image: swift:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Update and install dependencies
+      # Just ensure we have the latest `g++` for building protoc (since it is
+      # built by SwiftPM), full dependencies available at
+      # https://github.com/protocolbuffers/protobuf/blob/main/src/README.md
+      run: apt-get update && apt-get install -y g++
+    - name: Run linkage test
+      run: ./scripts/run-linkage-test.sh
 
   format-check:
     name: swift-format Check

--- a/Sources/SwiftProtobuf/Lock.swift
+++ b/Sources/SwiftProtobuf/Lock.swift
@@ -1,0 +1,218 @@
+// Sources/SwiftProtobuf/Lock.swift - Cross-platform synchronization lock
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Cross-platform synchronization lock adapted from SwiftNIO's `NIOLock`, but
+/// using `os_unfair_lock` on Apple platforms as a performance improvement
+/// there.
+///
+// -----------------------------------------------------------------------------
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import ucrt
+import WinSDK
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(Bionic)
+@preconcurrency import Bionic
+#elseif canImport(WASILibc)
+@preconcurrency import WASILibc
+#if canImport(wasi_pthread)
+import wasi_pthread
+#endif
+#else
+#error("Unable to identify your C library")
+#endif
+
+/// A threading lock based on `os_unfair_lock` on Apple platforms, `SRWLOCK` on
+/// Windows, and `pthread_mutex_t` on other POSIX platforms.
+///
+/// - Note: ``Lock`` has reference semantics.
+struct Lock: ~Copyable {
+    @usableFromInline
+    let _storage: LockStorage<Void>
+
+    /// Create a new lock.
+    @inlinable
+    init() {
+        self._storage = .create(value: ())
+    }
+
+    /// Acquire the lock for the duration of the given block.
+    ///
+    /// - Parameter body: The block to execute while holding the lock.
+    /// - Returns: The value returned by the block.
+    @inlinable
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+        return try body()
+    }
+
+    /// Acquire the lock.
+    @inlinable
+    func lock() {
+        self._storage.lock()
+    }
+
+    /// Release the lock.
+    @inlinable
+    func unlock() {
+        self._storage.unlock()
+    }
+}
+
+extension Lock: @unchecked Sendable {}
+
+#if canImport(Darwin)
+@usableFromInline
+typealias LockPrimitive = os_unfair_lock_s
+#elseif os(Windows)
+@usableFromInline
+typealias LockPrimitive = SRWLOCK
+#elseif os(FreeBSD) || os(OpenBSD)
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t?
+#else
+@usableFromInline
+typealias LockPrimitive = pthread_mutex_t
+#endif
+
+@usableFromInline
+enum LockOperations: Sendable {
+    @inlinable
+    static func create(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if canImport(Darwin)
+        mutex.initialize(to: os_unfair_lock_s())
+        #elseif os(Windows)
+        InitializeSRWLock(mutex)
+        #elseif os(FreeBSD) || os(OpenBSD)
+        var attr = pthread_mutexattr_t(bitPattern: 0)
+        pthread_mutexattr_init(&attr)
+        let err = pthread_mutex_init(mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr)
+        #if DEBUG
+        pthread_mutexattr_settype(&attr, Int32(PTHREAD_MUTEX_ERRORCHECK))
+        #endif
+
+        let err = pthread_mutex_init(mutex, &attr)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func destroy(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if canImport(Darwin)
+        // os_unfair_lock does not need to be freed
+        #elseif os(Windows)
+        // SRWLOCK does not need to be freed
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_destroy(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func lock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if canImport(Darwin)
+        os_unfair_lock_lock(mutex)
+        #elseif os(Windows)
+        AcquireSRWLockExclusive(mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_lock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+
+    @inlinable
+    static func unlock(_ mutex: UnsafeMutablePointer<LockPrimitive>) {
+        mutex.assertValidAlignment()
+
+        #if canImport(Darwin)
+        os_unfair_lock_unlock(mutex)
+        #elseif os(Windows)
+        ReleaseSRWLockExclusive(mutex)
+        #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))
+        let err = pthread_mutex_unlock(mutex)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
+        #endif
+    }
+}
+
+// Tail allocate both the mutex and a generic value using ManagedBuffer.
+// Both the header pointer and the elements pointer are stable for
+// the class's entire lifetime.
+//
+// See https://github.com/apple/swift-nio/blob/main/Sources/NIOConcurrencyHelpers/NIOLock.swift
+// for more information about why this stores the lock in the "elements" section
+// of the buffer instead of the header.
+@usableFromInline
+final class LockStorage<Value>: ManagedBuffer<Value, LockPrimitive> {
+    @inlinable
+    static func create(value: Value) -> Self {
+        let buffer = Self.create(minimumCapacity: 1) { _ in
+            value
+        }
+        let storage = unsafeDowncast(buffer, to: Self.self)
+        storage.withUnsafeMutablePointers { _, lockPtr in
+            LockOperations.create(lockPtr)
+        }
+        return storage
+    }
+
+    @inlinable
+    func lock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.lock(lockPtr)
+        }
+    }
+
+    @inlinable
+    func unlock() {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.unlock(lockPtr)
+        }
+    }
+
+    @inlinable
+    deinit {
+        self.withUnsafeMutablePointerToElements { lockPtr in
+            LockOperations.destroy(lockPtr)
+        }
+    }
+}
+
+// This compiler guard is here because `ManagedBuffer` is already declaring
+// Sendable unavailability after 6.1, which `LockStorage` inherits.
+#if compiler(<6.2)
+@available(*, unavailable)
+extension LockStorage: Sendable {}
+#endif
+
+extension UnsafeMutablePointer {
+    @inlinable
+    func assertValidAlignment() {
+        assert(UInt(bitPattern: self) % UInt(MemoryLayout<Pointee>.alignment) == 0)
+    }
+}

--- a/Sources/SwiftProtobuf/ReflectionTableReference.swift
+++ b/Sources/SwiftProtobuf/ReflectionTableReference.swift
@@ -51,14 +51,7 @@ final class ReflectionTableReference: @unchecked Sendable {
     /// Calls the given body with the reflection table, decompressing it on the
     /// first call if needed.
     func withTable<R>(_ body: (borrowing ReflectionTable) throws -> R) rethrows -> R {
-        // Fast path (lock-free): if we already have the decompressed table, use it.
-        if let table = cachedTable {
-            return try body(table)
-        }
-
-        return try lock.withLock {
-            // Second chance: another thread may have decompressed the table while
-            // we were waiting for the lock.
+        try lock.withLock {
             if let table = cachedTable {
                 return try body(table)
             }

--- a/Sources/SwiftProtobuf/ReflectionTableReference.swift
+++ b/Sources/SwiftProtobuf/ReflectionTableReference.swift
@@ -51,9 +51,9 @@ final class ReflectionTableReference: @unchecked Sendable {
     /// Calls the given body with the reflection table, decompressing it on the
     /// first call if needed.
     func withTable<R>(_ body: (borrowing ReflectionTable) throws -> R) rethrows -> R {
-        try lock.withLock {
+        let table: ReflectionTable = lock.withLock {
             if let table = cachedTable {
-                return try body(table)
+                return table
             }
 
             guard let compressed else {
@@ -65,7 +65,8 @@ final class ReflectionTableReference: @unchecked Sendable {
                 data: Compression.decompress(compressed)
             )
             cachedTable = table
-            return try body(table)
+            return table
         }
+        return try body(table)
     }
 }

--- a/Sources/SwiftProtobuf/ReflectionTableReference.swift
+++ b/Sources/SwiftProtobuf/ReflectionTableReference.swift
@@ -13,60 +13,66 @@
 ///
 // -----------------------------------------------------------------------------
 
-// TODO: Use this when not always using NSLock
-//#if canImport(FoundationEssentials)
-//import FoundationEssentials
-//#else
-//import Foundation
-//#endif
-import Foundation
-
 /// A reference to a reflection table, which may be inlined (embedded in the generated code) or
 /// stored as a compressed buffer.
 final class ReflectionTableReference: @unchecked Sendable {
-    private enum State {
-        case compressed(UnsafeRawBufferPointer, fieldCount: Int)
-        case direct(ReflectionTable)
-    }
+    /// The compressed reflection table data, if any.
+    private let compressed: UnsafeRawBufferPointer?
+
+    /// The number of fields in the message whose reflection table is being referenced.
+    private let fieldCount: Int
 
     /// A singleton instance that references the fixed reflection table for map entries.
     static let mapEntry: ReflectionTableReference = .init(direct: .mapEntry)
 
-    /// Guards `state`.
-    private let lock = NSLock()
+    /// Guards `cachedTable` during decompression.
+    private let lock = Lock()
 
-    /// The state of the table, either compressed or decompressed.
-    private var state: State
+    /// The cached decompressed reflection table.
+    private var cachedTable: ReflectionTable?
 
     /// Creates a new reflection table reference from a compressed buffer.
     ///
     /// The pointer to the compressed data is assumed to be immortal (either static data in
     /// the binary or allocated in a pool that lives for the lifetime of the reference).
     init(compressed: UnsafeRawBufferPointer, fieldCount: Int) {
-        self.state = .compressed(compressed, fieldCount: fieldCount)
+        self.compressed = compressed
+        self.fieldCount = fieldCount
+        self.cachedTable = nil
     }
 
     /// Creates a new reference to an existing reflection table.
     private init(direct table: ReflectionTable) {
-        self.state = .direct(table)
+        self.compressed = nil
+        self.fieldCount = 0
+        self.cachedTable = table
     }
 
     /// Calls the given body with the reflection table, decompressing it on the
     /// first call if needed.
     func withTable<R>(_ body: (borrowing ReflectionTable) throws -> R) rethrows -> R {
-        try lock.withLock {
-            switch state {
-            case .direct(let table):
-                return try body(table)
+        // Fast path (lock-free): if we already have the decompressed table, use it.
+        if let table = cachedTable {
+            return try body(table)
+        }
 
-            case .compressed(let buffer, let fieldCount):
-                let table = ReflectionTable(
-                    fieldCount: fieldCount,
-                    data: Compression.decompress(buffer)
-                )
-                state = .direct(table)
+        return try lock.withLock {
+            // Second chance: another thread may have decompressed the table while
+            // we were waiting for the lock.
+            if let table = cachedTable {
                 return try body(table)
             }
+
+            guard let compressed else {
+                fatalError("Corrupted state: compressed buffer missing")
+            }
+
+            let table = ReflectionTable(
+                fieldCount: fieldCount,
+                data: Compression.decompress(compressed)
+            )
+            cachedTable = table
+            return try body(table)
         }
     }
 }


### PR DESCRIPTION
This is adapted from `NIOLock` in swift-nio, but using `os_unfair_lock` on Apple platforms instead of `pthread_mutex`.

Also re-enable the no-Foundation linkage test.