### PR TITLE
Support multiple instances of ProtoPathModuleMappings option

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -133,10 +133,17 @@ another proto file, those generated files might end up in different modules.
 This option allows you to specify that the code generated from the proto
 files will be distributed in multiple modules. This data is used during
 generation to then `import` the module and scope the types. This option
-takes the path of a file providing the mapping:
+takes the path of a file providing the mapping (multiple instances of this option
+can be provided to load and combine multiple mapping files):
 
 ```
 protoc --swift_opt=ProtoPathModuleMappings=[path.asciipb] --swift_out=. foo/bar/*.proto
+```
+
+Or with multiple mapping files:
+
+```
+protoc --swift_opt=ProtoPathModuleMappings=[path1.asciipb],ProtoPathModuleMappings=[path2.asciipb] --swift_out=. foo/bar/*.proto
 ```
 
 The format of that mapping file is defined in

--- a/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
@@ -52,26 +52,59 @@ public struct ProtoFileToModuleMappings {
     /// Loads and parses the given module mapping from disk.  Raises LoadError
     /// or TextFormatDecodingError.
     public init(path: String) throws {
-        try self.init(path: path, swiftProtobufModuleName: nil)
+        try self.init(paths: [path], swiftProtobufModuleName: nil)
     }
 
     /// Loads and parses the given module mapping from disk.  Raises LoadError
     /// or TextFormatDecodingError.
     public init(path: String, swiftProtobufModuleName: String?) throws {
-        let content: String
-        do {
-            content = try String(contentsOfFile: path, encoding: String.Encoding.utf8)
-        } catch {
-            throw LoadError.failToOpen(path: path)
-        }
+        try self.init(paths: [path], swiftProtobufModuleName: swiftProtobufModuleName)
+    }
 
-        let mappingsProto = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: content)
-        try self.init(moduleMappingsProto: mappingsProto, swiftProtobufModuleName: swiftProtobufModuleName)
+    /// Loads and parses the given module mappings from disk.  Raises LoadError
+    /// or TextFormatDecodingError.
+    public init(paths: [String]) throws {
+        try self.init(paths: paths, swiftProtobufModuleName: nil)
+    }
+
+    /// Loads and parses the given module mappings from disk.  Raises LoadError
+    /// or TextFormatDecodingError.
+    public init(paths: [String], swiftProtobufModuleName: String?) throws {
+        var merged = SwiftProtobuf_GenSwift_ModuleMappings()
+        for path in paths {
+            let content: String
+            do {
+                content = try String(contentsOfFile: path, encoding: String.Encoding.utf8)
+            } catch {
+                throw LoadError.failToOpen(path: path)
+            }
+
+            let mappingsProto = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: content)
+            merged.mapping.append(contentsOf: mappingsProto.mapping)
+        }
+        try self.init(moduleMappingsProto: merged, swiftProtobufModuleName: swiftProtobufModuleName)
     }
 
     /// Parses the given module mapping.  Raises LoadError.
     public init(moduleMappingsProto mappings: SwiftProtobuf_GenSwift_ModuleMappings) throws {
         try self.init(moduleMappingsProto: mappings, swiftProtobufModuleName: nil)
+    }
+
+    /// Parses the given module mappings.  Raises LoadError.
+    public init(moduleMappingsProtos mappingsList: [SwiftProtobuf_GenSwift_ModuleMappings]) throws {
+        try self.init(moduleMappingsProtos: mappingsList, swiftProtobufModuleName: nil)
+    }
+
+    /// Parses the given module mappings.  Raises LoadError.
+    public init(
+        moduleMappingsProtos mappingsList: [SwiftProtobuf_GenSwift_ModuleMappings],
+        swiftProtobufModuleName: String?
+    ) throws {
+        var merged = SwiftProtobuf_GenSwift_ModuleMappings()
+        for mappings in mappingsList {
+            merged.mapping.append(contentsOf: mappings.mapping)
+        }
+        try self.init(moduleMappingsProto: merged, swiftProtobufModuleName: swiftProtobufModuleName)
     }
 
     /// Parses the given module mapping.  Raises LoadError.

