### PR TITLE
[table-driven-branch] Add runtime support for looking up weak schemas and generate those lookups.

### DIFF
--- a/CompileTests/WeakImports/Package.swift
+++ b/CompileTests/WeakImports/Package.swift
@@ -12,6 +12,10 @@ let swiftSettings: [SwiftSetting] = [
     .unsafeFlags(["-Xfrontend", "-internalize-at-link"])
 ]
 
+let linkerSettings: [LinkerSetting] = [
+    .unsafeFlags(["-Xlinker", "-export-dynamic"], .when(platforms: [.linux, .android]))
+]
+
 let package = Package(
     name: "WeakImports",
     dependencies: [
@@ -46,7 +50,8 @@ let package = Package(
             dependencies: [
                 .target(name: "ModuleA")
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings,
+            linkerSettings: linkerSettings
         ),
     ]
 )

--- a/CompileTests/WeakImports/Sources/Client/Client.swift
+++ b/CompileTests/WeakImports/Sources/Client/Client.swift
@@ -27,6 +27,7 @@ struct Main {
             // HAS-SYMBOL: type metadata accessor for ModuleA.Test_MessageA
             // HAS-SYMBOL: type metadata for ModuleA.Test_MessageA
             // HAS-SYMBOL: ModuleA.Test_MessageA.init() -> ModuleA.Test_MessageA
+            // HAS-SYMBOL: _test_MessageA_getMessageSchema
             var msg = Test_MessageA()
             msg.title = "Hello Weak Imports"
             expect(msg.hasTitle)
@@ -40,6 +41,7 @@ struct Main {
             // HAS-SYMBOL: nominal type descriptor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata accessor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata for ModuleC.Test_MessageC
+            // HAS-SYMBOL: _test_MessageC_getMessageSchema
             msg.nestedC.id = 12345
             expect(msg.hasNestedC)
             expect(msg.nestedC.id == 12345)
@@ -62,7 +64,8 @@ struct Main {
         // particular pattern end up in the final linkage.
         //
         // Protobuf runtime support:
-        //   HAS-SYMBOL: ModuleB.Test_MessageB.messageSchema.unsafeMutableAddressor : SwiftProtobuf.MessageSchema
+        //   HAS-SYMBOL: _test_MessageB_getMessageSchema
+        //   HAS-SYMBOL-NOT: ModuleB.Test_MessageB.messageSchema.unsafeMutableAddressor : SwiftProtobuf.MessageSchema
         //   HAS-SYMBOL: static ModuleB.Test_MessageB.messageSchema : SwiftProtobuf.MessageSchema
         //
         // Protocol conformance support:

--- a/CompileTests/WeakImports/Sources/Client/Client.swift
+++ b/CompileTests/WeakImports/Sources/Client/Client.swift
@@ -27,7 +27,7 @@ struct Main {
             // HAS-SYMBOL: type metadata accessor for ModuleA.Test_MessageA
             // HAS-SYMBOL: type metadata for ModuleA.Test_MessageA
             // HAS-SYMBOL: ModuleA.Test_MessageA.init() -> ModuleA.Test_MessageA
-            // HAS-SYMBOL: _test_MessageA_getMessageSchema
+            // HAS-SYMBOL: _test_DMessageA_getMessageSchema
             var msg = Test_MessageA()
             msg.title = "Hello Weak Imports"
             expect(msg.hasTitle)
@@ -41,7 +41,7 @@ struct Main {
             // HAS-SYMBOL: nominal type descriptor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata accessor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata for ModuleC.Test_MessageC
-            // HAS-SYMBOL: _test_MessageC_getMessageSchema
+            // HAS-SYMBOL: _test_DMessageC_getMessageSchema
             msg.nestedC.id = 12345
             expect(msg.hasNestedC)
             expect(msg.nestedC.id == 12345)
@@ -64,7 +64,7 @@ struct Main {
         // particular pattern end up in the final linkage.
         //
         // Protobuf runtime support:
-        //   HAS-SYMBOL: _test_MessageB_getMessageSchema
+        //   HAS-SYMBOL: _test_DMessageB_getMessageSchema
         //   HAS-SYMBOL-NOT: ModuleB.Test_MessageB.messageSchema.unsafeMutableAddressor : SwiftProtobuf.MessageSchema
         //   HAS-SYMBOL: static ModuleB.Test_MessageB.messageSchema : SwiftProtobuf.MessageSchema
         //

--- a/CompileTests/WeakImports/Sources/Client/Client.swift
+++ b/CompileTests/WeakImports/Sources/Client/Client.swift
@@ -27,7 +27,7 @@ struct Main {
             // HAS-SYMBOL: type metadata accessor for ModuleA.Test_MessageA
             // HAS-SYMBOL: type metadata for ModuleA.Test_MessageA
             // HAS-SYMBOL: ModuleA.Test_MessageA.init() -> ModuleA.Test_MessageA
-            // HAS-SYMBOL: _test_DMessageA_getMessageSchema
+            // HAS-SYMBOL: {{_?}}test_DMessageA_getMessageSchema
             var msg = Test_MessageA()
             msg.title = "Hello Weak Imports"
             expect(msg.hasTitle)
@@ -41,7 +41,7 @@ struct Main {
             // HAS-SYMBOL: nominal type descriptor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata accessor for ModuleC.Test_MessageC
             // HAS-SYMBOL: type metadata for ModuleC.Test_MessageC
-            // HAS-SYMBOL: _test_DMessageC_getMessageSchema
+            // HAS-SYMBOL: {{_?}}test_DMessageC_getMessageSchema
             msg.nestedC.id = 12345
             expect(msg.hasNestedC)
             expect(msg.nestedC.id == 12345)
@@ -64,8 +64,7 @@ struct Main {
         // particular pattern end up in the final linkage.
         //
         // Protobuf runtime support:
-        //   HAS-SYMBOL: _test_DMessageB_getMessageSchema
-        //   HAS-SYMBOL-NOT: ModuleB.Test_MessageB.messageSchema.unsafeMutableAddressor : SwiftProtobuf.MessageSchema
+        //   HAS-SYMBOL: {{_?}}test_DMessageB_getMessageSchema
         //   HAS-SYMBOL: static ModuleB.Test_MessageB.messageSchema : SwiftProtobuf.MessageSchema
         //
         // Protocol conformance support:

--- a/CompileTests/WeakImports/Sources/Client/Client.swift
+++ b/CompileTests/WeakImports/Sources/Client/Client.swift
@@ -21,6 +21,10 @@ struct Main {
 
         do {
             // Verify that MessageA is obviously kept in the linkage.
+            //
+            // Here and below, the C functions used to dynamically load schemas
+            // match optional leading underscores, because Darwin includes an
+            // underscore while Linux does not.
 
             // HAS-SYMBOL: full type metadata for ModuleA.Test_MessageA
             // HAS-SYMBOL: nominal type descriptor for ModuleA.Test_MessageA

--- a/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
@@ -258,22 +258,22 @@ public nonisolated let Test_A_Extensions: SwiftProtobuf.ExtensionMap = [
 
 public nonisolated let Test_Extensions_ext_message = SwiftProtobuf.ExtensionSchema(
   schema: "\0d\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{10}\0test.ext_message",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .message(ModuleB.Test_MessageB.messageSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum = SwiftProtobuf.ExtensionSchema(
   schema: "\0e\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{d}\0test.ext_enum",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .enum(ModuleB.Test_EnumB.enumSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 public nonisolated let Test_Extensions_ext_message_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0f\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{12}\0test.ext_message_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .message(ModuleC.Test_MessageC.messageSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0g\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{f}\0test.ext_enum_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .enum(ModuleC.Test_EnumC.enumSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -286,10 +286,10 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   private static func _protobuf_resolveSubmessageOrEnum(for token: SwiftProtobuf.SubmessageOrEnumToken) -> SwiftProtobuf.SubmessageOrEnumSchema? {
     switch token.index {
-    case 1: return .enum(ModuleB.Test_EnumB.enumSchema)
-    case 2: return .enum(ModuleC.Test_EnumC.enumSchema)
-    case 3: return .message(ModuleB.Test_MessageB.messageSchema)
-    case 4: return .message(ModuleC.Test_MessageC.messageSchema)
+    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
     case 5: return .message(_protobuf_mapEntrySchema_MapBEntry)
     case 6: return .message(_protobuf_mapEntrySchema_MapCEntry)
     default: preconditionFailure("invalid submessage/enum token; this is a generator bug")
@@ -302,4 +302,15 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageA_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageA.messageSchema
 }

--- a/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
@@ -258,22 +258,22 @@ public nonisolated let Test_A_Extensions: SwiftProtobuf.ExtensionMap = [
 
 public nonisolated let Test_Extensions_ext_message = SwiftProtobuf.ExtensionSchema(
   schema: "\0d\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{10}\0test.ext_message",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum = SwiftProtobuf.ExtensionSchema(
   schema: "\0e\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{d}\0test.ext_enum",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 public nonisolated let Test_Extensions_ext_message_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0f\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{12}\0test.ext_message_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0g\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{f}\0test.ext_enum_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -286,10 +286,10 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   private static func _protobuf_resolveSubmessageOrEnum(for token: SwiftProtobuf.SubmessageOrEnumToken) -> SwiftProtobuf.SubmessageOrEnumSchema? {
     switch token.index {
-    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
-    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
-    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
-    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
     case 5: return .message(_protobuf_mapEntrySchema_MapBEntry)
     case 6: return .message(_protobuf_mapEntrySchema_MapCEntry)
     default: preconditionFailure("invalid submessage/enum token; this is a generator bug")
@@ -305,12 +305,7 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageA_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageA_getMessageSchema") @used
+public func __test_DMessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageA.messageSchema
 }

--- a/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
@@ -88,13 +88,8 @@ nonisolated extension Test_EnumB {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_EnumB_getEnumSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_EnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DEnumB_getEnumSchema") @used
+public func __test_DEnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumB.enumSchema
 }
 
@@ -109,12 +104,7 @@ nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageB_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageB_getMessageSchema") @used
+public func __test_DMessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageB.messageSchema
 }

--- a/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
@@ -87,6 +87,17 @@ nonisolated extension Test_EnumB {
   public static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData, invokeWitness: SwiftProtobuf.EnumWitnesses<Self>.perform)
 }
 
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_EnumB_getEnumSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_EnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumB.enumSchema
+}
+
 nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
   private static let _protobuf_messageSchemaString: Swift.StaticString = "\0\u{8}\0\0\u{2}\0\0\0\0\0\0\0\0\u{3}\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\u{1}\0\0\0\0\u{4}\0\0\0\0\0\0\u{5}\u{2}\0\0\0\0\0\0@\u{1}\0\0\0\u{9}\u{d}\0test.MessageB"
   private static let _protobuf_reflectionData: Swift.StaticString = "<\0\0\0@^O'=Jl1\u{1f}\u{2}d\u{b}!\u{12}P\u{4}\u{5}\u{1e}'\u{18}?\u{f}.\u{18}E\u{1}=\u{16}aL'\u{8}q\u{6}tz\u{17}P\u{1}\0"
@@ -95,4 +106,15 @@ nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageB_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageB.messageSchema
 }

--- a/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
@@ -87,6 +87,17 @@ nonisolated extension Test_EnumC {
   public static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData, invokeWitness: SwiftProtobuf.EnumWitnesses<Self>.perform)
 }
 
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_EnumC_getEnumSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_EnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumC.enumSchema
+}
+
 nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
   private static let _protobuf_messageSchemaString: Swift.StaticString = "\0\u{8}\0\0\u{2}\0\0\0\0\0\0\0\0\u{3}\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\u{1}\0\0\0\0\u{4}\0\0\0\0\0\0\u{5}\u{2}\0\0\0\0\0\0@\u{1}\0\0\0\u{9}\u{d}\0test.MessageC"
   private static let _protobuf_reflectionData: Swift.StaticString = "<\0\0\0@^O'=Jl1\u{1f}\u{2}d\u{b}!\u{12}P\u{4}\u{5}\u{1e}'\u{18}?\u{f}.\u{18}E\u{1}=\u{16}aL'\u{8}q\u{6}tz\u{17}P\u{1}\0"
@@ -95,4 +106,15 @@ nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageC_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageC.messageSchema
 }

--- a/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
+++ b/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
@@ -88,13 +88,8 @@ nonisolated extension Test_EnumC {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_EnumC_getEnumSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_EnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DEnumC_getEnumSchema") @used
+public func __test_DEnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumC.enumSchema
 }
 
@@ -109,12 +104,7 @@ nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageC_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageC_getMessageSchema") @used
+public func __test_DMessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageC.messageSchema
 }

--- a/Makefile
+++ b/Makefile
@@ -282,11 +282,18 @@ compile-tests-nonisolateddeclarations:
 # Test that ensures weak imports across multiple modules compile.
 # Note that this is a `swift run` because we're verifying the runtime behavior
 # of our harness as well as the codegen.
+#
+# Since this is experimental and requires some features that are only supported
+# by Swift 6.3, we don't run the test on earlier compiler versions.
 compile-tests-weakimports:
-	${SWIFT} run -c release --package-path CompileTests/WeakImports
-	/usr/bin/env python3 CompileTests/WeakImports/check_symbols.py \
-	  --binary CompileTests/WeakImports/.build/release/Client \
-	  --check-file CompileTests/WeakImports/Sources/Client/Client.swift
+	@SWIFT_MAJOR=$$(${SWIFT} --version 2>/dev/null | sed -E -n 's/.*Swift version ([0-9]+)\.([0-9]+).*/\1/p' | head -n1); \
+	SWIFT_MINOR=$$(${SWIFT} --version 2>/dev/null | sed -E -n 's/.*Swift version ([0-9]+)\.([0-9]+).*/\2/p' | head -n1); \
+	if [ "$$SWIFT_MAJOR" -gt 6 ] 2>/dev/null || ([ "$$SWIFT_MAJOR" -eq 6 ] && [ "$$SWIFT_MINOR" -ge 3 ]) 2>/dev/null; then \
+		${SWIFT} run -c release --package-path CompileTests/WeakImports && \
+		/usr/bin/env python3 CompileTests/WeakImports/check_symbols.py \
+		  --binary CompileTests/WeakImports/.build/release/Client \
+		  --check-file CompileTests/WeakImports/Sources/Client/Client.swift; \
+	fi
 
 
 # Rebuild the reference files by running the local version of protoc-gen-swift

--- a/Reference/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
@@ -258,22 +258,22 @@ public nonisolated let Test_A_Extensions: SwiftProtobuf.ExtensionMap = [
 
 public nonisolated let Test_Extensions_ext_message = SwiftProtobuf.ExtensionSchema(
   schema: "\0d\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{10}\0test.ext_message",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .message(ModuleB.Test_MessageB.messageSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum = SwiftProtobuf.ExtensionSchema(
   schema: "\0e\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{d}\0test.ext_enum",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .enum(ModuleB.Test_EnumB.enumSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 public nonisolated let Test_Extensions_ext_message_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0f\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{12}\0test.ext_message_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .message(ModuleC.Test_MessageC.messageSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0g\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{f}\0test.ext_enum_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { .enum(ModuleC.Test_EnumC.enumSchema) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -286,10 +286,10 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   private static func _protobuf_resolveSubmessageOrEnum(for token: SwiftProtobuf.SubmessageOrEnumToken) -> SwiftProtobuf.SubmessageOrEnumSchema? {
     switch token.index {
-    case 1: return .enum(ModuleB.Test_EnumB.enumSchema)
-    case 2: return .enum(ModuleC.Test_EnumC.enumSchema)
-    case 3: return .message(ModuleB.Test_MessageB.messageSchema)
-    case 4: return .message(ModuleC.Test_MessageC.messageSchema)
+    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
     case 5: return .message(_protobuf_mapEntrySchema_MapBEntry)
     case 6: return .message(_protobuf_mapEntrySchema_MapCEntry)
     default: preconditionFailure("invalid submessage/enum token; this is a generator bug")
@@ -302,4 +302,15 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageA_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageA.messageSchema
 }

--- a/Reference/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleA/a.pb.swift
@@ -258,22 +258,22 @@ public nonisolated let Test_A_Extensions: SwiftProtobuf.ExtensionMap = [
 
 public nonisolated let Test_Extensions_ext_message = SwiftProtobuf.ExtensionSchema(
   schema: "\0d\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{10}\0test.ext_message",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum = SwiftProtobuf.ExtensionSchema(
   schema: "\0e\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{d}\0test.ext_enum",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 public nonisolated let Test_Extensions_ext_message_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0f\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{b}\u{12}\0test.ext_message_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message) }
   )
 
 public nonisolated let Test_Extensions_ext_enum_c = SwiftProtobuf.ExtensionSchema(
   schema: "\0g\0\0\0\u{10}\0\0\0\0\0\u{1}\0\u{e}\u{f}\0test.ext_enum_c",
-  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
+  extendedMessageResolver: { Test_MessageA.messageSchema },submessageOrEnumResolver: { return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum) }
   )
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -286,10 +286,10 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 
   private static func _protobuf_resolveSubmessageOrEnum(for token: SwiftProtobuf.SubmessageOrEnumToken) -> SwiftProtobuf.SubmessageOrEnumSchema? {
     switch token.index {
-    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
-    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_EnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
-    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
-    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_MessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 1: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumB_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 2: return SwiftProtobuf.EnumSchema.resolveLazy(named: "test_DEnumC_getEnumSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.enum)
+    case 3: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageB_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
+    case 4: return SwiftProtobuf.MessageSchema.resolveLazy(named: "test_DMessageC_getMessageSchema").map(SwiftProtobuf.SubmessageOrEnumSchema.message)
     case 5: return .message(_protobuf_mapEntrySchema_MapBEntry)
     case 6: return .message(_protobuf_mapEntrySchema_MapCEntry)
     default: preconditionFailure("invalid submessage/enum token; this is a generator bug")
@@ -305,12 +305,7 @@ nonisolated extension Test_MessageA: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageA_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageA_getMessageSchema") @used
+public func __test_DMessageA_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageA.messageSchema
 }

--- a/Reference/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
@@ -88,13 +88,8 @@ nonisolated extension Test_EnumB {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_EnumB_getEnumSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_EnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DEnumB_getEnumSchema") @used
+public func __test_DEnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumB.enumSchema
 }
 
@@ -109,12 +104,7 @@ nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageB_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageB_getMessageSchema") @used
+public func __test_DMessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageB.messageSchema
 }

--- a/Reference/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleB/b.pb.swift
@@ -87,6 +87,17 @@ nonisolated extension Test_EnumB {
   public static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData, invokeWitness: SwiftProtobuf.EnumWitnesses<Self>.perform)
 }
 
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_EnumB_getEnumSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_EnumB_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumB.enumSchema
+}
+
 nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
   private static let _protobuf_messageSchemaString: Swift.StaticString = "\0\u{8}\0\0\u{2}\0\0\0\0\0\0\0\0\u{3}\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\u{1}\0\0\0\0\u{4}\0\0\0\0\0\0\u{5}\u{2}\0\0\0\0\0\0@\u{1}\0\0\0\u{9}\u{d}\0test.MessageB"
   private static let _protobuf_reflectionData: Swift.StaticString = "<\0\0\0@^O'=Jl1\u{1f}\u{2}d\u{b}!\u{12}P\u{4}\u{5}\u{1e}'\u{18}?\u{f}.\u{18}E\u{1}=\u{16}aL'\u{8}q\u{6}tz\u{17}P\u{1}\0"
@@ -95,4 +106,15 @@ nonisolated extension Test_MessageB: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageB_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageB_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageB.messageSchema
 }

--- a/Reference/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
@@ -87,6 +87,17 @@ nonisolated extension Test_EnumC {
   public static let enumSchema = SwiftProtobuf.EnumSchema(schema: _protobuf_enumSchemaString, reflection: _protobuf_reflectionData, invokeWitness: SwiftProtobuf.EnumWitnesses<Self>.perform)
 }
 
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_EnumC_getEnumSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_EnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumC.enumSchema
+}
+
 nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
   private static let _protobuf_messageSchemaString: Swift.StaticString = "\0\u{8}\0\0\u{2}\0\0\0\0\0\0\0\0\u{3}\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\u{1}\0\0\0\0\u{4}\0\0\0\0\0\0\u{5}\u{2}\0\0\0\0\0\0@\u{1}\0\0\0\u{9}\u{d}\0test.MessageC"
   private static let _protobuf_reflectionData: Swift.StaticString = "<\0\0\0@^O'=Jl1\u{1f}\u{2}d\u{b}!\u{12}P\u{4}\u{5}\u{1e}'\u{18}?\u{f}.\u{18}E\u{1}=\u{16}aL'\u{8}q\u{6}tz\u{17}P\u{1}\0"
@@ -95,4 +106,15 @@ nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
 
   public func _protobuf_messageStorage(accessToken: SwiftProtobuf.MessageStorageToken) -> Swift.AnyObject { _storage }
 
+}
+
+@_spi(ForGeneratedCodeOnly)
+@_cdecl("test_MessageC_getMessageSchema")
+#if compiler(>=6.3)
+@used
+#else
+@_used
+#endif
+public func __test_MessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+    out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageC.messageSchema
 }

--- a/Reference/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
+++ b/Reference/CompileTests/WeakImports/Sources/ModuleC/c.pb.swift
@@ -88,13 +88,8 @@ nonisolated extension Test_EnumC {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_EnumC_getEnumSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_EnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DEnumC_getEnumSchema") @used
+public func __test_DEnumC_getEnumSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.EnumSchema?).self).pointee = Test_EnumC.enumSchema
 }
 
@@ -109,12 +104,7 @@ nonisolated extension Test_MessageC: SwiftProtobuf.GeneratedMessage {
 }
 
 @_spi(ForGeneratedCodeOnly)
-@_cdecl("test_MessageC_getMessageSchema")
-#if compiler(>=6.3)
-@used
-#else
-@_used
-#endif
-public func __test_MessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
+@_cdecl("test_DMessageC_getMessageSchema") @used
+public func __test_DMessageC_getMessageSchema(_ out: UnsafeMutableRawPointer) {
     out.assumingMemoryBound(to: (SwiftProtobuf.MessageSchema?).self).pointee = Test_MessageC.messageSchema
 }

--- a/Sources/SwiftProtobuf/WeakLinkageSupport.swift
+++ b/Sources/SwiftProtobuf/WeakLinkageSupport.swift
@@ -1,0 +1,77 @@
+// Sources/SwiftProtobuf/WeakLinkageSupport.swift - Dynamic lookup for weak linkage
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/main/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Dynamic symbol resolution functions to support weak-linked protobuf modules.
+///
+// -----------------------------------------------------------------------------
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(Bionic)
+@preconcurrency import Bionic
+#endif
+
+#if canImport(Darwin)
+private var defaultDynamicLibraryHandle: UnsafeMutableRawPointer? {
+    UnsafeMutableRawPointer(bitPattern: -2)
+}
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+private var defaultDynamicLibraryHandle: UnsafeMutableRawPointer? {
+    UnsafeMutableRawPointer(bitPattern: 0)
+}
+#endif
+
+extension MessageSchema {
+    /// Dynamically looks up a message schema based on the name of a generated
+    /// accessor function.
+    ///
+    /// Returns nil if the symbol is not found (i.e., if it has been dropped by the
+    /// linker).
+    @_spi(ForGeneratedCodeOnly)
+    public static func resolveLazy(named symbolName: String) -> MessageSchema? {
+        // TODO: Put a cache around this.
+        #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        guard let symbol = dlsym(defaultDynamicLibraryHandle, symbolName) else { return nil }
+        typealias Resolver = @convention(c) (UnsafeMutableRawPointer) -> Void
+        let resolver = unsafeBitCast(symbol, to: Resolver.self)
+        var schema: MessageSchema? = nil
+        withUnsafeMutablePointer(to: &schema) { schemaPointer in resolver(schemaPointer) }
+        return schema
+        #else
+        return nil
+        #endif
+    }
+}
+
+extension EnumSchema {
+    /// Dynamically looks up an enum schema based on the name of a generated
+    /// accessor function.
+    ///
+    /// Returns nil if the symbol is not found (i.e., if it has been dropped by the
+    /// linker).
+    @_spi(ForGeneratedCodeOnly)
+    public static func resolveLazy(named symbolName: String) -> EnumSchema? {
+        // TODO: Put a cache around this.
+        #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        guard let symbol = dlsym(defaultDynamicLibraryHandle, symbolName) else { return nil }
+        typealias Resolver = @convention(c) (UnsafeMutableRawPointer) -> Void
+        let resolver = unsafeBitCast(symbol, to: Resolver.self)
+        var schema: EnumSchema? = nil
+        withUnsafeMutablePointer(to: &schema) { schemaPointer in resolver(schemaPointer) }
+        return schema
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/SwiftProtobuf/WeakLinkageSupport.swift
+++ b/Sources/SwiftProtobuf/WeakLinkageSupport.swift
@@ -28,7 +28,7 @@ import Darwin
 #if canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
 private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: -2) }
 #elseif os(Android) && _pointerBitWidth(_32)
-private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: UInt(0xFFFFFFFF)) }
+private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: UInt(0xFFFF_FFFF)) }
 #elseif os(Linux) || os(Android)
 private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: 0) }
 #endif

--- a/Sources/SwiftProtobuf/WeakLinkageSupport.swift
+++ b/Sources/SwiftProtobuf/WeakLinkageSupport.swift
@@ -22,14 +22,15 @@ import Darwin
 @preconcurrency import Bionic
 #endif
 
-#if canImport(Darwin)
-private var defaultDynamicLibraryHandle: UnsafeMutableRawPointer? {
-    UnsafeMutableRawPointer(bitPattern: -2)
-}
-#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
-private var defaultDynamicLibraryHandle: UnsafeMutableRawPointer? {
-    UnsafeMutableRawPointer(bitPattern: 0)
-}
+// These constants are equal to the `RTLD_DEFAULT` value from dlfcn.h on each
+// platform. That C constant cannot be reliably referenced from Swift because
+// Linux only defines it when `_GNU_SOURCE` is defined, so we repeat it here.
+#if canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
+private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: -2) }
+#elseif os(Android) && _pointerBitWidth(_32)
+private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: UInt(0xFFFFFFFF)) }
+#elseif os(Linux) || os(Android)
+private var rtldDefault: UnsafeMutableRawPointer? { .init(bitPattern: 0) }
 #endif
 
 extension MessageSchema {
@@ -42,7 +43,7 @@ extension MessageSchema {
     public static func resolveLazy(named symbolName: String) -> MessageSchema? {
         // TODO: Put a cache around this.
         #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
-        guard let symbol = dlsym(defaultDynamicLibraryHandle, symbolName) else { return nil }
+        guard let symbol = dlsym(rtldDefault, symbolName) else { return nil }
         typealias Resolver = @convention(c) (UnsafeMutableRawPointer) -> Void
         let resolver = unsafeBitCast(symbol, to: Resolver.self)
         var schema: MessageSchema? = nil
@@ -64,7 +65,7 @@ extension EnumSchema {
     public static func resolveLazy(named symbolName: String) -> EnumSchema? {
         // TODO: Put a cache around this.
         #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic)
-        guard let symbol = dlsym(defaultDynamicLibraryHandle, symbolName) else { return nil }
+        guard let symbol = dlsym(rtldDefault, symbolName) else { return nil }
         typealias Resolver = @convention(c) (UnsafeMutableRawPointer) -> Void
         let resolver = unsafeBitCast(symbol, to: Resolver.self)
         var schema: EnumSchema? = nil

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -119,6 +119,26 @@ class EnumGenerator {
             )
         }
         p.print("}")
+
+        if generatorOptions.experimentalWeakImports {
+            let getterSymbol = namer.dynamicSymbolName(
+                forProtoFullName: enumDescriptor.fullName,
+                suffix: "_getEnumSchema"
+            )
+            let spiSnippet = generatorOptions.visibilitySourceSnippet.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
+            p.print(
+                "",
+                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\")",
+                "#if compiler(>=6.3)",
+                "@used",
+                "#else",
+                "@_used",
+                "#endif",
+                "\(generatorOptions.visibilitySourceSnippet)func __\(getterSymbol)(_ out: UnsafeMutableRawPointer) {",
+                "    out.assumingMemoryBound(to: (\(namer.swiftProtobufModulePrefix)EnumSchema?).self).pointee = \(swiftFullName).enumSchema",
+                "}"
+            )
+        }
     }
 
     /// Iterates over the cases in the protobuf enum and generates the appropriate cases or static

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -125,7 +125,8 @@ class EnumGenerator {
                 forProtoFullName: enumDescriptor.fullName,
                 suffix: "_getEnumSchema"
             )
-            let spiSnippet = generatorOptions.visibilitySourceSnippet.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
+            let spiSnippet =
+                generatorOptions.visibilitySourceSnippet.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
             p.print(
                 "",
                 "\(spiSnippet)@_cdecl(\"\(getterSymbol)\")",

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -125,16 +125,10 @@ class EnumGenerator {
                 forProtoFullName: enumDescriptor.fullName,
                 suffix: "_getEnumSchema"
             )
-            let spiSnippet =
-                generatorOptions.visibilitySourceSnippet.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
+            let spiSnippet = generatorOptions.visibility == .public ? "@_spi(ForGeneratedCodeOnly)\n" : ""
             p.print(
                 "",
-                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\")",
-                "#if compiler(>=6.3)",
-                "@used",
-                "#else",
-                "@_used",
-                "#endif",
+                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\") @used",
                 "\(generatorOptions.visibilitySourceSnippet)func __\(getterSymbol)(_ out: UnsafeMutableRawPointer) {",
                 "    out.assumingMemoryBound(to: (\(namer.swiftProtobufModulePrefix)EnumSchema?).self).pointee = \(swiftFullName).enumSchema",
                 "}"

--- a/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionSetGenerator.swift
@@ -54,18 +54,27 @@ class ExtensionSetGenerator {
             switch descriptor.type {
             case .group:
                 let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-                submessageOrEnumReference = .message(swiftSingularType)
+                submessageOrEnumReference = .message(
+                    swiftTypeName: swiftSingularType,
+                    protoFullName: descriptor.messageType!.fullName
+                )
             case .message:
                 if descriptor.isMap {
                     let entrySchemaName = MapEntryGenerator.schemaName(for: descriptor.messageType!)
                     submessageOrEnumReference = .map(entrySchemaName)
                 } else {
                     let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-                    submessageOrEnumReference = .message(swiftSingularType)
+                    submessageOrEnumReference = .message(
+                        swiftTypeName: swiftSingularType,
+                        protoFullName: descriptor.messageType!.fullName
+                    )
                 }
             case .enum:
                 let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-                submessageOrEnumReference = .enum(swiftSingularType)
+                submessageOrEnumReference = .enum(
+                    swiftTypeName: swiftSingularType,
+                    protoFullName: descriptor.enumType!.fullName
+                )
             default:
                 submessageOrEnumReference = nil
             }
@@ -115,10 +124,28 @@ class ExtensionSetGenerator {
                 if let field = extensionSchemaCalculator.submessageOrEnumFields.first {
                     let resolver: String
                     switch field.kind {
-                    case .message(let name):
-                        resolver = ".message(\(name).messageSchema)"
-                    case .enum(let name):
-                        resolver = ".enum(\(name).enumSchema)"
+                    case .message(let swiftTypeName, let protoFullName):
+                        if generatorOptions.experimentalWeakImports {
+                            let symbol = namer.dynamicSymbolName(
+                                forProtoFullName: protoFullName,
+                                suffix: "_getMessageSchema"
+                            )
+                            resolver =
+                                "return \(namer.swiftProtobufModulePrefix)MessageSchema.resolveLazy(named: \"\(symbol)\").map(\(namer.swiftProtobufModulePrefix)SubmessageOrEnumSchema.message)"
+                        } else {
+                            resolver = ".message(\(swiftTypeName).messageSchema)"
+                        }
+                    case .enum(let swiftTypeName, let protoFullName):
+                        if generatorOptions.experimentalWeakImports {
+                            let symbol = namer.dynamicSymbolName(
+                                forProtoFullName: protoFullName,
+                                suffix: "_getEnumSchema"
+                            )
+                            resolver =
+                                "return \(namer.swiftProtobufModulePrefix)EnumSchema.resolveLazy(named: \"\(symbol)\").map(\(namer.swiftProtobufModulePrefix)SubmessageOrEnumSchema.enum)"
+                        } else {
+                            resolver = ".enum(\(swiftTypeName).enumSchema)"
+                        }
                     case .map:
                         preconditionFailure("unreachable; extensions cannot be map fields")
                     }

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -40,13 +40,13 @@ package enum FieldPresence {
 package enum SubmessageOrEnumReference: Equatable, Hashable {
     /// The field is a singular or repeated message or group type.
     ///
-    /// The associated value is the full Swift name of that type.
-    case message(String)
+    /// The associated values are the full Swift name of that type and its full proto name.
+    case message(swiftTypeName: String, protoFullName: String)
 
     /// The field is a singular or repeated enum type.
     ///
-    /// The associated value is the full Swift name of that type.
-    case `enum`(String)
+    /// The associated values are the full Swift name of that type and its full proto name.
+    case `enum`(swiftTypeName: String, protoFullName: String)
 
     /// The field is a map type.
     ///

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -90,18 +90,27 @@ class MessageFieldGenerator: FieldGeneratorBase, FieldGenerator {
         switch descriptor.type {
         case .group:
             let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-            submessageOrEnumReference = .message(swiftSingularType)
+            submessageOrEnumReference = .message(
+                swiftTypeName: swiftSingularType,
+                protoFullName: descriptor.messageType!.fullName
+            )
         case .message:
             if descriptor.isMap {
                 let entrySchemaName = MapEntryGenerator.schemaName(for: descriptor.messageType!)
                 submessageOrEnumReference = .map(entrySchemaName)
             } else {
                 let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-                submessageOrEnumReference = .message(swiftSingularType)
+                submessageOrEnumReference = .message(
+                    swiftTypeName: swiftSingularType,
+                    protoFullName: descriptor.messageType!.fullName
+                )
             }
         case .enum:
             let swiftSingularType = descriptor.swiftSingularType(namer: namer)
-            submessageOrEnumReference = .enum(swiftSingularType)
+            submessageOrEnumReference = .enum(
+                swiftTypeName: swiftSingularType,
+                protoFullName: descriptor.enumType!.fullName
+            )
         default:
             submessageOrEnumReference = nil
         }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -232,15 +232,10 @@ class MessageGenerator {
                 forProtoFullName: descriptor.fullName,
                 suffix: "_getMessageSchema"
             )
-            let spiSnippet = visibility.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
+            let spiSnippet = generatorOptions.visibility == .public ? "@_spi(ForGeneratedCodeOnly)\n" : ""
             p.print(
                 "",
-                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\")",
-                "#if compiler(>=6.3)",
-                "@used",
-                "#else",
-                "@_used",
-                "#endif",
+                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\") @used",
                 "\(visibility)func __\(getterSymbol)(_ out: UnsafeMutableRawPointer) {",
                 "    out.assumingMemoryBound(to: (\(namer.swiftProtobufModulePrefix)MessageSchema?).self).pointee = \(swiftFullName).messageSchema",
                 "}"

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -227,6 +227,26 @@ class MessageGenerator {
         }
         p.print("}")
 
+        if generatorOptions.experimentalWeakImports {
+            let getterSymbol = namer.dynamicSymbolName(
+                forProtoFullName: descriptor.fullName,
+                suffix: "_getMessageSchema"
+            )
+            let spiSnippet = visibility.contains("public") ? "@_spi(ForGeneratedCodeOnly)\n" : ""
+            p.print(
+                "",
+                "\(spiSnippet)@_cdecl(\"\(getterSymbol)\")",
+                "#if compiler(>=6.3)",
+                "@used",
+                "#else",
+                "@_used",
+                "#endif",
+                "\(visibility)func __\(getterSymbol)(_ out: UnsafeMutableRawPointer) {",
+                "    out.assumingMemoryBound(to: (\(namer.swiftProtobufModulePrefix)MessageSchema?).self).pointee = \(swiftFullName).messageSchema",
+                "}"
+            )
+        }
+
         // Nested enums and messages
         for e in enums {
             e.generateRuntimeSupport(printer: &p)
@@ -263,16 +283,11 @@ class MessageGenerator {
             p.withIndentation { p in
                 p.print("switch token.index {")
                 for field in submessageOrEnumFields {
-                    let schema: String
-                    switch field.kind {
-                    case .enum(let typeName):
-                        schema = ".enum(\(typeName).enumSchema)"
-                    case .message(let typeName):
-                        schema = ".message(\(typeName).messageSchema)"
-                    case .map(let schemaName):
-                        schema = ".message(\(schemaName))"
+                    if generatorOptions.experimentalWeakImports {
+                        generateWeakSubmessageOrEnumResolverCase(for: field, printer: &p)
+                    } else {
+                        generateStrongSubmessageOrEnumResolverCase(for: field, printer: &p)
                     }
-                    p.print("case \(field.index): return \(schema)")
                 }
                 p.print(
                     "default: preconditionFailure(\"invalid submessage/enum token; this is a generator bug\")",
@@ -289,6 +304,41 @@ class MessageGenerator {
                     entryGenerator.generateSchema(into: &p)
                 }
             }
+        }
+    }
+
+    private func generateStrongSubmessageOrEnumResolverCase(
+        for field: SubmessageOrEnumField,
+        printer p: inout CodePrinter
+    ) {
+        switch field.kind {
+        case .enum(let swiftTypeName, _):
+            p.print("case \(field.index): return .enum(\(swiftTypeName).enumSchema)")
+        case .message(let swiftTypeName, _):
+            p.print("case \(field.index): return .message(\(swiftTypeName).messageSchema)")
+        case .map(let schemaName):
+            p.print("case \(field.index): return .message(\(schemaName))")
+        }
+    }
+
+    private func generateWeakSubmessageOrEnumResolverCase(
+        for field: SubmessageOrEnumField,
+        printer p: inout CodePrinter
+    ) {
+        switch field.kind {
+        case .enum(_, let protoFullName):
+            let symbol = namer.dynamicSymbolName(forProtoFullName: protoFullName, suffix: "_getEnumSchema")
+            p.print(
+                "case \(field.index): return \(namer.swiftProtobufModulePrefix)EnumSchema.resolveLazy(named: \"\(symbol)\").map(\(namer.swiftProtobufModulePrefix)SubmessageOrEnumSchema.enum)"
+            )
+        case .message(_, let protoFullName):
+            let symbol = namer.dynamicSymbolName(forProtoFullName: protoFullName, suffix: "_getMessageSchema")
+            p.print(
+                "case \(field.index): return \(namer.swiftProtobufModulePrefix)MessageSchema.resolveLazy(named: \"\(symbol)\").map(\(namer.swiftProtobufModulePrefix)SubmessageOrEnumSchema.message)"
+            )
+        case .map(let schemaName):
+            // TODO: Support lazy map entry schemas.
+            p.print("case \(field.index): return .message(\(schemaName))")
         }
     }
 

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -80,9 +80,15 @@ class OneofGenerator {
 
             switch descriptor.type {
             case .group, .message:
-                submessageOrEnumReference = .message(swiftType)
+                submessageOrEnumReference = .message(
+                    swiftTypeName: swiftType,
+                    protoFullName: descriptor.messageType!.fullName
+                )
             case .enum:
-                submessageOrEnumReference = .enum(swiftType)
+                submessageOrEnumReference = .enum(
+                    swiftTypeName: swiftType,
+                    protoFullName: descriptor.enumType!.fullName
+                )
             default:
                 submessageOrEnumReference = nil
             }

--- a/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
+++ b/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
@@ -44,9 +44,12 @@ extension SwiftProtobufNamer {
         }
     }
 
-    /// Returns the symbol name to use for dynamic schema lookups
-    // (`@_silgen_name`) for the given proto full name and suffix.
+    /// Returns the symbol name to use for dynamic schema lookups for the given proto full name
+    /// and suffix.
     package func dynamicSymbolName(forProtoFullName protoFullName: String, suffix: String) -> String {
-        protoFullName.replacingOccurrences(of: ".", with: "_") + suffix
+        protoFullName
+            .replacingOccurrences(of: "_", with: "__")
+            .replacingOccurrences(of: ".", with: "_D")
+            + suffix
     }
 }

--- a/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
+++ b/Sources/protoc-gen-swift/SwiftProtobufNamer+Extensions.swift
@@ -43,4 +43,10 @@ extension SwiftProtobufNamer {
             return aliasInfo.aliases(aliasOf)![firstAlias!] === $0
         }
     }
+
+    /// Returns the symbol name to use for dynamic schema lookups
+    // (`@_silgen_name`) for the given proto full name and suffix.
+    package func dynamicSymbolName(forProtoFullName protoFullName: String, suffix: String) -> String {
+        protoFullName.replacingOccurrences(of: ".", with: "_") + suffix
+    }
 }


### PR DESCRIPTION
More progress toward weak protos.

I've punted on map fields for the time being because those need a little bit more care; the interaction with `MessageWitness` today means we have to put the map entry's value type into it as a generic argument, which blows away the savings. Options there may include either wedging in a placeholder type (like the "implicit weak message" that C++ uses).