--- a/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
@@ -24,13 +24,41 @@ public struct ProtoFileToModuleMappings {
         /// Raised if the path wasn't found.
         case failToOpen(path: String)
         /// Raised if an mapping entry in the protobuf doesn't have a module name.
-        /// mappingIndex is the index (0-N) of the mapping.
-        case entryMissingModuleName(mappingIndex: Int)
+        /// mappingIndex is the index (0-N) of the mapping within the source file or proto.
+        case entryMissingModuleName(mappingIndex: Int, path: String?)
         /// Raised if an mapping entry in the protobuf doesn't have any proto files listed.
-        /// mappingIndex is the index (0-N) of the mapping.
-        case entryHasNoProtoPaths(mappingIndex: Int)
+        /// mappingIndex is the index (0-N) of the mapping within the source file or proto.
+        case entryHasNoProtoPaths(mappingIndex: Int, path: String?)
         /// The given proto path was listed for both modules.
-        case duplicateProtoPathMapping(path: String, firstModule: String, secondModule: String)
+        case duplicateProtoPathMapping(
+            path: String,
+            firstModule: String,
+            firstPath: String?,
+            secondModule: String,
+            secondPath: String?
+        )
+
+        public static func entryMissingModuleName(mappingIndex: Int) -> LoadError {
+            .entryMissingModuleName(mappingIndex: mappingIndex, path: nil)
+        }
+
+        public static func entryHasNoProtoPaths(mappingIndex: Int) -> LoadError {
+            .entryHasNoProtoPaths(mappingIndex: mappingIndex, path: nil)
+        }
+
+        public static func duplicateProtoPathMapping(
+            path: String,
+            firstModule: String,
+            secondModule: String
+        ) -> LoadError {
+            .duplicateProtoPathMapping(
+                path: path,
+                firstModule: firstModule,
+                firstPath: nil,
+                secondModule: secondModule,
+                secondPath: nil
+            )
+        }
     }
 
     /// Proto file name to module name.
@@ -70,7 +98,13 @@ public struct ProtoFileToModuleMappings {
     /// Loads and parses the given module mappings from disk.  Raises LoadError
     /// or TextFormatDecodingError.
     public init(paths: [String], swiftProtobufModuleName: String?) throws {
-        var merged = SwiftProtobuf_GenSwift_ModuleMappings()
+        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
+        var builder = [String: (module: String, sourcePath: String?)]()
+        for (proto, mod) in wktMappings(swiftProtobufModuleName: self.swiftProtobufModuleName) {
+            builder[proto] = (module: mod, sourcePath: nil)
+        }
+        let initialCount = builder.count
+
         for path in paths {
             let content: String
             do {
@@ -80,9 +114,15 @@ public struct ProtoFileToModuleMappings {
             }
 
             let mappingsProto = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: content)
-            merged.mapping.append(contentsOf: mappingsProto.mapping)
+            try Self.add(
+                mappings: mappingsProto,
+                sourcePath: path,
+                into: &builder
+            )
         }
-        try self.init(moduleMappingsProto: merged, swiftProtobufModuleName: swiftProtobufModuleName)
+
+        self.mappings = builder.mapValues { $0.module }
+        self.hasMappings = initialCount != builder.count
     }
 
     /// Parses the given module mapping.  Raises LoadError.
@@ -100,11 +140,23 @@ public struct ProtoFileToModuleMappings {
         moduleMappingsProtos mappingsList: [SwiftProtobuf_GenSwift_ModuleMappings],
         swiftProtobufModuleName: String?
     ) throws {
-        var merged = SwiftProtobuf_GenSwift_ModuleMappings()
-        for mappings in mappingsList {
-            merged.mapping.append(contentsOf: mappings.mapping)
+        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
+        var builder = [String: (module: String, sourcePath: String?)]()
+        for (proto, mod) in wktMappings(swiftProtobufModuleName: self.swiftProtobufModuleName) {
+            builder[proto] = (module: mod, sourcePath: nil)
         }
-        try self.init(moduleMappingsProto: merged, swiftProtobufModuleName: swiftProtobufModuleName)
+        let initialCount = builder.count
+
+        for mappings in mappingsList {
+            try Self.add(
+                mappings: mappings,
+                sourcePath: nil,
+                into: &builder
+            )
+        }
+
+        self.mappings = builder.mapValues { $0.module }
+        self.hasMappings = initialCount != builder.count
     }
 
     /// Parses the given module mapping.  Raises LoadError.
@@ -112,33 +164,38 @@ public struct ProtoFileToModuleMappings {
         moduleMappingsProto mappings: SwiftProtobuf_GenSwift_ModuleMappings,
         swiftProtobufModuleName: String?
     ) throws {
-        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
-        var builder = wktMappings(swiftProtobufModuleName: self.swiftProtobufModuleName)
-        let initialCount = builder.count
+        try self.init(moduleMappingsProtos: [mappings], swiftProtobufModuleName: swiftProtobufModuleName)
+    }
+
+    private static func add(
+        mappings: SwiftProtobuf_GenSwift_ModuleMappings,
+        sourcePath: String?,
+        into builder: inout [String: (module: String, sourcePath: String?)]
+    ) throws {
         for (idx, mapping) in mappings.mapping.lazy.enumerated() {
             if mapping.moduleName.isEmpty {
-                throw LoadError.entryMissingModuleName(mappingIndex: idx)
+                throw LoadError.entryMissingModuleName(mappingIndex: idx, path: sourcePath)
             }
             if mapping.protoFilePath.isEmpty {
-                throw LoadError.entryHasNoProtoPaths(mappingIndex: idx)
+                throw LoadError.entryHasNoProtoPaths(mappingIndex: idx, path: sourcePath)
             }
-            for path in mapping.protoFilePath {
-                if let existing = builder[path] {
-                    if existing != mapping.moduleName {
+            for protoPath in mapping.protoFilePath {
+                if let existing = builder[protoPath] {
+                    if existing.module != mapping.moduleName {
                         throw LoadError.duplicateProtoPathMapping(
-                            path: path,
-                            firstModule: existing,
-                            secondModule: mapping.moduleName
+                            path: protoPath,
+                            firstModule: existing.module,
+                            firstPath: existing.sourcePath,
+                            secondModule: mapping.moduleName,
+                            secondPath: sourcePath
                         )
                     }
                     // Was a repeat, just allow it.
                 } else {
-                    builder[path] = mapping.moduleName
+                    builder[protoPath] = (module: mapping.moduleName, sourcePath: sourcePath)
                 }
             }
         }
-        self.mappings = builder
-        self.hasMappings = initialCount != builder.count
     }
 
     public init() {
@@ -222,3 +279,41 @@ public struct ProtoFileToModuleMappings {
 private func wktMappings(swiftProtobufModuleName: String) -> [String: String] {
     SwiftProtobufInfo.bundledProtoFiles.reduce(into: [:]) { $0[$1] = swiftProtobufModuleName }
 }
+
+extension ProtoFileToModuleMappings.LoadError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .failToOpen(let path):
+            return "Failed to open '\(path)'"
+        case .entryMissingModuleName(let mappingIndex, let path):
+            if let path = path {
+                return "Mapping entry \(mappingIndex) in '\(path)' is missing a module_name"
+            } else {
+                return "Mapping entry \(mappingIndex) is missing a module_name"
+            }
+        case .entryHasNoProtoPaths(let mappingIndex, let path):
+            if let path = path {
+                return "Mapping entry \(mappingIndex) in '\(path)' has no proto_file_path entries"
+            } else {
+                return "Mapping entry \(mappingIndex) has no proto_file_path entries"
+            }
+        case .duplicateProtoPathMapping(
+            let protoPath,
+            let firstModule,
+            let firstPath,
+            let secondModule,
+            let secondPath
+        ):
+            var msg = "Duplicate mapping for proto '\(protoPath)': '\(firstModule)'"
+            if let firstPath = firstPath {
+                msg += " (in '\(firstPath)')"
+            }
+            msg += " vs '\(secondModule)'"
+            if let secondPath = secondPath {
+                msg += " (in '\(secondPath)')"
+            }
+            return msg
+        }
+    }
+}
+

--- a/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
+++ b/Sources/SwiftProtobufPluginLibrary/ProtoFileToModuleMappings.swift
@@ -98,31 +98,17 @@ public struct ProtoFileToModuleMappings {
     /// Loads and parses the given module mappings from disk.  Raises LoadError
     /// or TextFormatDecodingError.
     public init(paths: [String], swiftProtobufModuleName: String?) throws {
-        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
-        var builder = [String: (module: String, sourcePath: String?)]()
-        for (proto, mod) in wktMappings(swiftProtobufModuleName: self.swiftProtobufModuleName) {
-            builder[proto] = (module: mod, sourcePath: nil)
-        }
-        let initialCount = builder.count
-
-        for path in paths {
+        let mappingsList: [(mapping: SwiftProtobuf_GenSwift_ModuleMappings, path: String?)] = try paths.map { path in
             let content: String
             do {
                 content = try String(contentsOfFile: path, encoding: String.Encoding.utf8)
             } catch {
                 throw LoadError.failToOpen(path: path)
             }
-
             let mappingsProto = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: content)
-            try Self.add(
-                mappings: mappingsProto,
-                sourcePath: path,
-                into: &builder
-            )
+            return (mapping: mappingsProto, path: path)
         }
-
-        self.mappings = builder.mapValues { $0.module }
-        self.hasMappings = initialCount != builder.count
+        try self.init(moduleMappings: mappingsList, swiftProtobufModuleName: swiftProtobufModuleName)
     }
 
     /// Parses the given module mapping.  Raises LoadError.
@@ -140,23 +126,10 @@ public struct ProtoFileToModuleMappings {
         moduleMappingsProtos mappingsList: [SwiftProtobuf_GenSwift_ModuleMappings],
         swiftProtobufModuleName: String?
     ) throws {
-        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
-        var builder = [String: (module: String, sourcePath: String?)]()
-        for (proto, mod) in wktMappings(swiftProtobufModuleName: self.swiftProtobufModuleName) {
-            builder[proto] = (module: mod, sourcePath: nil)
-        }
-        let initialCount = builder.count
-
-        for mappings in mappingsList {
-            try Self.add(
-                mappings: mappings,
-                sourcePath: nil,
-                into: &builder
-            )
-        }
-
-        self.mappings = builder.mapValues { $0.module }
-        self.hasMappings = initialCount != builder.count
+        try self.init(
+            moduleMappings: mappingsList.map { (mapping: $0, path: nil) },
+            swiftProtobufModuleName: swiftProtobufModuleName
+        )
     }
 
     /// Parses the given module mapping.  Raises LoadError.
@@ -167,35 +140,46 @@ public struct ProtoFileToModuleMappings {
         try self.init(moduleMappingsProtos: [mappings], swiftProtobufModuleName: swiftProtobufModuleName)
     }
 
-    private static func add(
-        mappings: SwiftProtobuf_GenSwift_ModuleMappings,
-        sourcePath: String?,
-        into builder: inout [String: (module: String, sourcePath: String?)]
+    private init(
+        moduleMappings: [(mapping: SwiftProtobuf_GenSwift_ModuleMappings, path: String?)],
+        swiftProtobufModuleName: String?
     ) throws {
-        for (idx, mapping) in mappings.mapping.lazy.enumerated() {
-            if mapping.moduleName.isEmpty {
-                throw LoadError.entryMissingModuleName(mappingIndex: idx, path: sourcePath)
-            }
-            if mapping.protoFilePath.isEmpty {
-                throw LoadError.entryHasNoProtoPaths(mappingIndex: idx, path: sourcePath)
-            }
-            for protoPath in mapping.protoFilePath {
-                if let existing = builder[protoPath] {
-                    if existing.module != mapping.moduleName {
-                        throw LoadError.duplicateProtoPathMapping(
-                            path: protoPath,
-                            firstModule: existing.module,
-                            firstPath: existing.sourcePath,
-                            secondModule: mapping.moduleName,
-                            secondPath: sourcePath
-                        )
+        self.swiftProtobufModuleName = swiftProtobufModuleName ?? defaultSwiftProtobufModuleName
+        var builder = [String: (module: String, sourcePath: String?)]()
+        for proto in SwiftProtobufInfo.bundledProtoFiles {
+            builder[proto] = (module: self.swiftProtobufModuleName, sourcePath: nil)
+        }
+        let initialCount = builder.count
+
+        for (mappings, sourcePath) in moduleMappings {
+            for (idx, mapping) in mappings.mapping.lazy.enumerated() {
+                if mapping.moduleName.isEmpty {
+                    throw LoadError.entryMissingModuleName(mappingIndex: idx, path: sourcePath)
+                }
+                if mapping.protoFilePath.isEmpty {
+                    throw LoadError.entryHasNoProtoPaths(mappingIndex: idx, path: sourcePath)
+                }
+                for protoPath in mapping.protoFilePath {
+                    if let existing = builder[protoPath] {
+                        if existing.module != mapping.moduleName {
+                            throw LoadError.duplicateProtoPathMapping(
+                                path: protoPath,
+                                firstModule: existing.module,
+                                firstPath: existing.sourcePath,
+                                secondModule: mapping.moduleName,
+                                secondPath: sourcePath
+                            )
+                        }
+                        // Was a repeat, just allow it.
+                    } else {
+                        builder[protoPath] = (module: mapping.moduleName, sourcePath: sourcePath)
                     }
-                    // Was a repeat, just allow it.
-                } else {
-                    builder[protoPath] = (module: mapping.moduleName, sourcePath: sourcePath)
                 }
             }
         }
+
+        self.mappings = builder.mapValues { $0.module }
+        self.hasMappings = initialCount != builder.count
     }
 
     public init() {
@@ -275,10 +259,6 @@ public struct ProtoFileToModuleMappings {
     }
 }
 
-// Used to seed the mappings, the wkt are all part of the main library.
-private func wktMappings(swiftProtobufModuleName: String) -> [String: String] {
-    SwiftProtobufInfo.bundledProtoFiles.reduce(into: [:]) { $0[$1] = swiftProtobufModuleName }
-}
 
 extension ProtoFileToModuleMappings.LoadError: CustomStringConvertible {
     public var description: String {

--- a/Sources/protoc-gen-swift/Docs.docc/index.md
+++ b/Sources/protoc-gen-swift/Docs.docc/index.md
@@ -139,10 +139,17 @@ another proto file, those generated files might end up in different modules.
 This option allows you to specify that the code generated from the proto
 files will be distributed in multiple modules. This data is used during
 generation to then `import` the module and scope the types. This option
-takes the path of a file providing the mapping:
+takes the path of a file providing the mapping (multiple instances of this option
+can be provided to load and combine multiple mapping files):
 
 ```
 $ protoc --swift_opt=ProtoPathModuleMappings=[path.asciipb] --swift_out=. foo/bar/*.proto
+```
+
+Or with multiple mapping files:
+
+```
+$ protoc --swift_opt=ProtoPathModuleMappings=[path1.asciipb],ProtoPathModuleMappings=[path2.asciipb] --swift_out=. foo/bar/*.proto
 ```
 
 The format of that mapping file is defined in

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -148,7 +148,7 @@ package class GeneratorOptions {
     package init(parameter: any CodeGeneratorParameter) throws {
         var outputNaming: OutputNaming = .fullPath
         var enumGeneration: EnumGeneration = .none
-        var moduleMapPath: String?
+        var moduleMapPaths: [String] = []
         var visibility: Visibility = .internal
         var swiftProtobufModuleName: String? = nil
         var implementationOnlyImports: Bool = false
@@ -178,7 +178,7 @@ package class GeneratorOptions {
                 }
             case "ProtoPathModuleMappings":
                 if !pair.value.isEmpty {
-                    moduleMapPath = pair.value
+                    moduleMapPaths.append(pair.value)
                 }
             case "Visibility":
                 if let value = Visibility(flag: pair.value) {
@@ -243,15 +243,15 @@ package class GeneratorOptions {
             }
         }
 
-        if let moduleMapPath = moduleMapPath {
+        if !moduleMapPaths.isEmpty {
             do {
                 self.protoToModuleMappings = try ProtoFileToModuleMappings(
-                    path: moduleMapPath,
+                    paths: moduleMapPaths,
                     swiftProtobufModuleName: swiftProtobufModuleName
                 )
             } catch let e {
                 throw GenerationError.wrappedError(
-                    message: "Parameter 'ProtoPathModuleMappings=\(moduleMapPath)'",
+                    message: "Parameter 'ProtoPathModuleMappings=\(moduleMapPaths.joined(separator: ","))'",
                     error: e
                 )
             }

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -117,7 +117,7 @@ package class GeneratorOptions {
 
     let outputNaming: OutputNaming
     let enumGeneration: EnumGeneration
-    let protoToModuleMappings: ProtoFileToModuleMappings
+    package let protoToModuleMappings: ProtoFileToModuleMappings
     let visibility: Visibility
     let importDirective: ImportDirective
     let experimentalStripNonfunctionalCodegen: Bool

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -317,4 +317,93 @@ final class Test_ProtoFileToModuleMappings: XCTestCase {
         }
     }
 
+    func test_Initialization_MultipleProtos() {
+        let baselineEntries = SwiftProtobufInfo.bundledProtoFiles.count
+        let baselineModules = 1
+
+        let config1Text = """
+        mapping { module_name: "ModuleA", proto_file_path: ["a.proto", "shared.proto"] }
+        """
+        let config2Text = """
+        mapping { module_name: "ModuleB", proto_file_path: "b.proto" }
+        mapping { module_name: "ModuleA", proto_file_path: "shared.proto" }
+        """
+
+        do {
+            let proto1 = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: config1Text)
+            let proto2 = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: config2Text)
+
+            let mapper = try ProtoFileToModuleMappings(moduleMappingsProtos: [proto1, proto2])
+            XCTAssertEqual(mapper.mappings.count, 3 + baselineEntries)
+            XCTAssertEqual(Set(mapper.mappings.values).count, 2 + baselineModules)
+            XCTAssertEqual(mapper.mappings["a.proto"], "ModuleA")
+            XCTAssertEqual(mapper.mappings["b.proto"], "ModuleB")
+            XCTAssertEqual(mapper.mappings["shared.proto"], "ModuleA")
+            XCTAssertTrue(mapper.hasMappings)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        // Conflicting mappings across protos should fail.
+        let conflictingConfigText = """
+        mapping { module_name: "ModuleConflict", proto_file_path: "shared.proto" }
+        """
+        do {
+            let proto1 = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: config1Text)
+            let protoConflict = try SwiftProtobuf_GenSwift_ModuleMappings(textFormatString: conflictingConfigText)
+            XCTAssertThrowsError(try ProtoFileToModuleMappings(moduleMappingsProtos: [proto1, protoConflict])) { error in
+                guard let loadError = error as? ProtoFileToModuleMappings.LoadError else {
+                    XCTFail("Expected LoadError, got \(error)")
+                    return
+                }
+                XCTAssertEqual(
+                    loadError,
+                    .duplicateProtoPathMapping(
+                        path: "shared.proto",
+                        firstModule: "ModuleA",
+                        secondModule: "ModuleConflict"
+                    )
+                )
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_Initialization_MultiplePaths() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let path1 = tempDir.appendingPathComponent("map1.asciipb").path
+        let path2 = tempDir.appendingPathComponent("map2.asciipb").path
+
+        let config1Text = """
+        mapping { module_name: "Core", proto_file_path: ["core1.proto", "core2.proto"] }
+        """
+        let config2Text = """
+        mapping { module_name: "Auth", proto_file_path: "auth.proto" }
+        """
+
+        try config1Text.write(toFile: path1, atomically: true, encoding: .utf8)
+        try config2Text.write(toFile: path2, atomically: true, encoding: .utf8)
+
+        let mapper = try ProtoFileToModuleMappings(paths: [path1, path2])
+        XCTAssertEqual(mapper.mappings["core1.proto"], "Core")
+        XCTAssertEqual(mapper.mappings["core2.proto"], "Core")
+        XCTAssertEqual(mapper.mappings["auth.proto"], "Auth")
+
+        // Fail to open missing file
+        let nonExistentPath = tempDir.appendingPathComponent("missing.asciipb").path
+        XCTAssertThrowsError(try ProtoFileToModuleMappings(paths: [path1, nonExistentPath])) { error in
+            guard let loadError = error as? ProtoFileToModuleMappings.LoadError else {
+                XCTFail("Expected LoadError, got \(error)")
+                return
+            }
+            XCTAssertEqual(loadError, .failToOpen(path: nonExistentPath))
+        }
+    }
+
 }

--- a/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
+++ b/Tests/SwiftProtobufPluginLibraryTests/Test_ProtoFileToModuleMappings.swift
@@ -361,7 +361,9 @@ final class Test_ProtoFileToModuleMappings: XCTestCase {
                     .duplicateProtoPathMapping(
                         path: "shared.proto",
                         firstModule: "ModuleA",
-                        secondModule: "ModuleConflict"
+                        firstPath: nil,
+                        secondModule: "ModuleConflict",
+                        secondPath: nil
                     )
                 )
             }
@@ -379,6 +381,8 @@ final class Test_ProtoFileToModuleMappings: XCTestCase {
 
         let path1 = tempDir.appendingPathComponent("map1.asciipb").path
         let path2 = tempDir.appendingPathComponent("map2.asciipb").path
+        let pathConflict = tempDir.appendingPathComponent("conflict.asciipb").path
+        let pathInvalidEntry = tempDir.appendingPathComponent("invalid.asciipb").path
 
         let config1Text = """
         mapping { module_name: "Core", proto_file_path: ["core1.proto", "core2.proto"] }
@@ -386,9 +390,18 @@ final class Test_ProtoFileToModuleMappings: XCTestCase {
         let config2Text = """
         mapping { module_name: "Auth", proto_file_path: "auth.proto" }
         """
+        let configConflictText = """
+        mapping { module_name: "Other", proto_file_path: "core1.proto" }
+        """
+        let configInvalidEntryText = """
+        mapping { module_name: "Valid", proto_file_path: "valid.proto" }
+        mapping { module_name: "", proto_file_path: "bad.proto" }
+        """
 
         try config1Text.write(toFile: path1, atomically: true, encoding: .utf8)
         try config2Text.write(toFile: path2, atomically: true, encoding: .utf8)
+        try configConflictText.write(toFile: pathConflict, atomically: true, encoding: .utf8)
+        try configInvalidEntryText.write(toFile: pathInvalidEntry, atomically: true, encoding: .utf8)
 
         let mapper = try ProtoFileToModuleMappings(paths: [path1, path2])
         XCTAssertEqual(mapper.mappings["core1.proto"], "Core")
@@ -403,6 +416,45 @@ final class Test_ProtoFileToModuleMappings: XCTestCase {
                 return
             }
             XCTAssertEqual(loadError, .failToOpen(path: nonExistentPath))
+            XCTAssertEqual(loadError.description, "Failed to open '\(nonExistentPath)'")
+        }
+
+        // Duplicate conflict with source paths
+        XCTAssertThrowsError(try ProtoFileToModuleMappings(paths: [path1, pathConflict])) { error in
+            guard let loadError = error as? ProtoFileToModuleMappings.LoadError else {
+                XCTFail("Expected LoadError, got \(error)")
+                return
+            }
+            XCTAssertEqual(
+                loadError,
+                .duplicateProtoPathMapping(
+                    path: "core1.proto",
+                    firstModule: "Core",
+                    firstPath: path1,
+                    secondModule: "Other",
+                    secondPath: pathConflict
+                )
+            )
+            XCTAssertEqual(
+                loadError.description,
+                "Duplicate mapping for proto 'core1.proto': 'Core' (in '\(path1)') vs 'Other' (in '\(pathConflict)')"
+            )
+        }
+
+        // Invalid entry in second file reports file-local index (1) and path
+        XCTAssertThrowsError(try ProtoFileToModuleMappings(paths: [path1, pathInvalidEntry])) { error in
+            guard let loadError = error as? ProtoFileToModuleMappings.LoadError else {
+                XCTFail("Expected LoadError, got \(error)")
+                return
+            }
+            XCTAssertEqual(
+                loadError,
+                .entryMissingModuleName(mappingIndex: 1, path: pathInvalidEntry)
+            )
+            XCTAssertEqual(
+                loadError.description,
+                "Mapping entry 1 in '\(pathInvalidEntry)' is missing a module_name"
+            )
         }
     }
 

--- a/Tests/protoc-gen-swiftTests/Test_GeneratorOptions.swift
+++ b/Tests/protoc-gen-swiftTests/Test_GeneratorOptions.swift
@@ -52,4 +52,36 @@ final class Test_GeneratorOptions: XCTestCase {
             try GeneratorOptions(parameter: FakeParameter(pairs: [("ExperimentalHiddenNames", "unknownFeature")]))
         )
     }
+
+    func testProtoPathModuleMappings() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let path1 = tempDir.appendingPathComponent("map1.asciipb").path
+        let path2 = tempDir.appendingPathComponent("map2.asciipb").path
+
+        let config1Text = """
+        mapping { module_name: "Core", proto_file_path: "core.proto" }
+        """
+        let config2Text = """
+        mapping { module_name: "Auth", proto_file_path: "auth.proto" }
+        """
+
+        try config1Text.write(toFile: path1, atomically: true, encoding: .utf8)
+        try config2Text.write(toFile: path2, atomically: true, encoding: .utf8)
+
+        let options = try GeneratorOptions(
+            parameter: FakeParameter(pairs: [
+                ("ProtoPathModuleMappings", path1),
+                ("ProtoPathModuleMappings", path2),
+            ])
+        )
+        XCTAssertTrue(options.protoToModuleMappings.hasMappings)
+        XCTAssertEqual(options.protoToModuleMappings.mappings["core.proto"], "Core")
+        XCTAssertEqual(options.protoToModuleMappings.mappings["auth.proto"], "Auth")
+    }
 }
+


### PR DESCRIPTION
### Description
Fixes #1067.

Currently, the `ProtoPathModuleMappings=PATH` generation option in `protoc-gen-swift` only supports a single mapping file. In complex or layered multi-package architectures (such as `swift-llbuild2`), developers often have multiple module mapping files across packages and dependencies. Previously, passing multiple `--swift_opt=ProtoPathModuleMappings=...` flags would cause `GeneratorOptions` to overwrite `moduleMapPath` with the last value provided, forcing users to manually concatenate mapping files before running `protoc`.

This PR:
1. **Adds Multi-Path Initializers to `ProtoFileToModuleMappings`**:
   - Adds `init(paths: [String], swiftProtobufModuleName: String? = nil)` to load and merge module mappings from multiple files on disk.
   - Adds `init(moduleMappingsProtos: [SwiftProtobuf_GenSwift_ModuleMappings], swiftProtobufModuleName: String? = nil)` to merge multiple mapping message structures in-memory.
   - Preserves all collision detection and error handling (e.g. `LoadError.duplicateProtoPathMapping` if a proto file is assigned to different modules across files).
2. **Updates `GeneratorOptions` in `protoc-gen-swift`**:
   - Accumulates multiple `ProtoPathModuleMappings` arguments into `moduleMapPaths: [String]` rather than overwriting.
3. **Updates Documentation**:
   - Documents multi-mapping support in `Documentation/PLUGIN.md` and `Sources/protoc-gen-swift/Docs.docc/index.md`.
4. **Adds Unit Tests**:
   - Adds test cases for multiple proto/file loading, disjoint merge, identical mapping overlap (allowed), and conflicting mappings (`duplicateProtoPathMapping`) in `Test_ProtoFileToModuleMappings.swift`.
   - Adds test case in `Test_GeneratorOptions.swift` verifying multiple `ProtoPathModuleMappings` parameters.

### Testing
- Ran `swift test --filter Test_ProtoFileToModuleMappings` (all 9 tests passed).
- Ran `swift test --filter Test_GeneratorOptions` (all 2 tests passed).
